### PR TITLE
feat: make central project transfer-ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-06-01
+
+- added root `PROJECT_STATE.md` and `logs/latest.md` so the central repository complies with its own active transfer-readiness standard
+- updated `PROJECT.md` and `PROJECT_INDEX.md` after the successful temporary `Test123` bootstrap smoke test and its deletion
+- recorded the central project as transfer-ready for the next executor
+
 ## 2026-05-21
 
 - clarified `START_HERE.md` as the one top-level entry, with routing into new-project, existing-project, and fast-orientation paths

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -16,26 +16,32 @@
 - This repository is the committed source of truth for `Project Execution OS` standards, templates, skills, and reusable repository artifacts.
 - `START_HERE.md` is the stable system door.
 - `docs/ROUTER.md` is the live internal map.
+- `PROJECT_STATE.md` and `logs/latest.md` preserve the current active continuity state for executor handoff.
 
 ## Current Status
 
 - Mode: `document-first`
 - Phase: `foundation`
-- Status: `bootstrap and PROJECT.md migration reviewed and adopted`
+- Status: `transfer-ready central project`
 
 ## Done So Far
 
 - Established `START_HERE.md` as the stable top-level entrypoint.
 - Split live routing into `docs/ROUTER.md`.
 - Built central standards for lifecycle, context assembly, repository memory, review, research, handoff, and bootstrap.
+- Migrated the canonical local project entrypoint to `PROJECT.md`.
+- Adopted lightweight standalone bootstrap: local Git, `AGENTS.md`, and `PROJECT.md`.
+- Confirmed separate handling for internal subprojects without nested Git by default.
+- Smoke-tested the bootstrap model with temporary project `Test123`; the owner reports that the test project was deleted after validation.
+- Added root `PROJECT_STATE.md` and `logs/latest.md` so this central project complies with its own active continuity standard.
 
 ## Current Focus
 
-- Keep central standards internally consistent while making real-project bootstrap lightweight and safe.
+- Keep the central system internally consistent and transfer-ready after every meaningful change.
 
 ## Next Practical Step
 
-- Validate the new bootstrap model on the next intentionally created real project.
+- Await the owner's next bounded central-system task.
 
 ## Key Decisions And Constraints
 
@@ -44,11 +50,13 @@
 - `PROJECT.md` is the canonical local project entrypoint for GitHub-backed and file-executed projects.
 - `PROJECT_INDEX.md` remains an index and must not replace the role of `PROJECT.md`.
 - Local Git is the default bootstrap for real project folders; GitHub, Notion, and Google Drive are attached only when they are actually needed.
+- Active projects must maintain `PROJECT_STATE.md` and `logs/latest.md` after meaningful changes.
 
 ## Read Next
 
 1. `START_HERE.md`
 2. `docs/ROUTER.md`
-3. `PROJECT_INDEX.md`
-4. `docs/PROJECT_BOOTSTRAP_STANDARD.md`
-5. `docs/PROJECT_ENTRYPOINT_STANDARD.md`
+3. `PROJECT_STATE.md`
+4. `logs/latest.md`
+5. `PROJECT_INDEX.md` only when broader navigation is needed
+6. routed standards only when the active task requires them

--- a/PROJECT_INDEX.md
+++ b/PROJECT_INDEX.md
@@ -47,12 +47,14 @@ Mode:
 
 Status:
 
-`foundation_candidate`
+`transfer_ready`
 
 ## Canonical Documents
 
 - `README.md`
 - `PROJECT.md`
+- `PROJECT_STATE.md`
+- `logs/latest.md`
 - `START_HERE.md`
 - `docs/ROUTER.md`
 - `Start New Project.md`
@@ -157,8 +159,10 @@ logs/latest.md
 
 ## Current Status
 
-Foundation initialized as committed repository artifacts.
+The central repository is an active transfer-ready project with committed continuity artifacts.
+
+The lightweight bootstrap model was smoke-tested with temporary project `Test123`; the owner reports that the temporary test project has been deleted.
 
 ## Next Required Action
 
-Validate the adopted bootstrap model on the next intentionally created real project.
+Await the owner's next bounded central-system task.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -1,0 +1,76 @@
+---
+project_name: Project Execution OS
+project_mode: compact
+status: transfer_ready
+updated_at: 2026-06-01
+source_of_truth: repository
+active_branch: main
+---
+
+# PROJECT_STATE.md
+
+## Current State
+
+`Project Execution OS` is an active central project and is prepared for transfer to another executor.
+
+The repository now uses the minimum active continuity set required by `docs/ALWAYS_TRANSFER_READY_STATE_STANDARD.md`:
+
+```text
+PROJECT.md
+PROJECT_STATE.md
+logs/latest.md
+```
+
+## Latest Confirmed Milestone
+
+- PR `#6` was merged into `main`.
+- Merge commit: `8c86466fa6394bcaf9d833a5ca29d7464893eeba`.
+- Canonical local project entrypoint: `PROJECT.md`.
+- New standalone real project folders bootstrap with local Git, `AGENTS.md`, and `PROJECT.md`.
+- Internal subprojects inside an existing repository inherit the parent Git layer and do not receive nested `git init` unless separately authorized.
+- Zero-state and active-state project structures are explicitly separated.
+- Project index maintenance, stable-prefix behavior, communication-channel routing, and executor continuity are part of the active standards.
+- GitHub Actions validates both project structure and system-context manifest integrity.
+- The bootstrap model was smoke-tested with temporary project `Test123`; the owner reports that the temporary test project has been deleted.
+
+## Current Focus
+
+Keep the central project internally consistent and transfer-ready after every meaningful change.
+
+## Current Next Safe Action
+
+No implementation task is currently active.
+
+Await the owner's next bounded central-system task. When a new task arrives:
+
+1. enter through `START_HERE.md`;
+2. follow `docs/ROUTER.md`;
+3. read `PROJECT.md`, then this file and `logs/latest.md`;
+4. perform only the smallest justified change;
+5. update `PROJECT_STATE.md` and `logs/latest.md` after the meaningful step.
+
+## Active Files For Re-entry
+
+Read in this order when resuming central-project work:
+
+1. `START_HERE.md`
+2. `docs/ROUTER.md`
+3. `PROJECT.md`
+4. `PROJECT_STATE.md`
+5. `logs/latest.md`
+6. `PROJECT_INDEX.md` only when broader navigation is needed
+7. routed standards only when the active task requires them
+
+## Known Blockers
+
+None currently recorded.
+
+## Do-Not-Break Rules
+
+- Do not bypass `START_HERE.md` as the stable top-level entrypoint.
+- Do not replace `docs/ROUTER.md` with duplicated navigation logic elsewhere.
+- Do not treat chat memory as durable project truth.
+- Do not add files, folders, or architectural layers ritualistically.
+- Do not claim execution without a confirmed repository event.
+- Preserve the smallest sufficient context-loading path.
+- Update this file and `logs/latest.md` after every meaningful central-project change.

--- a/logs/latest.md
+++ b/logs/latest.md
@@ -1,0 +1,59 @@
+# Latest Project Log — Project Execution OS
+
+## Current Recorded State
+
+`Project Execution OS` has been brought into compliance with its active transfer-readiness standard.
+
+## Latest Confirmed Events
+
+- PR `#6` was merged into `main`.
+- Merge commit: `8c86466fa6394bcaf9d833a5ca29d7464893eeba`.
+- Canonical local project entrypoint is now `PROJECT.md`.
+- Minimal bootstrap for standalone external project folders is:
+
+```text
+git init
+AGENTS.md
+PROJECT.md
+```
+
+- Internal subprojects inside existing repositories inherit the parent Git layer and must not receive nested `git init` without a separate explicit decision.
+- Zero-state bootstrap and active execution state are separated.
+- GitHub Actions validates both project structure and system-context manifest integrity.
+- The bootstrap model was manually smoke-tested with temporary project `Test123`.
+- The owner reports that `Test123` has been fully deleted after the successful test.
+
+## Transfer-Readiness Update
+
+Created the root continuity files required for an active project:
+
+```text
+PROJECT_STATE.md
+logs/latest.md
+```
+
+The central project now has the required active minimum set:
+
+```text
+PROJECT.md
+PROJECT_STATE.md
+logs/latest.md
+```
+
+## Current Next Safe Action
+
+No implementation task is active.
+
+Await the owner's next bounded central-system task. On re-entry, read:
+
+1. `START_HERE.md`
+2. `docs/ROUTER.md`
+3. `PROJECT.md`
+4. `PROJECT_STATE.md`
+5. `logs/latest.md`
+
+Then load only the minimum routed files needed for the task.
+
+## Known Blockers
+
+None currently recorded.


### PR DESCRIPTION
## Summary
- add root `PROJECT_STATE.md` and `logs/latest.md` for active continuity
- update `PROJECT.md` and `PROJECT_INDEX.md` after the successful temporary `Test123` bootstrap smoke test
- record the central repository as transfer-ready for the next executor
- update `CHANGELOG.md`

## Notes
- `Test123` was temporary and the owner reports it has been deleted
- `logs/WORKFLOW_LOG.md` was intentionally not rewritten because the connector does not provide a safe append operation for the long historical log; current continuity is recorded in `logs/latest.md` and `CHANGELOG.md`

## Expected transfer test
A fresh executor should be able to read:
1. `START_HERE.md`
2. `docs/ROUTER.md`
3. `PROJECT.md`
4. `PROJECT_STATE.md`
5. `logs/latest.md`

and identify the next safe action without reconstructing chat context.