### PR TITLE
Add reusable website design block

### DIFF
--- a/SYSTEM_CONTEXT_MANIFEST.md
+++ b/SYSTEM_CONTEXT_MANIFEST.md
@@ -21,15 +21,15 @@ It identifies the intended ordered context foundation. It does not prove provide
 ```text
 docs/integrations/chatgpt/CORE_SYSTEM_PROMPT.md=ffa44bccdd2e24dd96c1b6ee726c0726712f1e1a
 START_HERE.md=f315656999e3e78b1b797ad2c1c971ef64fccbf9
-docs/ROUTER.md=72866fa917b20b97026a7527aa21ae2a910c9b23
+docs/ROUTER.md=4655ea2adf88c15bec71b99c529ecbe14ebb304f
 docs/CONTEXT_ASSEMBLY_STANDARD.md=c9b2e4e8739a0ec5cc1ce6e0657e238f5f443541
-docs/KNOWLEDGE_SYSTEM.md=8f7336081925f182a55a6102bd8dfe1a326eecd5
+docs/KNOWLEDGE_SYSTEM.md=e5500ceb295997403f0e2e6ca47ee9c02f3c623c
 ```
 
 ### SHA-256 Fingerprint
 
 ```text
-1bbce391d1350f78140131eedf9f9e566192e455cd56b129ecdb0fa073de991a
+30b8b8f1bf63bbe8f76ef6189e8857de4b664700c4ea2658624565410dfa8e99
 ```
 
 ### Loading Rule

--- a/blocks/PROJECT_INDEX.md
+++ b/blocks/PROJECT_INDEX.md
@@ -10,6 +10,20 @@ Blocks live below the central operating system:
 
 ## Current Blocks
 
+### Design Block
+
+Path:
+
+`blocks/design/`
+
+Purpose:
+
+Provide one reusable workflow for website design that stays usable, buildable, reviewable, and implementation-aware.
+
+Current status:
+
+`candidate`
+
 ### Documentation Block
 
 Path:

--- a/blocks/design/BLOCK.md
+++ b/blocks/design/BLOCK.md
@@ -1,0 +1,89 @@
+# Design Block
+
+## Purpose
+
+This block gives `Project Execution OS` one reusable workflow for website-design work that must stay usable, buildable, and reviewable.
+
+It teaches an agent to move from product intent to page structure to wireframe to UI system to frontend-aware handoff, instead of stopping at decorative mockups.
+
+## Status
+
+`candidate`
+
+## When To Use
+
+Use this block when the task is to:
+
+- design a new website, landing page, marketing page, or product flow;
+- turn a project idea into a structured website plan;
+- define sitemap, page structure, or user-path-first page scope;
+- create a frontend-aware UI specification before implementation;
+- review an existing website design for usability, clarity, and buildability;
+- prepare design guidance that Codex or another frontend executor can implement.
+
+## When Not To Use
+
+Do not use this block for:
+
+- pure branding work with no website or product-flow outcome;
+- decorative image generation;
+- final visual polish without first clarifying user path and page structure;
+- backend-only or infrastructure-only work;
+- tasks where direct frontend implementation should begin immediately from an already-accepted spec.
+
+## Core Rule
+
+Do not treat website design as image prompting.
+
+A valid design pass must connect:
+
+`goal -> user scenario -> page structure -> wireframe -> UI system -> responsive behavior -> frontend-aware handoff -> review`
+
+If one of those layers is missing, the design is incomplete.
+
+## Required Reading Inside This Block
+
+Open in this order:
+
+1. `blocks/design/WEBSITE_DESIGN_PIPELINE.md`
+2. `blocks/design/DESIGN_AGENT_STANDARD.md`
+3. `blocks/design/DESIGN_REVIEW_STANDARD.md` when the task is review-first or after a design draft exists
+4. `blocks/design/DONORS.md` only when donor rationale or pattern borrowing is needed
+
+## Relationship To Codex And Frontend Execution
+
+This block does not replace frontend implementation.
+
+Its job is to produce a design package that a frontend executor can build with minimal guessing.
+
+That means the design output should make clear:
+
+- what the page is trying to achieve;
+- what the user must notice, decide, and do;
+- which sections and components exist;
+- how the layout changes across screen sizes;
+- which interaction states or content rules matter;
+- what is still intentionally left for implementation judgment.
+
+## Typical Outputs
+
+Typical outputs:
+
+- website goal summary;
+- primary user path;
+- sitemap or page structure;
+- low-fidelity wireframe notes;
+- UI system direction;
+- responsive behavior rules;
+- frontend-aware handoff spec;
+- design review findings and required revisions.
+
+## Boundary
+
+This block stores the reusable website-design workflow layer.
+
+Keep project-specific brand choices, final copy, and implementation details in the target project unless they are being generalized into a reusable standard.
+
+## Final Rule
+
+Make designs that can be built and reviewed, not just admired.

--- a/blocks/design/DESIGN_AGENT_STANDARD.md
+++ b/blocks/design/DESIGN_AGENT_STANDARD.md
@@ -1,0 +1,105 @@
+# Design Agent Standard
+
+## Purpose
+
+This standard defines how an agent creates a website design that is useful to both decision-makers and frontend implementers.
+
+## Core Rule
+
+The agent is not a decorative image generator.
+
+The agent must reason from user path and page structure first, then produce visual-system decisions that support implementation.
+
+## Required Inputs
+
+Minimum useful inputs:
+
+- product or page goal;
+- target user or audience;
+- desired user action;
+- known constraints such as platform, stack, existing brand, or content limits;
+- whether the output is net-new design or revision of an existing page.
+
+## Workflow
+
+1. Restate the design problem in one tight sentence.
+2. Define the primary user scenario.
+3. Choose the smallest page or section structure that can succeed.
+4. Draft the wireframe before styling.
+5. Define the UI system in terms that map to real components.
+6. Specify responsive behavior.
+7. Produce a frontend-aware handoff package.
+8. Run design review before marking the work complete.
+
+## Design Output Contract
+
+The agent should usually return these sections:
+
+- objective;
+- primary user path;
+- sitemap or section structure;
+- wireframe;
+- UI system;
+- responsive behavior;
+- implementation notes;
+- open questions.
+
+## Wireframe Rule
+
+The wireframe should explain layout and hierarchy clearly enough that another agent or frontend engineer can reproduce the structure without guessing the intended flow.
+
+## UI System Rule
+
+The UI system should use implementation-facing language.
+
+Prefer:
+
+- section patterns;
+- component names;
+- state descriptions;
+- spacing and hierarchy rules;
+- reusable tokens or roles when relevant.
+
+Avoid vague outputs such as:
+
+- "make it modern";
+- "clean and premium";
+- "add nice animations";
+- any style language not tied to actual page behavior.
+
+## Frontend-Aware Handoff Rule
+
+The design must acknowledge implementation reality.
+
+At minimum, include:
+
+- component inventory;
+- layout behavior;
+- important states;
+- accessibility-sensitive elements;
+- responsive rules;
+- ambiguity or risk notes.
+
+## Review Before Completion
+
+Before completion, the agent must check:
+
+- whether the design supports the stated goal;
+- whether the CTA path is clear;
+- whether any section exists only for visual filler;
+- whether the layout remains coherent on mobile;
+- whether the design can plausibly be implemented in a normal frontend stack.
+
+## Anti-Patterns
+
+Do not:
+
+- jump straight from prompt to polished UI with no page logic;
+- produce long style prose with no structure;
+- hide missing reasoning behind aesthetic language;
+- invent interaction details that the goal does not need;
+- over-design an MVP page that only needs one clear action.
+
+## Final Rule
+
+Design decisions must survive both user scrutiny and frontend implementation.

--- a/blocks/design/DESIGN_REVIEW_STANDARD.md
+++ b/blocks/design/DESIGN_REVIEW_STANDARD.md
@@ -1,0 +1,109 @@
+# Design Review Standard
+
+## Purpose
+
+This standard defines how an agent reviews an existing website or page design clearly and practically.
+
+## Review Goal
+
+The review should identify whether the design is:
+
+- aligned to its goal;
+- understandable to the user;
+- structurally coherent;
+- visually consistent;
+- responsive;
+- realistically buildable.
+
+## Review Order
+
+Review in this order:
+
+1. goal fit;
+2. user path;
+3. page structure;
+4. wireframe or layout hierarchy;
+5. UI system consistency;
+6. responsive behavior;
+7. frontend handoff quality.
+
+## Findings Format
+
+For each finding, state:
+
+- severity;
+- what is wrong;
+- why it matters;
+- what change would fix or reduce it.
+
+Prefer practical language over taste-based commentary.
+
+## Review Checklist
+
+### Goal Fit
+
+Check:
+
+- Is the primary action obvious?
+- Does the page spend enough space on the decision the user must make?
+- Is any important proof or context missing before the CTA?
+
+### User Path
+
+Check:
+
+- Does the information appear in a sensible order?
+- Are questions answered before the CTA asks for commitment?
+- Is the user forced to infer too much from visuals alone?
+
+### Structure And Wireframe
+
+Check:
+
+- Are sections distinct and purposeful?
+- Is hierarchy visible at a glance?
+- Are there filler sections or duplicated content blocks?
+- Does the page scan cleanly?
+
+### UI System
+
+Check:
+
+- Are components consistent across the page?
+- Do typography, spacing, and color roles behave like a system?
+- Are emphasis and contrast used intentionally rather than everywhere?
+
+### Responsive Behavior
+
+Check:
+
+- Does the layout still work on mobile?
+- Are CTA, nav, and proof sections still easy to reach?
+- Do grids, cards, or comparison tables collapse sensibly?
+
+### Buildability
+
+Check:
+
+- Can this be built with standard frontend techniques?
+- Are key interactions defined well enough to implement?
+- Does the design depend on unrealistic one-off behavior or hidden assumptions?
+
+## Output Shape
+
+A useful review usually contains:
+
+- brief context;
+- ordered findings;
+- open questions;
+- pass / revise recommendation.
+
+## Boundary
+
+This standard is for product and execution-oriented design review.
+
+It is not a substitute for brand critique, visual-art critique, or stakeholder preference debates.
+
+## Final Rule
+
+Review the design the user must use and the frontend team must build, not the imaginary version in the reviewer's head.

--- a/blocks/design/DONORS.md
+++ b/blocks/design/DONORS.md
@@ -1,0 +1,86 @@
+# Design Block Donors
+
+## Purpose
+
+This file records the main donor tools and patterns that informed the first `Design Block` shape.
+
+The goal is pattern borrowing, not vendor lock-in.
+
+## Donors And Borrowed Ideas
+
+### Relume
+
+Borrow:
+
+- move from sitemap to wireframe instead of styling first;
+- keep page structure explicit before component polish;
+- treat site architecture as part of design work.
+
+### v0
+
+Borrow:
+
+- use prompting to generate high-fidelity UI exploration quickly;
+- keep outputs close to real frontend implementation;
+- treat design and implementation handoff as adjacent, not separate worlds.
+
+### shadcn/ui
+
+Borrow:
+
+- think in reusable components and composition patterns;
+- prefer buildable UI systems over static mockup-only language;
+- keep component naming and structure implementation-friendly.
+
+### Builder.io / Visual Copilot
+
+Borrow:
+
+- map design output toward real code components and design tokens;
+- keep design-to-code handoff explicit;
+- care about responsive output and component reuse.
+
+### Figma Make
+
+Borrow:
+
+- use prompt-driven iteration as a fast exploration step;
+- allow design refinement through direct iteration rather than one-shot output;
+- keep prototype thinking close to the working interface.
+
+### Google Stitch
+
+Borrow:
+
+- support early UI exploration from text, sketch, or reference;
+- move quickly from rough idea to structured interface candidate;
+- treat exploration as upstream of review and implementation.
+
+### screenshot-to-code / v0.diy
+
+Borrow:
+
+- use open-source implementation references as reality checks;
+- value reproducible UI structure over presentation-only inspiration;
+- keep awareness that generated designs eventually need code-level translation.
+
+### AI UX Playground
+
+Borrow:
+
+- use explicit review prompts and checklist-style critique;
+- make UX evaluation part of the workflow, not an optional afterthought;
+- keep the system teachable for future agents.
+
+## What Stays Custom
+
+This block stays custom in these areas:
+
+- routing shape inside `Project Execution OS`;
+- the exact lightweight document set;
+- the buildability-first rule for Codex handoff;
+- the review order and minimum output contract.
+
+## Final Rule
+
+Borrow the useful workflow shape, but keep the canonical reusable standard inside this repository.

--- a/blocks/design/WEBSITE_DESIGN_PIPELINE.md
+++ b/blocks/design/WEBSITE_DESIGN_PIPELINE.md
@@ -1,0 +1,177 @@
+# Website Design Pipeline
+
+## Purpose
+
+This pipeline defines the default flow for turning a website idea into a buildable and reviewable design package.
+
+## Core Flow
+
+```text
+idea
+-> website goal
+-> user scenario
+-> sitemap or page structure
+-> wireframe
+-> UI system
+-> responsive spec
+-> frontend handoff
+-> design review
+```
+
+## Stage 1 - Website Goal
+
+Define:
+
+- the business or product outcome;
+- the page or site type;
+- the primary conversion or success action;
+- the main audience;
+- the biggest failure mode to avoid.
+
+Output:
+
+- one short goal statement;
+- one primary action;
+- one scope boundary.
+
+## Stage 2 - User Scenario
+
+Describe the main user path in plain language:
+
+- where the user comes from;
+- what they already know;
+- what question or doubt they have;
+- what they need to understand before acting;
+- what action they should take next.
+
+Output:
+
+- one primary scenario;
+- optional secondary scenarios only if they materially change page structure.
+
+## Stage 3 - Sitemap Or Page Structure
+
+Decide the smallest page set or section set that supports the goal.
+
+For single-page work, this may be a section map instead of a multi-page sitemap.
+
+Define:
+
+- required pages or sections;
+- order of information;
+- relationship between pages or sections;
+- where trust, proof, pricing, FAQ, or CTA elements belong.
+
+Output:
+
+- sitemap or ordered section list with short purpose notes.
+
+## Stage 4 - Wireframe
+
+Create a low-fidelity structure before visual styling.
+
+Focus on:
+
+- hierarchy;
+- content grouping;
+- CTA placement;
+- scan path;
+- section sequencing;
+- essential states such as empty, loading, comparison, or expanded detail when relevant.
+
+Avoid:
+
+- premature color decisions;
+- ornamental illustration decisions;
+- pixel-level polishing before structure is stable.
+
+Output:
+
+- section-by-section wireframe notes, ASCII wireframe, or structured layout description.
+
+## Stage 5 - UI System
+
+Only after wireframe stability, define the visual and component system.
+
+Cover:
+
+- visual direction;
+- typography roles;
+- spacing rhythm;
+- color roles;
+- component families;
+- interaction states;
+- icon or media usage rules.
+
+Output:
+
+- compact UI system spec tied to the wireframe, not detached moodboard language.
+
+## Stage 6 - Responsive Spec
+
+Define how the design behaves across screen sizes.
+
+Minimum coverage:
+
+- mobile;
+- tablet when relevant;
+- desktop.
+
+State:
+
+- section stacking behavior;
+- nav behavior;
+- grid collapse rules;
+- priority changes for content;
+- interaction differences if any.
+
+Output:
+
+- responsive behavior notes for each important page or section.
+
+## Stage 7 - Frontend Handoff
+
+Translate the design into implementation-facing guidance.
+
+Include:
+
+- page and section inventory;
+- component inventory;
+- state and interaction notes;
+- content constraints;
+- accessibility concerns that affect structure;
+- implementation risks or unanswered design questions.
+
+Output:
+
+- frontend-aware handoff package that reduces guesswork for the builder.
+
+## Stage 8 - Design Review
+
+Review the result against:
+
+- goal fit;
+- clarity;
+- user-path coherence;
+- usability;
+- responsive behavior;
+- component consistency;
+- buildability.
+
+If a design fails review, return to the narrowest broken stage rather than restarting from zero.
+
+## Minimal Deliverable Shape
+
+The default lightweight package is:
+
+1. goal and user scenario;
+2. sitemap or section map;
+3. wireframe notes;
+4. UI system notes;
+5. responsive notes;
+6. frontend handoff notes;
+7. review findings.
+
+## Final Rule
+
+Lock structure before surface polish, and lock handoff before calling the design done.

--- a/docs/ROUTER.md
+++ b/docs/ROUTER.md
@@ -23,6 +23,7 @@ Do not append an unrelated next-project question after answering the active requ
 - explicit preservation intent such as save, capture, record, remember, add to library, add to project, or do not lose this -> `docs/AUTOMATIC_CAPTURE_STANDARD.md`
 - idea or reference that should be preserved but is not yet a project -> `docs/REFERENCE_IDEA_CAPTURE_STANDARD.md`
 - lifecycle or storage-layer decision -> `docs/PROJECT_LIFECYCLE_MODEL.md`
+- website design, landing-page design, page structure, wireframe, UI system, responsive UI spec, or website design review -> `blocks/design/BLOCK.md`
 - current-project summary, status, orientation, or "where are we now?" question -> read the current project's entrypoint and only the minimum necessary current-state evidence; answer the question directly; stop after the answer; do not trigger `Start New Project.md` or ask which new project to create unless the owner explicitly requests a new project
 - entry into a specific existing project -> that project's current entrypoint; prefer `PROJECT.md`, fall back to legacy `PROJECT_ENTRYPOINT.md` only during migration, and use `docs/PROJECT_ENTRYPOINT_STANDARD.md` if no project entrypoint exists
 - transfer readiness, executor continuity, durable state maintenance, or handoff survivability -> `docs/ALWAYS_TRANSFER_READY_STATE_STANDARD.md`


### PR DESCRIPTION
## Summary
- add a new `blocks/design/` reusable website-design block
- define the pipeline, agent standard, review standard, and donor rationale
- register the block in the router and blocks index

## Validation
- verified issue #14 scope and required files
- checked existing repository block patterns before adding the new block
- confirmed minimal registration in `docs/ROUTER.md` and `blocks/PROJECT_INDEX.md`

Closes #14