### PR TITLE
Build local Design Picker MVP

### DIFF
--- a/SYSTEM_CONTEXT_MANIFEST.md
+++ b/SYSTEM_CONTEXT_MANIFEST.md
@@ -21,7 +21,7 @@ It identifies the intended ordered context foundation. It does not prove provide
 ```text
 docs/integrations/chatgpt/CORE_SYSTEM_PROMPT.md=ffa44bccdd2e24dd96c1b6ee726c0726712f1e1a
 START_HERE.md=f315656999e3e78b1b797ad2c1c971ef64fccbf9
-docs/ROUTER.md=86de8756c90b44f88bc5837907860c18d35498cc
+docs/ROUTER.md=42232138a547dbd244c583aac7f0d7e1e221f360
 docs/CONTEXT_ASSEMBLY_STANDARD.md=c9b2e4e8739a0ec5cc1ce6e0657e238f5f443541
 docs/KNOWLEDGE_SYSTEM.md=e5500ceb295997403f0e2e6ca47ee9c02f3c623c
 ```
@@ -29,7 +29,7 @@ docs/KNOWLEDGE_SYSTEM.md=e5500ceb295997403f0e2e6ca47ee9c02f3c623c
 ### SHA-256 Fingerprint
 
 ```text
-a9872af67e850bb9d23fd33dbf689a694fad9c26a6e5f42d67adce5f19262c69
+055ef54507e49291578423242cfaa50861d3968f299f678dd5e3f7b548e1f150
 ```
 
 ### Loading Rule

--- a/projects/design-picker/Launch-Design-Picker.bat
+++ b/projects/design-picker/Launch-Design-Picker.bat
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+set "TARGET=%~dp0index.html"
+if not exist "%TARGET%" (
+  echo Could not find index.html next to this launcher.
+  exit /b 1
+)
+start "" "%TARGET%"

--- a/projects/design-picker/PROJECT.md
+++ b/projects/design-picker/PROJECT.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-`initialized — active research and MVP definition`
+`active — local MVP implemented`
 
 ## Purpose
 
@@ -57,4 +57,4 @@ The first research candidates are Linkwarden and Karakeep. The project must deci
 
 ## Next Practical Step
 
-Complete reuse-first research and record the adaptation decision.
+Validate the local MVP on a real donor shortlist, then decide whether the next step is Linkwarden-backed preview integration or richer project-board workflow.

--- a/projects/design-picker/PROJECT_STATE.md
+++ b/projects/design-picker/PROJECT_STATE.md
@@ -1,3 +1,10 @@
+---
+status: in-progress
+project_mode: compact
+last_updated: 2026-06-07
+next_action: Wait for PR `#26` review and merge, then run the Design Picker against a larger real donor set.
+---
+
 # Design Picker — Project State
 
 Date: 2026-06-07

--- a/projects/design-picker/PROJECT_STATE.md
+++ b/projects/design-picker/PROJECT_STATE.md
@@ -4,7 +4,7 @@ Date: 2026-06-07
 
 ## Current Phase
 
-`implementation bootstrap`
+`local MVP built and browser-validated`
 
 ## Confirmed Direction
 
@@ -56,6 +56,48 @@ The first internal MVP must remain standalone enough to run without Linkwarden, 
 - deployment;
 - AI tagging.
 
+## Latest Result
+
+A polished static local MVP now exists with:
+
+- donor card grid;
+- add, edit, delete, and refresh actions;
+- decision statuses;
+- pattern selection;
+- search and filtering;
+- local persistence;
+- Markdown and JSON export;
+- a preview-provider adapter seam;
+- Windows launcher path.
+
+## Validation Evidence
+
+Browser validation confirmed:
+
+- two real public donor URLs were added successfully;
+- one donor was edited after creation;
+- one donor persisted as `primary` and another as `partial`;
+- automatic preview URLs were generated through the adapter;
+- refresh preview worked;
+- local persistence survived reload;
+- Markdown and JSON exports downloaded with expected records;
+- the layout remained usable at a narrow viewport without horizontal overflow.
+
+## Active Files
+
+- `projects/design-picker/index.html`
+- `projects/design-picker/styles.css`
+- `projects/design-picker/app.js`
+- `projects/design-picker/Launch-Design-Picker.bat`
+- `projects/design-picker/README.md`
+- `projects/design-picker/PROJECT.md`
+- `projects/design-picker/PROJECT_STATE.md`
+- `projects/design-picker/logs/latest.md`
+
 ## Next Practical Step
 
-Create a browser-runnable static MVP and verify the interaction model before adding backend integration.
+Run the MVP against a larger real donor set and then choose between:
+
+- keeping the static local tool and refining board workflow;
+- adding Linkwarden-backed screenshot integration;
+- introducing a lightweight local server only if richer metadata import becomes necessary.

--- a/projects/design-picker/README.md
+++ b/projects/design-picker/README.md
@@ -1,56 +1,56 @@
 # Design Picker MVP
 
-## Purpose
+## Назначение
 
-`Design Picker` is a local internal website for collecting design donors, browsing them as visual cards, marking what should be reused, and exporting a clean selection record.
+`Design Picker` — это локальный внутренний сайт для сбора дизайн-доноров, просмотра их как визуальных карточек, фиксации того, что стоит переиспользовать, и экспорта понятной selection record.
 
-## Windows Launch
+## Запуск на Windows
 
-### Fastest path
+### Самый быстрый путь
 
-Double-click:
+Двойной клик по:
 
 `Launch-Design-Picker.bat`
 
-This opens:
+Откроется:
 
 `index.html`
 
-in your default browser.
+в браузере по умолчанию.
 
-### One copy-ready command
+### Одна готовая команда
 
-From PowerShell inside `projects/design-picker/`:
+Из PowerShell внутри `projects/design-picker/`:
 
 ```powershell
 .\Launch-Design-Picker.bat
 ```
 
-No install step is required for the MVP.
+Для MVP ничего устанавливать не нужно.
 
-## Owner Workflow
+## Как пользоваться
 
-1. Launch the site.
-2. Click `Add donor`.
-3. Paste a public website URL.
-4. Leave `Manual preview override` empty to use the automatic preview adapter.
-5. Add tags, notes, and pattern selections.
-6. Mark the donor as `Primary`, `Partial`, `Rejected`, or `Undecided`.
-7. Use search and filters to shape the shortlist.
-8. Export Markdown or JSON when the board is ready.
+1. Запусти сайт.
+2. Нажми `Добавить донора`.
+3. Вставь публичный URL сайта.
+4. Оставь поле `Ручная замена превью` пустым, чтобы использовать автоматический preview adapter.
+5. Добавь теги, заметки и выбранные паттерны.
+6. Поставь статус: `Основной`, `Частичный`, `Отклонён` или `Не решено`.
+7. Используй поиск и фильтры, чтобы собрать shortlist.
+8. Экспортируй Markdown или JSON, когда отбор готов.
 
-## Current MVP Capabilities
+## Что уже умеет MVP
 
-- clean local website with visual donor cards;
-- add donor flow with one required field: source URL;
-- automatic title fallback from the donor domain;
-- automatic preview generation through a preview-provider adapter;
-- manual preview override;
-- edit, delete, and refresh donor actions;
-- search by title, URL, notes, tags, and patterns;
-- filter by decision status and by pattern;
-- design statuses: `primary`, `partial`, `rejected`, `undecided`;
-- reusable pattern selection:
+- аккуратный локальный сайт с визуальными карточками доноров;
+- добавление донора с одним обязательным полем: source URL;
+- автоматическое название по домену, если вручную не заполнено;
+- автоматическая генерация превью через preview-provider adapter;
+- ручная замена превью;
+- действия: редактировать, удалить, обновить превью;
+- поиск по названию, URL, заметкам, тегам и паттернам;
+- фильтрация по статусу решения и по паттерну;
+- внутренние статусы: `primary`, `partial`, `rejected`, `undecided`;
+- выбор переиспользуемых паттернов:
   - `hero`
   - `cards`
   - `pricing`
@@ -60,48 +60,48 @@ No install step is required for the MVP.
   - `onboarding`
   - `checkout`
   - `custom`
-- owner notes and strong-points field;
-- Markdown export;
-- JSON export;
-- local persistence through browser `localStorage`.
+- заметки владельца и поле сильных сторон;
+- экспорт в Markdown;
+- экспорт в JSON;
+- локальное сохранение через browser `localStorage`.
 
-## Files
+## Файлы
 
-- `index.html` — app shell
-- `styles.css` — visual system and responsive layout
-- `app.js` — state, preview adapter, filters, editor, export logic
-- `Launch-Design-Picker.bat` — Windows double-click launcher
+- `index.html` — оболочка приложения
+- `styles.css` — визуальная система и responsive layout
+- `app.js` — состояние, preview adapter, фильтры, редактор и экспорт
+- `Launch-Design-Picker.bat` — Windows launcher для двойного клика
 
 ## Preview Provider Adapter
 
-The MVP keeps preview generation behind a small adapter seam inside `app.js`.
+MVP держит генерацию превью за небольшим adapter seam внутри `app.js`.
 
-Current runtime order:
+Текущий порядок работы:
 
 1. manual preview override;
 2. hosted screenshot endpoint;
-3. built-in visual fallback card.
+3. встроенная fallback-карточка.
 
-Current hosted screenshot endpoint:
+Текущий hosted screenshot endpoint:
 
 ```text
 https://image.thum.io/get/width/1440/crop/900/noanimate/{url}
 ```
 
-This is a local-validation adapter, not a final locked dependency.
+Это локальный validation adapter, а не финальная жёстко зафиксированная зависимость.
 
-## Existing Solutions Reused Conceptually
+## Что заимствовано концептуально
 
 - Linkwarden:
-  - screenshot-preservation direction;
-  - future backend preview path;
-  - donor preservation mindset.
+  - направление на screenshot-preservation;
+  - будущий backend path для превью;
+  - модель сохранения доноров.
 - Karakeep:
-  - visual browsing feel;
-  - lightweight bookmark-card UX inspiration;
-  - modern collection-oriented browsing patterns.
+  - ощущение визуального browse-режима;
+  - лёгкий bookmark-card UX;
+  - современные паттерны коллекционного просмотра.
 
-## What Is Still Deferred
+## Что пока отложено
 
 - server-side metadata extraction;
 - Linkwarden API integration;
@@ -112,8 +112,8 @@ This is a local-validation adapter, not a final locked dependency.
 - deployment;
 - AI tagging or automatic design analysis.
 
-## Security Note
+## Замечание по безопасности
 
-This MVP stores data only in the current browser profile and uses an external screenshot endpoint for public URLs.
+Этот MVP хранит данные только в текущем профиле браузера и использует внешний screenshot endpoint для публичных URL.
 
-Use public donor URLs only during this MVP phase.
+На этой стадии используй только публичные donor URL.

--- a/projects/design-picker/README.md
+++ b/projects/design-picker/README.md
@@ -1,72 +1,119 @@
 # Design Picker MVP
 
-## Run
+## Purpose
 
-This version is intentionally build-free.
+`Design Picker` is a local internal website for collecting design donors, browsing them as visual cards, marking what should be reused, and exporting a clean selection record.
 
-1. Download `index.html`.
-2. Open it in a modern browser.
-3. Add a donor URL.
-4. Leave the preview field empty to generate an automatic screenshot preview.
-5. Select reusable patterns and decision status.
-6. Export Markdown or JSON when ready.
+## Windows Launch
 
-## What Works
+### Fastest path
 
-- browser-runnable visual donor grid;
-- local persistence in `localStorage`;
-- add, edit, and remove donor cards;
-- source URL normalization;
-- automatic title fallback from the donor domain;
-- automatic screenshot preview generation from donor URL through a screenshot endpoint;
-- optional manual preview URL override;
-- refresh preview action;
-- project type;
-- style and section tags;
-- status filtering;
-- primary / partial / rejected / undecided decisions;
-- pattern selection;
-- owner notes;
-- Markdown export;
-- JSON export.
+Double-click:
 
-## Current Preview Adapter
+`Launch-Design-Picker.bat`
 
-The static MVP uses a public screenshot endpoint:
+This opens:
 
-```text
-https://image.thum.io/get/width/1280/crop/720/noanimate/{encodedUrl}
+`index.html`
+
+in your default browser.
+
+### One copy-ready command
+
+From PowerShell inside `projects/design-picker/`:
+
+```powershell
+.\Launch-Design-Picker.bat
 ```
 
-This is only the first runnable adapter for validating the interaction model.
+No install step is required for the MVP.
 
-Do not treat it as the final production dependency.
+## Owner Workflow
 
-## What Is Deferred
+1. Launch the site.
+2. Click `Add donor`.
+3. Paste a public website URL.
+4. Leave `Manual preview override` empty to use the automatic preview adapter.
+5. Add tags, notes, and pattern selections.
+6. Mark the donor as `Primary`, `Partial`, `Rejected`, or `Undecided`.
+7. Use search and filters to shape the shortlist.
+8. Export Markdown or JSON when the board is ready.
+
+## Current MVP Capabilities
+
+- clean local website with visual donor cards;
+- add donor flow with one required field: source URL;
+- automatic title fallback from the donor domain;
+- automatic preview generation through a preview-provider adapter;
+- manual preview override;
+- edit, delete, and refresh donor actions;
+- search by title, URL, notes, tags, and patterns;
+- filter by decision status and by pattern;
+- design statuses: `primary`, `partial`, `rejected`, `undecided`;
+- reusable pattern selection:
+  - `hero`
+  - `cards`
+  - `pricing`
+  - `navigation`
+  - `motion`
+  - `dashboard`
+  - `onboarding`
+  - `checkout`
+  - `custom`
+- owner notes and strong-points field;
+- Markdown export;
+- JSON export;
+- local persistence through browser `localStorage`.
+
+## Files
+
+- `index.html` — app shell
+- `styles.css` — visual system and responsive layout
+- `app.js` — state, preview adapter, filters, editor, export logic
+- `Launch-Design-Picker.bat` — Windows double-click launcher
+
+## Preview Provider Adapter
+
+The MVP keeps preview generation behind a small adapter seam inside `app.js`.
+
+Current runtime order:
+
+1. manual preview override;
+2. hosted screenshot endpoint;
+3. built-in visual fallback card.
+
+Current hosted screenshot endpoint:
+
+```text
+https://image.thum.io/get/width/1440/crop/900/noanimate/{url}
+```
+
+This is a local-validation adapter, not a final locked dependency.
+
+## Existing Solutions Reused Conceptually
+
+- Linkwarden:
+  - screenshot-preservation direction;
+  - future backend preview path;
+  - donor preservation mindset.
+- Karakeep:
+  - visual browsing feel;
+  - lightweight bookmark-card UX inspiration;
+  - modern collection-oriented browsing patterns.
+
+## What Is Still Deferred
 
 - server-side metadata extraction;
 - Linkwarden API integration;
-- durable database;
+- screenshot caching;
+- private-network URL blocking on a backend;
 - authentication;
-- hosted deployment;
-- AI tagging;
-- screenshot caching and provider credentials;
-- private-network URL blocking on a backend.
-
-## Linkwarden Integration Seam
-
-Linkwarden source inspection confirmed that generated previews are served through:
-
-```text
-/api/v1/archives/{linkId}?format=jpeg&preview=true&updatedAt=...
-```
-
-The next backend version should replace or augment the public screenshot endpoint with a provider adapter and allow a Linkwarden-backed preview source.
+- multi-user access;
+- deployment;
+- AI tagging or automatic design analysis.
 
 ## Security Note
 
-The static MVP stores records only in the current browser profile.
+This MVP stores data only in the current browser profile and uses an external screenshot endpoint for public URLs.
 
-Do not treat it as a shared or durable production system yet.
-
-Because the current screenshot endpoint is external, only submit public website URLs during MVP validation.
+Use public donor URLs only during this MVP phase.

--- a/projects/design-picker/app.js
+++ b/projects/design-picker/app.js
@@ -12,11 +12,23 @@ const PATTERN_OPTIONS = [
   "custom"
 ];
 
+const PATTERN_LABELS = {
+  hero: "Hero — главный первый экран",
+  cards: "Cards — карточки",
+  pricing: "Pricing — тарифы и цены",
+  navigation: "Navigation — навигация",
+  motion: "Motion — движение и анимация",
+  dashboard: "Dashboard — панель управления",
+  onboarding: "Onboarding — первые шаги пользователя",
+  checkout: "Checkout — оформление заказа",
+  custom: "Custom — свой паттерн"
+};
+
 const STATUS_LABELS = {
-  primary: "Primary",
-  partial: "Partial",
-  rejected: "Rejected",
-  undecided: "Undecided"
+  primary: "Основной",
+  partial: "Частичный",
+  rejected: "Отклонён",
+  undecided: "Не решено"
 };
 
 const seedDonors = [
@@ -25,13 +37,13 @@ const seedDonors = [
     title: "Linear",
     sourceUrl: "https://linear.app",
     manualPreviewUrl: "",
-    projectType: "SaaS product",
+    projectType: "SaaS-продукт",
     styleTags: ["minimal", "dark", "premium"],
     sectionTags: ["hero", "navigation", "product"],
     decision: "partial",
     patterns: ["hero", "navigation", "motion"],
-    notes: "Use the calm density and product-led framing. Do not copy the exact dark palette.",
-    strongPoints: "Strong visual hierarchy and mature interface tone.",
+    notes: "Нравится спокойная плотность интерфейса и продуктовая подача. Не копировать тёмную палитру буквально.",
+    strongPoints: "Сильная визуальная иерархия и зрелый тон интерфейса.",
     previewMeta: {
       provider: "screenshot_api",
       status: "ready",
@@ -47,13 +59,13 @@ const seedDonors = [
     title: "Stripe",
     sourceUrl: "https://stripe.com",
     manualPreviewUrl: "",
-    projectType: "Marketing site",
+    projectType: "Маркетинговый сайт",
     styleTags: ["technical", "light", "clear"],
     sectionTags: ["hero", "pricing", "trust"],
     decision: "undecided",
     patterns: ["hero", "pricing"],
-    notes: "Good reference for explanation sequence and proof blocks.",
-    strongPoints: "Clear product storytelling with strong section pacing.",
+    notes: "Хороший ориентир для порядка объяснения и блоков доверия.",
+    strongPoints: "Понятная подача продукта и сильный темп секций.",
     previewMeta: {
       provider: "screenshot_api",
       status: "ready",
@@ -78,7 +90,7 @@ const previewAdapter = {
         provider: "manual",
         status: "ready",
         capturedAt: donor.previewMeta?.capturedAt || donor.updatedAt || new Date().toISOString(),
-        fallbackLabel: "Manual preview"
+        fallbackLabel: "Ручное превью"
       };
     },
 
@@ -95,7 +107,7 @@ const previewAdapter = {
         provider: "screenshot_api",
         status: "ready",
         capturedAt: donor.previewMeta?.capturedAt || donor.updatedAt || new Date().toISOString(),
-        fallbackLabel: "Auto preview"
+        fallbackLabel: "Автопревью"
       };
     }
   },
@@ -106,7 +118,7 @@ const previewAdapter = {
       provider: "placeholder",
       status: "failed",
       capturedAt: donor.previewMeta?.capturedAt || donor.updatedAt || new Date().toISOString(),
-      fallbackLabel: "Preview unavailable"
+      fallbackLabel: "Превью недоступно"
     };
   }
 };
@@ -188,13 +200,13 @@ function bindEvents() {
 function hydratePatternOptions() {
   nodes.patternFilter.insertAdjacentHTML(
     "beforeend",
-    PATTERN_OPTIONS.map(pattern => `<option value="${pattern}">${pattern}</option>`).join("")
+    PATTERN_OPTIONS.map(pattern => `<option value="${pattern}">${escapeHtml(PATTERN_LABELS[pattern])}</option>`).join("")
   );
 
   nodes.patternChecklist.innerHTML = PATTERN_OPTIONS.map(pattern => `
     <label class="pattern-toggle">
       <input type="checkbox" value="${pattern}" />
-      <span>${pattern}</span>
+      <span>${escapeHtml(PATTERN_LABELS[pattern])}</span>
     </label>
   `).join("");
 }
@@ -213,11 +225,11 @@ function renderHeroStats() {
   const patterns = new Set(state.donors.flatMap(donor => donor.patterns || []));
 
   nodes.heroStats.innerHTML = [
-    { value: state.donors.length, label: "saved donors" },
-    { value: primary, label: "primary picks" },
-    { value: partial, label: "partial references" },
-    { value: patterns.size, label: "pattern types selected" },
-    { value: withManualPreview, label: "manual preview overrides" }
+    { value: state.donors.length, label: "сохранённых доноров" },
+    { value: primary, label: "основных направлений" },
+    { value: partial, label: "частичных референсов" },
+    { value: patterns.size, label: "типов паттернов выбрано" },
+    { value: withManualPreview, label: "ручных замен превью" }
   ].map(stat => `
     <article class="hero-stat">
       <strong>${stat.value}</strong>
@@ -243,22 +255,22 @@ function renderBoardSummary() {
 
   nodes.boardSummary.innerHTML = `
     <div>
-      <p class="section-kicker">Selection board</p>
-      <h3>See the shortlist shape before exporting.</h3>
-      <p class="hero-text">This board stays local in the browser, survives reloads, and keeps the preview provider behind one adapter seam for later Linkwarden integration.</p>
+      <p class="section-kicker">Доска отбора</p>
+      <h3>Смотри форму shortlist до экспорта.</h3>
+      <p class="hero-text">Эта доска хранится локально в браузере, переживает перезагрузки и сохраняет preview-provider adapter как отдельный seam для будущей интеграции с Linkwarden.</p>
     </div>
     <div class="board-summary-grid">
       ${countsByStatus.map(item => `
         <article class="summary-card">
           <strong class="status-${item.status}">${item.count}</strong>
-          <span>${STATUS_LABELS[item.status]} donors</span>
+          <span>${STATUS_LABELS[item.status]} доноров</span>
         </article>
       `).join("")}
       <article class="summary-card">
         <strong>${topPatterns.length}</strong>
-        <span>top active patterns</span>
+        <span>активных паттернов в топе</span>
         <ul>
-          ${topPatterns.length ? topPatterns.map(item => `<li>${item.pattern}: ${item.count}</li>`).join("") : "<li>No patterns selected yet.</li>"}
+          ${topPatterns.length ? topPatterns.map(item => `<li>${escapeHtml(PATTERN_LABELS[item.pattern])}: ${item.count}</li>`).join("") : "<li>Пока ни один паттерн не выбран.</li>"}
         </ul>
       </article>
     </div>
@@ -274,10 +286,10 @@ function renderCardGrid(donors) {
   nodes.cardGrid.innerHTML = donors.map(donor => {
     const preview = previewAdapter.capture(donor);
     const providerLabel = preview.provider === "manual"
-      ? "Manual preview"
+      ? "Ручное превью"
       : preview.provider === "screenshot_api"
-        ? "Auto screenshot"
-        : "Fallback";
+        ? "Автоскриншот"
+        : "Запасной вариант";
 
     return `
       <article class="donor-card">
@@ -294,7 +306,7 @@ function renderCardGrid(donors) {
         <div class="donor-body">
           <div class="donor-header">
             <div>
-              <p class="section-kicker">Donor</p>
+              <p class="section-kicker">Донор</p>
               <h3 class="donor-title">${escapeHtml(donor.title)}</h3>
             </div>
             <span class="meta-pill status-chip status-${donor.decision}">${STATUS_LABELS[donor.decision]}</span>
@@ -303,29 +315,29 @@ function renderCardGrid(donors) {
           <a class="donor-url" href="${escapeHtml(donor.sourceUrl)}" target="_blank" rel="noreferrer">${escapeHtml(donor.sourceUrl)}</a>
 
           <div class="meta-cluster">
-            <span class="meta-pill">${escapeHtml(donor.projectType || "Project type not set")}</span>
+            <span class="meta-pill">${escapeHtml(donor.projectType || "Тип проекта не указан")}</span>
             <span class="meta-pill">${escapeHtml(getDomainLabel(donor.sourceUrl))}</span>
-            <span class="meta-pill">${preview.provider === "manual" ? "Manual override active" : "Adapter preview"}</span>
+            <span class="meta-pill">${preview.provider === "manual" ? "Ручная замена активна" : "Превью через адаптер"}</span>
           </div>
 
-          ${renderPillCluster("Style tags", donor.styleTags, "tag")}
-          ${renderPillCluster("Section tags", donor.sectionTags, "tag")}
-          ${renderPillCluster("Patterns", donor.patterns, "pattern")}
+          ${renderPillCluster("Теги стиля", donor.styleTags, "tag")}
+          ${renderPillCluster("Теги секций", donor.sectionTags, "tag")}
+          ${renderPillCluster("Паттерны", donor.patterns, "pattern")}
 
           <div>
-            <p class="subheading">Strong points</p>
-            <div class="donor-copy">${escapeHtml(donor.strongPoints || "Not captured yet.")}</div>
+            <p class="subheading">Сильные стороны</p>
+            <div class="donor-copy">${escapeHtml(donor.strongPoints || "Пока не зафиксировано.")}</div>
           </div>
 
           <div>
-            <p class="subheading">Notes</p>
-            <div class="donor-copy">${escapeHtml(donor.notes || "No notes yet.")}</div>
+            <p class="subheading">Заметки</p>
+            <div class="donor-copy">${escapeHtml(donor.notes || "Пока нет заметок.")}</div>
           </div>
 
           <div class="action-row">
-            <button class="button button-primary" type="button" data-action="edit" data-id="${donor.id}">Edit</button>
-            <button class="button button-secondary" type="button" data-action="refresh" data-id="${donor.id}">Refresh preview</button>
-            <button class="button button-ghost" type="button" data-action="delete" data-id="${donor.id}">Delete</button>
+            <button class="button button-primary" type="button" data-action="edit" data-id="${donor.id}">Редактировать</button>
+            <button class="button button-secondary" type="button" data-action="refresh" data-id="${donor.id}">Обновить превью</button>
+            <button class="button button-ghost" type="button" data-action="delete" data-id="${donor.id}">Удалить</button>
           </div>
         </div>
       </article>
@@ -343,11 +355,15 @@ function renderPillCluster(label, values, kind) {
   }
 
   const className = kind === "pattern" ? "pattern-pill" : "tag-pill";
+  const renderedValues = kind === "pattern"
+    ? values.map(value => `<span class="${className}">${escapeHtml(PATTERN_LABELS[value] || value)}</span>`).join("")
+    : values.map(value => `<span class="${className}">${escapeHtml(value)}</span>`).join("");
+
   return `
     <div>
       <p class="subheading">${label}</p>
       <div class="${kind}-cluster">
-        ${values.map(value => `<span class="${className}">${escapeHtml(value)}</span>`).join("")}
+        ${renderedValues}
       </div>
     </div>
   `;
@@ -400,7 +416,7 @@ function handleCardAction(action, id) {
 
 function openEditor(donor = null) {
   state.editingId = donor?.id || null;
-  nodes.dialogTitle.textContent = donor ? "Edit donor" : "Add donor";
+  nodes.dialogTitle.textContent = donor ? "Редактировать донора" : "Добавить донора";
   nodes.sourceUrlInput.value = donor?.sourceUrl || "";
   nodes.titleInput.value = donor?.title || "";
   nodes.projectTypeInput.value = donor?.projectType || "";
@@ -465,7 +481,7 @@ function saveEditor(event) {
 
   const duplicate = state.donors.find(item => item.id !== donor.id && normalizeUrl(item.sourceUrl) === donor.sourceUrl);
   if (duplicate) {
-    const shouldReplace = window.confirm(`A donor for ${donor.sourceUrl} already exists. Replace the existing record?`);
+    const shouldReplace = window.confirm(`Донор для ${donor.sourceUrl} уже существует. Заменить существующую запись?`);
     if (!shouldReplace) {
       return;
     }
@@ -524,18 +540,18 @@ function exportMarkdown() {
   const grouped = groupByStatus(state.donors);
   const markdown = `# Design Selection Record
 
-Generated: ${new Date().toISOString()}
+Сгенерировано: ${new Date().toISOString()}
 
-## Primary Direction
+## Основное направление
 ${renderMarkdownList(grouped.primary)}
 
-## Partial References
+## Частичные референсы
 ${renderMarkdownList(grouped.partial)}
 
-## Rejected Directions
+## Отклонённые направления
 ${renderMarkdownList(grouped.rejected)}
 
-## Undecided Donors
+## Доноры без решения
 ${renderMarkdownList(grouped.undecided)}
 `;
 
@@ -564,22 +580,22 @@ function groupByStatus(donors) {
 
 function renderMarkdownList(donors) {
   if (!donors.length) {
-    return "- None.\n";
+    return "- Нет записей.\n";
   }
 
   return donors.map(donor => {
     const preview = previewAdapter.capture(donor);
     return `### ${donor.title}
 - URL: ${donor.sourceUrl}
-- Decision: ${STATUS_LABELS[donor.decision]}
-- Project type: ${donor.projectType || "Not set"}
-- Patterns: ${(donor.patterns || []).join(", ") || "None"}
-- Style tags: ${(donor.styleTags || []).join(", ") || "None"}
-- Section tags: ${(donor.sectionTags || []).join(", ") || "None"}
-- Strong points: ${donor.strongPoints || "Not captured"}
-- Notes: ${donor.notes || "No notes"}
-- Preview source: ${preview.provider}
-- Preview URL: ${preview.imageUrl || "Fallback only"}
+- Статус: ${STATUS_LABELS[donor.decision]}
+- Тип проекта: ${donor.projectType || "Не указан"}
+- Паттерны: ${(donor.patterns || []).map(pattern => PATTERN_LABELS[pattern] || pattern).join(", ") || "Нет"}
+- Теги стиля: ${(donor.styleTags || []).join(", ") || "Нет"}
+- Теги секций: ${(donor.sectionTags || []).join(", ") || "Нет"}
+- Сильные стороны: ${donor.strongPoints || "Не зафиксировано"}
+- Заметки: ${donor.notes || "Нет заметок"}
+- Источник превью: ${preview.provider}
+- URL превью: ${preview.imageUrl || "Только fallback"}
 `;
   }).join("\n");
 }
@@ -634,12 +650,12 @@ function normalizeUrl(value, options = {}) {
 
 function formatDate(value) {
   if (!value) {
-    return "Fresh";
+    return "Свежо";
   }
 
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
-    return "Fresh";
+    return "Свежо";
   }
 
   return date.toLocaleDateString(undefined, {
@@ -660,7 +676,7 @@ function escapeHtml(value = "") {
 
 window.__designPickerHandlePreviewError = function handlePreviewError(event) {
   const image = event.target;
-  const title = image.dataset.fallbackTitle || "Preview unavailable";
+  const title = image.dataset.fallbackTitle || "Превью недоступно";
   const domain = image.dataset.fallbackDomain || "";
   image.replaceWith(createFallbackNode(title, domain));
 };
@@ -672,7 +688,7 @@ function createFallbackNode(title, domain) {
     <div>
       <strong>${escapeHtml(title)}</strong>
       <div>${escapeHtml(domain)}</div>
-      <div>Preview unavailable. Use manual override if needed.</div>
+      <div>Превью недоступно. При необходимости используй ручную замену.</div>
     </div>
   `;
   return wrapper;

--- a/projects/design-picker/app.js
+++ b/projects/design-picker/app.js
@@ -1,0 +1,679 @@
+const STORAGE_KEY = "design-picker-catalog-v3";
+const STATUS_ORDER = { primary: 0, partial: 1, undecided: 2, rejected: 3 };
+const PATTERN_OPTIONS = [
+  "hero",
+  "cards",
+  "pricing",
+  "navigation",
+  "motion",
+  "dashboard",
+  "onboarding",
+  "checkout",
+  "custom"
+];
+
+const STATUS_LABELS = {
+  primary: "Primary",
+  partial: "Partial",
+  rejected: "Rejected",
+  undecided: "Undecided"
+};
+
+const seedDonors = [
+  {
+    id: crypto.randomUUID(),
+    title: "Linear",
+    sourceUrl: "https://linear.app",
+    manualPreviewUrl: "",
+    projectType: "SaaS product",
+    styleTags: ["minimal", "dark", "premium"],
+    sectionTags: ["hero", "navigation", "product"],
+    decision: "partial",
+    patterns: ["hero", "navigation", "motion"],
+    notes: "Use the calm density and product-led framing. Do not copy the exact dark palette.",
+    strongPoints: "Strong visual hierarchy and mature interface tone.",
+    previewMeta: {
+      provider: "screenshot_api",
+      status: "ready",
+      capturedAt: new Date().toISOString(),
+      viewport: "desktop",
+      refreshNonce: 0
+    },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  },
+  {
+    id: crypto.randomUUID(),
+    title: "Stripe",
+    sourceUrl: "https://stripe.com",
+    manualPreviewUrl: "",
+    projectType: "Marketing site",
+    styleTags: ["technical", "light", "clear"],
+    sectionTags: ["hero", "pricing", "trust"],
+    decision: "undecided",
+    patterns: ["hero", "pricing"],
+    notes: "Good reference for explanation sequence and proof blocks.",
+    strongPoints: "Clear product storytelling with strong section pacing.",
+    previewMeta: {
+      provider: "screenshot_api",
+      status: "ready",
+      capturedAt: new Date().toISOString(),
+      viewport: "desktop",
+      refreshNonce: 0
+    },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  }
+];
+
+const previewAdapter = {
+  providers: {
+    manual(donor) {
+      if (!donor.manualPreviewUrl?.trim()) {
+        return null;
+      }
+
+      return {
+        imageUrl: normalizeUrl(donor.manualPreviewUrl),
+        provider: "manual",
+        status: "ready",
+        capturedAt: donor.previewMeta?.capturedAt || donor.updatedAt || new Date().toISOString(),
+        fallbackLabel: "Manual preview"
+      };
+    },
+
+    screenshotApi(donor) {
+      const normalized = normalizeUrl(donor.sourceUrl);
+
+      if (!normalized) {
+        return null;
+      }
+
+      const cacheBuster = donor.previewMeta?.refreshNonce || 0;
+      return {
+        imageUrl: `https://image.thum.io/get/width/1440/crop/900/noanimate/${normalized}?refresh=${cacheBuster}`,
+        provider: "screenshot_api",
+        status: "ready",
+        capturedAt: donor.previewMeta?.capturedAt || donor.updatedAt || new Date().toISOString(),
+        fallbackLabel: "Auto preview"
+      };
+    }
+  },
+
+  capture(donor) {
+    return this.providers.manual(donor) || this.providers.screenshotApi(donor) || {
+      imageUrl: "",
+      provider: "placeholder",
+      status: "failed",
+      capturedAt: donor.previewMeta?.capturedAt || donor.updatedAt || new Date().toISOString(),
+      fallbackLabel: "Preview unavailable"
+    };
+  }
+};
+
+const state = {
+  donors: loadDonors(),
+  editingId: null
+};
+
+const nodes = {
+  heroStats: document.getElementById("heroStats"),
+  boardSummary: document.getElementById("boardSummary"),
+  cardGrid: document.getElementById("cardGrid"),
+  searchInput: document.getElementById("searchInput"),
+  statusFilter: document.getElementById("statusFilter"),
+  patternFilter: document.getElementById("patternFilter"),
+  sortMode: document.getElementById("sortMode"),
+  openCreateButton: document.getElementById("openCreateButton"),
+  exportMarkdownButton: document.getElementById("exportMarkdownButton"),
+  exportJsonButton: document.getElementById("exportJsonButton"),
+  editorDialog: document.getElementById("editorDialog"),
+  editorForm: document.getElementById("editorForm"),
+  closeDialogButton: document.getElementById("closeDialogButton"),
+  cancelButton: document.getElementById("cancelButton"),
+  dialogTitle: document.getElementById("dialogTitle"),
+  sourceUrlInput: document.getElementById("sourceUrlInput"),
+  titleInput: document.getElementById("titleInput"),
+  projectTypeInput: document.getElementById("projectTypeInput"),
+  manualPreviewInput: document.getElementById("manualPreviewInput"),
+  styleTagsInput: document.getElementById("styleTagsInput"),
+  sectionTagsInput: document.getElementById("sectionTagsInput"),
+  decisionInput: document.getElementById("decisionInput"),
+  strongPointsInput: document.getElementById("strongPointsInput"),
+  notesInput: document.getElementById("notesInput"),
+  patternChecklist: document.getElementById("patternChecklist"),
+  emptyStateTemplate: document.getElementById("emptyStateTemplate")
+};
+
+hydratePatternOptions();
+bindEvents();
+render();
+
+function loadDonors() {
+  const raw = localStorage.getItem(STORAGE_KEY);
+
+  if (!raw) {
+    return structuredClone(seedDonors);
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) && parsed.length ? parsed : structuredClone(seedDonors);
+  } catch {
+    return structuredClone(seedDonors);
+  }
+}
+
+function persist() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state.donors));
+}
+
+function bindEvents() {
+  nodes.openCreateButton.addEventListener("click", () => openEditor());
+  nodes.closeDialogButton.addEventListener("click", closeEditor);
+  nodes.cancelButton.addEventListener("click", closeEditor);
+  nodes.searchInput.addEventListener("input", render);
+  nodes.statusFilter.addEventListener("change", render);
+  nodes.patternFilter.addEventListener("change", render);
+  nodes.sortMode.addEventListener("change", render);
+  nodes.exportMarkdownButton.addEventListener("click", exportMarkdown);
+  nodes.exportJsonButton.addEventListener("click", exportJson);
+  nodes.editorForm.addEventListener("submit", saveEditor);
+  nodes.editorDialog.addEventListener("cancel", event => {
+    event.preventDefault();
+    closeEditor();
+  });
+}
+
+function hydratePatternOptions() {
+  nodes.patternFilter.insertAdjacentHTML(
+    "beforeend",
+    PATTERN_OPTIONS.map(pattern => `<option value="${pattern}">${pattern}</option>`).join("")
+  );
+
+  nodes.patternChecklist.innerHTML = PATTERN_OPTIONS.map(pattern => `
+    <label class="pattern-toggle">
+      <input type="checkbox" value="${pattern}" />
+      <span>${pattern}</span>
+    </label>
+  `).join("");
+}
+
+function render() {
+  const donors = getFilteredDonors();
+  renderHeroStats();
+  renderBoardSummary();
+  renderCardGrid(donors);
+}
+
+function renderHeroStats() {
+  const primary = state.donors.filter(donor => donor.decision === "primary").length;
+  const partial = state.donors.filter(donor => donor.decision === "partial").length;
+  const withManualPreview = state.donors.filter(donor => donor.manualPreviewUrl?.trim()).length;
+  const patterns = new Set(state.donors.flatMap(donor => donor.patterns || []));
+
+  nodes.heroStats.innerHTML = [
+    { value: state.donors.length, label: "saved donors" },
+    { value: primary, label: "primary picks" },
+    { value: partial, label: "partial references" },
+    { value: patterns.size, label: "pattern types selected" },
+    { value: withManualPreview, label: "manual preview overrides" }
+  ].map(stat => `
+    <article class="hero-stat">
+      <strong>${stat.value}</strong>
+      <span>${stat.label}</span>
+    </article>
+  `).join("");
+}
+
+function renderBoardSummary() {
+  const countsByStatus = Object.keys(STATUS_LABELS).map(status => ({
+    status,
+    count: state.donors.filter(donor => donor.decision === status).length
+  }));
+
+  const topPatterns = PATTERN_OPTIONS
+    .map(pattern => ({
+      pattern,
+      count: state.donors.filter(donor => (donor.patterns || []).includes(pattern)).length
+    }))
+    .filter(entry => entry.count > 0)
+    .sort((left, right) => right.count - left.count)
+    .slice(0, 4);
+
+  nodes.boardSummary.innerHTML = `
+    <div>
+      <p class="section-kicker">Selection board</p>
+      <h3>See the shortlist shape before exporting.</h3>
+      <p class="hero-text">This board stays local in the browser, survives reloads, and keeps the preview provider behind one adapter seam for later Linkwarden integration.</p>
+    </div>
+    <div class="board-summary-grid">
+      ${countsByStatus.map(item => `
+        <article class="summary-card">
+          <strong class="status-${item.status}">${item.count}</strong>
+          <span>${STATUS_LABELS[item.status]} donors</span>
+        </article>
+      `).join("")}
+      <article class="summary-card">
+        <strong>${topPatterns.length}</strong>
+        <span>top active patterns</span>
+        <ul>
+          ${topPatterns.length ? topPatterns.map(item => `<li>${item.pattern}: ${item.count}</li>`).join("") : "<li>No patterns selected yet.</li>"}
+        </ul>
+      </article>
+    </div>
+  `;
+}
+
+function renderCardGrid(donors) {
+  if (!donors.length) {
+    nodes.cardGrid.replaceChildren(nodes.emptyStateTemplate.content.cloneNode(true));
+    return;
+  }
+
+  nodes.cardGrid.innerHTML = donors.map(donor => {
+    const preview = previewAdapter.capture(donor);
+    const providerLabel = preview.provider === "manual"
+      ? "Manual preview"
+      : preview.provider === "screenshot_api"
+        ? "Auto screenshot"
+        : "Fallback";
+
+    return `
+      <article class="donor-card">
+        <div class="donor-preview">
+          ${preview.imageUrl
+            ? `<img src="${escapeHtml(preview.imageUrl)}" alt="${escapeHtml(donor.title)} preview" data-fallback-title="${escapeHtml(donor.title)}" data-fallback-domain="${escapeHtml(getDomainLabel(donor.sourceUrl))}" onerror="window.__designPickerHandlePreviewError(event)" />`
+            : ""}
+          ${!preview.imageUrl ? buildFallbackMarkup(donor, preview.fallbackLabel) : ""}
+          <div class="preview-chip-row">
+            <span class="chip">${providerLabel}</span>
+            <span class="chip">${formatDate(preview.capturedAt)}</span>
+          </div>
+        </div>
+        <div class="donor-body">
+          <div class="donor-header">
+            <div>
+              <p class="section-kicker">Donor</p>
+              <h3 class="donor-title">${escapeHtml(donor.title)}</h3>
+            </div>
+            <span class="meta-pill status-chip status-${donor.decision}">${STATUS_LABELS[donor.decision]}</span>
+          </div>
+
+          <a class="donor-url" href="${escapeHtml(donor.sourceUrl)}" target="_blank" rel="noreferrer">${escapeHtml(donor.sourceUrl)}</a>
+
+          <div class="meta-cluster">
+            <span class="meta-pill">${escapeHtml(donor.projectType || "Project type not set")}</span>
+            <span class="meta-pill">${escapeHtml(getDomainLabel(donor.sourceUrl))}</span>
+            <span class="meta-pill">${preview.provider === "manual" ? "Manual override active" : "Adapter preview"}</span>
+          </div>
+
+          ${renderPillCluster("Style tags", donor.styleTags, "tag")}
+          ${renderPillCluster("Section tags", donor.sectionTags, "tag")}
+          ${renderPillCluster("Patterns", donor.patterns, "pattern")}
+
+          <div>
+            <p class="subheading">Strong points</p>
+            <div class="donor-copy">${escapeHtml(donor.strongPoints || "Not captured yet.")}</div>
+          </div>
+
+          <div>
+            <p class="subheading">Notes</p>
+            <div class="donor-copy">${escapeHtml(donor.notes || "No notes yet.")}</div>
+          </div>
+
+          <div class="action-row">
+            <button class="button button-primary" type="button" data-action="edit" data-id="${donor.id}">Edit</button>
+            <button class="button button-secondary" type="button" data-action="refresh" data-id="${donor.id}">Refresh preview</button>
+            <button class="button button-ghost" type="button" data-action="delete" data-id="${donor.id}">Delete</button>
+          </div>
+        </div>
+      </article>
+    `;
+  }).join("");
+
+  nodes.cardGrid.querySelectorAll("[data-action]").forEach(button => {
+    button.addEventListener("click", () => handleCardAction(button.dataset.action, button.dataset.id));
+  });
+}
+
+function renderPillCluster(label, values, kind) {
+  if (!values?.length) {
+    return "";
+  }
+
+  const className = kind === "pattern" ? "pattern-pill" : "tag-pill";
+  return `
+    <div>
+      <p class="subheading">${label}</p>
+      <div class="${kind}-cluster">
+        ${values.map(value => `<span class="${className}">${escapeHtml(value)}</span>`).join("")}
+      </div>
+    </div>
+  `;
+}
+
+function buildFallbackMarkup(donor, label) {
+  return `
+    <div class="preview-overlay">
+      <div>
+        <strong>${escapeHtml(donor.title)}</strong>
+        <div>${escapeHtml(getDomainLabel(donor.sourceUrl))}</div>
+        <div>${escapeHtml(label)}</div>
+      </div>
+    </div>
+  `;
+}
+
+function handleCardAction(action, id) {
+  if (action === "edit") {
+    const donor = state.donors.find(item => item.id === id);
+    if (donor) {
+      openEditor(donor);
+    }
+    return;
+  }
+
+  if (action === "refresh") {
+    state.donors = state.donors.map(donor => donor.id === id ? {
+      ...donor,
+      previewMeta: {
+        ...(donor.previewMeta || {}),
+        provider: donor.manualPreviewUrl?.trim() ? "manual" : "screenshot_api",
+        status: donor.manualPreviewUrl?.trim() ? "ready" : "pending",
+        capturedAt: new Date().toISOString(),
+        refreshNonce: Date.now()
+      },
+      updatedAt: new Date().toISOString()
+    } : donor);
+    persist();
+    render();
+    return;
+  }
+
+  if (action === "delete") {
+    state.donors = state.donors.filter(donor => donor.id !== id);
+    persist();
+    render();
+  }
+}
+
+function openEditor(donor = null) {
+  state.editingId = donor?.id || null;
+  nodes.dialogTitle.textContent = donor ? "Edit donor" : "Add donor";
+  nodes.sourceUrlInput.value = donor?.sourceUrl || "";
+  nodes.titleInput.value = donor?.title || "";
+  nodes.projectTypeInput.value = donor?.projectType || "";
+  nodes.manualPreviewInput.value = donor?.manualPreviewUrl || "";
+  nodes.styleTagsInput.value = (donor?.styleTags || []).join(", ");
+  nodes.sectionTagsInput.value = (donor?.sectionTags || []).join(", ");
+  nodes.decisionInput.value = donor?.decision || "undecided";
+  nodes.strongPointsInput.value = donor?.strongPoints || "";
+  nodes.notesInput.value = donor?.notes || "";
+
+  nodes.patternChecklist.querySelectorAll("input").forEach(input => {
+    input.checked = donor?.patterns?.includes(input.value) || false;
+  });
+
+  nodes.editorDialog.showModal();
+}
+
+function closeEditor() {
+  nodes.editorDialog.close();
+  state.editingId = null;
+  nodes.editorForm.reset();
+  nodes.patternChecklist.querySelectorAll("input").forEach(input => {
+    input.checked = false;
+  });
+}
+
+function saveEditor(event) {
+  event.preventDefault();
+
+  const sourceUrl = normalizeUrl(nodes.sourceUrlInput.value);
+  if (!sourceUrl) {
+    nodes.sourceUrlInput.focus();
+    return;
+  }
+
+  const existing = state.editingId ? state.donors.find(donor => donor.id === state.editingId) : null;
+  const now = new Date().toISOString();
+  const manualPreviewUrl = normalizeUrl(nodes.manualPreviewInput.value, { allowImageOnly: true });
+
+  const donor = {
+    id: state.editingId || crypto.randomUUID(),
+    title: nodes.titleInput.value.trim() || titleFromUrl(sourceUrl),
+    sourceUrl,
+    manualPreviewUrl,
+    projectType: nodes.projectTypeInput.value.trim(),
+    styleTags: parseTagInput(nodes.styleTagsInput.value),
+    sectionTags: parseTagInput(nodes.sectionTagsInput.value),
+    decision: nodes.decisionInput.value,
+    patterns: getPatternSelection(),
+    notes: nodes.notesInput.value.trim(),
+    strongPoints: nodes.strongPointsInput.value.trim(),
+    previewMeta: {
+      provider: manualPreviewUrl ? "manual" : "screenshot_api",
+      status: "ready",
+      capturedAt: now,
+      viewport: "desktop",
+      refreshNonce: existing?.previewMeta?.refreshNonce || 0
+    },
+    createdAt: existing?.createdAt || now,
+    updatedAt: now
+  };
+
+  const duplicate = state.donors.find(item => item.id !== donor.id && normalizeUrl(item.sourceUrl) === donor.sourceUrl);
+  if (duplicate) {
+    const shouldReplace = window.confirm(`A donor for ${donor.sourceUrl} already exists. Replace the existing record?`);
+    if (!shouldReplace) {
+      return;
+    }
+
+    state.donors = state.donors.filter(item => item.id !== duplicate.id);
+  }
+
+  state.donors = state.editingId
+    ? state.donors.map(item => item.id === state.editingId ? donor : item)
+    : [donor, ...state.donors];
+
+  persist();
+  closeEditor();
+  render();
+}
+
+function getFilteredDonors() {
+  const query = nodes.searchInput.value.trim().toLowerCase();
+  const status = nodes.statusFilter.value;
+  const pattern = nodes.patternFilter.value;
+  const sortMode = nodes.sortMode.value;
+
+  const filtered = state.donors.filter(donor => {
+    const haystack = [
+      donor.title,
+      donor.sourceUrl,
+      donor.projectType,
+      donor.notes,
+      donor.strongPoints,
+      ...(donor.styleTags || []),
+      ...(donor.sectionTags || []),
+      ...(donor.patterns || [])
+    ].join(" ").toLowerCase();
+
+    const matchesQuery = !query || haystack.includes(query);
+    const matchesStatus = status === "all" || donor.decision === status;
+    const matchesPattern = pattern === "all" || (donor.patterns || []).includes(pattern);
+    return matchesQuery && matchesStatus && matchesPattern;
+  });
+
+  return filtered.sort((left, right) => {
+    if (sortMode === "title") {
+      return left.title.localeCompare(right.title);
+    }
+
+    if (sortMode === "status") {
+      return (STATUS_ORDER[left.decision] ?? 99) - (STATUS_ORDER[right.decision] ?? 99) ||
+        right.updatedAt.localeCompare(left.updatedAt);
+    }
+
+    return right.updatedAt.localeCompare(left.updatedAt);
+  });
+}
+
+function exportMarkdown() {
+  const grouped = groupByStatus(state.donors);
+  const markdown = `# Design Selection Record
+
+Generated: ${new Date().toISOString()}
+
+## Primary Direction
+${renderMarkdownList(grouped.primary)}
+
+## Partial References
+${renderMarkdownList(grouped.partial)}
+
+## Rejected Directions
+${renderMarkdownList(grouped.rejected)}
+
+## Undecided Donors
+${renderMarkdownList(grouped.undecided)}
+`;
+
+  downloadFile("design-selection-record.md", markdown, "text/markdown");
+}
+
+function exportJson() {
+  const enriched = state.donors.map(donor => ({
+    ...donor,
+    preview: previewAdapter.capture(donor)
+  }));
+  downloadFile("design-picker-donors.json", JSON.stringify(enriched, null, 2), "application/json");
+}
+
+function groupByStatus(donors) {
+  return donors.reduce((groups, donor) => {
+    groups[donor.decision].push(donor);
+    return groups;
+  }, {
+    primary: [],
+    partial: [],
+    rejected: [],
+    undecided: []
+  });
+}
+
+function renderMarkdownList(donors) {
+  if (!donors.length) {
+    return "- None.\n";
+  }
+
+  return donors.map(donor => {
+    const preview = previewAdapter.capture(donor);
+    return `### ${donor.title}
+- URL: ${donor.sourceUrl}
+- Decision: ${STATUS_LABELS[donor.decision]}
+- Project type: ${donor.projectType || "Not set"}
+- Patterns: ${(donor.patterns || []).join(", ") || "None"}
+- Style tags: ${(donor.styleTags || []).join(", ") || "None"}
+- Section tags: ${(donor.sectionTags || []).join(", ") || "None"}
+- Strong points: ${donor.strongPoints || "Not captured"}
+- Notes: ${donor.notes || "No notes"}
+- Preview source: ${preview.provider}
+- Preview URL: ${preview.imageUrl || "Fallback only"}
+`;
+  }).join("\n");
+}
+
+function downloadFile(filename, content, contentType) {
+  const blob = new Blob([content], { type: contentType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+function parseTagInput(value) {
+  return value
+    .split(",")
+    .map(item => item.trim())
+    .filter(Boolean);
+}
+
+function getPatternSelection() {
+  return [...nodes.patternChecklist.querySelectorAll("input:checked")].map(input => input.value);
+}
+
+function titleFromUrl(sourceUrl) {
+  return getDomainLabel(sourceUrl);
+}
+
+function getDomainLabel(value) {
+  try {
+    return new URL(normalizeUrl(value)).hostname.replace(/^www\./, "");
+  } catch {
+    return value.trim();
+  }
+}
+
+function normalizeUrl(value, options = {}) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  if (options.allowImageOnly && /^(data:image\/|blob:)/i.test(trimmed)) {
+    return trimmed;
+  }
+
+  return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+}
+
+function formatDate(value) {
+  if (!value) {
+    return "Fresh";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Fresh";
+  }
+
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric"
+  });
+}
+
+function escapeHtml(value = "") {
+  return String(value).replace(/[&<>"']/g, character => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;"
+  })[character]);
+}
+
+window.__designPickerHandlePreviewError = function handlePreviewError(event) {
+  const image = event.target;
+  const title = image.dataset.fallbackTitle || "Preview unavailable";
+  const domain = image.dataset.fallbackDomain || "";
+  image.replaceWith(createFallbackNode(title, domain));
+};
+
+function createFallbackNode(title, domain) {
+  const wrapper = document.createElement("div");
+  wrapper.className = "preview-overlay";
+  wrapper.innerHTML = `
+    <div>
+      <strong>${escapeHtml(title)}</strong>
+      <div>${escapeHtml(domain)}</div>
+      <div>Preview unavailable. Use manual override if needed.</div>
+    </div>
+  `;
+  return wrapper;
+}

--- a/projects/design-picker/index.html
+++ b/projects/design-picker/index.html
@@ -1,392 +1,163 @@
 <!doctype html>
-<html lang="ru">
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Design Picker MVP</title>
-  <style>
-    :root {
-      font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      color: #1f2937;
-      background: #f5f7fb;
-    }
-    * { box-sizing: border-box; }
-    body { margin: 0; }
-    header {
-      padding: 24px;
-      background: white;
-      border-bottom: 1px solid #e5e7eb;
-      position: sticky;
-      top: 0;
-      z-index: 5;
-    }
-    h1 { margin: 0 0 6px; font-size: 24px; }
-    .muted { color: #6b7280; font-size: 14px; }
-    main { padding: 24px; display: grid; gap: 20px; }
-    .panel {
-      background: white;
-      border: 1px solid #e5e7eb;
-      border-radius: 16px;
-      padding: 16px;
-      box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
-    }
-    .toolbar {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-      gap: 12px;
-    }
-    input, select, textarea, button {
-      width: 100%;
-      border: 1px solid #d1d5db;
-      border-radius: 10px;
-      padding: 10px 12px;
-      font: inherit;
-    }
-    textarea { min-height: 88px; resize: vertical; }
-    button {
-      cursor: pointer;
-      background: #111827;
-      color: white;
-      border: 0;
-      font-weight: 600;
-    }
-    button.secondary { background: #e5e7eb; color: #111827; }
-    button.ghost { background: transparent; color: #111827; border: 1px solid #d1d5db; }
-    .grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 16px;
-    }
-    .card {
-      background: white;
-      border: 1px solid #e5e7eb;
-      border-radius: 16px;
-      overflow: hidden;
-      display: flex;
-      flex-direction: column;
-      min-height: 360px;
-    }
-    .preview {
-      aspect-ratio: 16 / 9;
-      background: #eef2ff;
-      display: grid;
-      place-items: center;
-      overflow: hidden;
-      border-bottom: 1px solid #e5e7eb;
-      position: relative;
-    }
-    .preview img { width: 100%; height: 100%; object-fit: cover; }
-    .preview-badge {
-      position: absolute;
-      right: 8px;
-      bottom: 8px;
-      background: rgba(17, 24, 39, .75);
-      color: white;
-      border-radius: 999px;
-      padding: 4px 8px;
-      font-size: 11px;
-    }
-    .card-body { padding: 14px; display: grid; gap: 10px; }
-    .card-title { margin: 0; font-size: 18px; }
-    .url { color: #2563eb; text-decoration: none; font-size: 13px; word-break: break-all; }
-    .tags { display: flex; flex-wrap: wrap; gap: 6px; }
-    .tag { background: #eef2ff; color: #3730a3; border-radius: 999px; padding: 4px 8px; font-size: 12px; }
-    .status { font-weight: 700; font-size: 13px; }
-    .status-primary { color: #047857; }
-    .status-partial { color: #b45309; }
-    .status-rejected { color: #b91c1c; }
-    .status-undecided { color: #6b7280; }
-    .row { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; }
-    .small { font-size: 12px; color: #6b7280; }
-    dialog {
-      width: min(760px, calc(100vw - 32px));
-      border: 0;
-      border-radius: 16px;
-      padding: 0;
-    }
-    dialog::backdrop { background: rgba(15, 23, 42, 0.45); }
-    .dialog-body { padding: 18px; display: grid; gap: 12px; }
-    .checkbox-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 8px; }
-    .checkbox-grid label { display: flex; gap: 8px; align-items: center; font-size: 14px; }
-    .checkbox-grid input { width: auto; }
-    .empty { text-align: center; color: #6b7280; padding: 40px 10px; }
-    @media (max-width: 640px) {
-      header, main { padding: 16px; }
-      .row { grid-template-columns: 1fr; }
-    }
-  </style>
+  <title>Design Picker</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>
-  <header>
-    <h1>Design Picker MVP</h1>
-    <div class="muted">Каталог дизайн-доноров: вставь ссылку, получи превью, выбери паттерны и экспортируй решение.</div>
-  </header>
-
-  <main>
-    <section class="panel">
-      <div class="toolbar">
-        <input id="search" placeholder="Поиск по названию, URL или тегам" />
-        <select id="filterStatus">
-          <option value="all">Все статусы</option>
-          <option value="primary">Основной</option>
-          <option value="partial">Частичный</option>
-          <option value="rejected">Отклонён</option>
-          <option value="undecided">Не решено</option>
-        </select>
-        <button id="addBtn">Добавить донора</button>
-        <button id="exportMdBtn" class="secondary">Экспорт Markdown</button>
-        <button id="exportJsonBtn" class="ghost">Экспорт JSON</button>
+  <div class="shell">
+    <header class="hero">
+      <div class="hero-copy">
+        <p class="eyebrow">Internal design donor catalog</p>
+        <h1>Pick a direction visually, not from memory.</h1>
+        <p class="hero-text">
+          Paste a donor URL, get a preview card, mark what is worth reusing, and export a clean handoff for later design work.
+        </p>
       </div>
-    </section>
+      <div class="hero-stats" id="heroStats"></div>
+    </header>
 
-    <section id="grid" class="grid"></section>
-  </main>
+    <main class="workspace">
+      <section class="panel panel-toolbar">
+        <div class="panel-heading">
+          <div>
+            <p class="section-kicker">Catalog</p>
+            <h2>Design donor board</h2>
+          </div>
+          <div class="toolbar-actions">
+            <button id="openCreateButton" class="button button-primary" type="button">Add donor</button>
+            <button id="exportMarkdownButton" class="button button-secondary" type="button">Export Markdown</button>
+            <button id="exportJsonButton" class="button button-ghost" type="button">Export JSON</button>
+          </div>
+        </div>
 
-  <dialog id="editor">
-    <form method="dialog" id="editorForm" class="dialog-body">
-      <h2 id="editorTitle">Добавить донора</h2>
-      <input id="title" placeholder="Название (можно оставить пустым — возьмём домен)" />
-      <input id="sourceUrl" placeholder="https://example.com" required />
-      <input id="previewUrl" placeholder="Необязательно: свой URL превью вместо автоматического screenshot" />
-      <div class="small">Если поле превью пустое, приложение автоматически сформирует screenshot URL через внешний preview endpoint.</div>
-      <input id="projectType" placeholder="Тип проекта: SaaS, landing, dashboard..." />
-      <input id="styleTags" placeholder="Теги стиля через запятую" />
-      <input id="sectionTags" placeholder="Теги секций через запятую" />
-      <select id="decision">
-        <option value="undecided">Не решено</option>
-        <option value="primary">Основной</option>
-        <option value="partial">Частичный</option>
-        <option value="rejected">Отклонён</option>
-      </select>
-      <div>
-        <div class="small">Выбрать полезные паттерны</div>
-        <div class="checkbox-grid" id="patterns"></div>
+        <div class="toolbar-grid">
+          <label class="field">
+            <span>Search</span>
+            <input id="searchInput" type="search" placeholder="Title, URL, notes, tags, patterns" />
+          </label>
+          <label class="field">
+            <span>Status</span>
+            <select id="statusFilter">
+              <option value="all">All statuses</option>
+              <option value="primary">Primary</option>
+              <option value="partial">Partial</option>
+              <option value="rejected">Rejected</option>
+              <option value="undecided">Undecided</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>Pattern</span>
+            <select id="patternFilter">
+              <option value="all">All patterns</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>Sort</span>
+            <select id="sortMode">
+              <option value="recent">Most recent</option>
+              <option value="status">Status</option>
+              <option value="title">Title</option>
+            </select>
+          </label>
+        </div>
+      </section>
+
+      <section class="panel board-summary" id="boardSummary"></section>
+
+      <section id="cardGrid" class="card-grid" aria-live="polite"></section>
+    </main>
+  </div>
+
+  <dialog id="editorDialog" class="editor-dialog">
+    <form id="editorForm" method="dialog" class="editor-form">
+      <div class="dialog-topbar">
+        <div>
+          <p class="section-kicker">Editor</p>
+          <h2 id="dialogTitle">Add donor</h2>
+        </div>
+        <button id="closeDialogButton" class="icon-button" type="button" aria-label="Close">×</button>
       </div>
-      <textarea id="notes" placeholder="Что нравится, что не брать, что упростить"></textarea>
-      <div class="row">
-        <button value="save" id="saveBtn">Сохранить</button>
-        <button value="cancel" class="secondary">Отмена</button>
+
+      <div class="dialog-grid">
+        <label class="field field-wide">
+          <span>Source URL</span>
+          <input id="sourceUrlInput" type="url" placeholder="https://example.com" required />
+          <small>Required. If title is empty, the domain becomes the title automatically.</small>
+        </label>
+
+        <label class="field">
+          <span>Title</span>
+          <input id="titleInput" type="text" placeholder="Optional custom title" />
+        </label>
+
+        <label class="field">
+          <span>Project type</span>
+          <input id="projectTypeInput" type="text" placeholder="SaaS, dashboard, landing, onboarding" />
+        </label>
+
+        <label class="field field-wide">
+          <span>Manual preview override</span>
+          <input id="manualPreviewInput" type="url" placeholder="Optional image URL to replace automatic preview" />
+          <small>Leave empty to use the automatic preview provider adapter.</small>
+        </label>
+
+        <label class="field">
+          <span>Style tags</span>
+          <input id="styleTagsInput" type="text" placeholder="minimal, premium, playful" />
+        </label>
+
+        <label class="field">
+          <span>Section tags</span>
+          <input id="sectionTagsInput" type="text" placeholder="hero, cards, pricing, onboarding" />
+        </label>
+
+        <label class="field">
+          <span>Decision status</span>
+          <select id="decisionInput">
+            <option value="undecided">Undecided</option>
+            <option value="primary">Primary</option>
+            <option value="partial">Partial</option>
+            <option value="rejected">Rejected</option>
+          </select>
+        </label>
+
+        <label class="field">
+          <span>Strong points</span>
+          <input id="strongPointsInput" type="text" placeholder="What is working well here?" />
+        </label>
+
+        <label class="field field-wide">
+          <span>Pattern selection</span>
+          <div id="patternChecklist" class="pattern-checklist"></div>
+        </label>
+
+        <label class="field field-wide">
+          <span>Notes</span>
+          <textarea id="notesInput" placeholder="What to borrow, what to avoid, what to simplify"></textarea>
+        </label>
+      </div>
+
+      <div class="dialog-actions">
+        <button id="saveButton" class="button button-primary" type="submit" value="save">Save donor</button>
+        <button id="cancelButton" class="button button-secondary" type="button">Cancel</button>
       </div>
     </form>
   </dialog>
 
-  <script>
-    const PATTERNS = ["hero", "cards", "pricing", "navigation", "motion", "dashboard", "onboarding", "checkout", "custom"];
-    const STORAGE_KEY = "design-picker-mvp-v2";
-    const SCREENSHOT_PROVIDER = "thum.io";
+  <template id="emptyStateTemplate">
+    <article class="panel empty-state">
+      <p class="section-kicker">No donors yet</p>
+      <h3>Start with one public URL.</h3>
+      <p>Add a donor, mark what is reusable, and build a shortlist visually.</p>
+    </article>
+  </template>
 
-    const seed = [
-      {
-        id: crypto.randomUUID(),
-        title: "Linear",
-        sourceUrl: "https://linear.app",
-        previewUrl: "",
-        projectType: "SaaS",
-        styleTags: ["minimal", "dark", "premium"],
-        sectionTags: ["hero", "product", "navigation"],
-        decision: "partial",
-        patterns: ["hero", "navigation", "motion"],
-        notes: "Нравится спокойная премиальная подача и плотная навигация. Не копировать цвета буквально."
-      },
-      {
-        id: crypto.randomUUID(),
-        title: "Stripe",
-        sourceUrl: "https://stripe.com",
-        previewUrl: "",
-        projectType: "Landing",
-        styleTags: ["clean", "technical", "light"],
-        sectionTags: ["hero", "pricing", "trust"],
-        decision: "undecided",
-        patterns: ["hero", "pricing"],
-        notes: "Полезно посмотреть структуру объяснения продукта и доверительные блоки."
-      }
-    ];
-
-    let donors = load();
-    let editingId = null;
-
-    const grid = document.getElementById("grid");
-    const editor = document.getElementById("editor");
-    const form = document.getElementById("editorForm");
-    const patternBox = document.getElementById("patterns");
-
-    function load() {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      if (!raw) return seed;
-      try { return JSON.parse(raw); } catch { return seed; }
-    }
-
-    function persist() {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(donors));
-    }
-
-    function splitTags(value) {
-      return value.split(",").map(x => x.trim()).filter(Boolean);
-    }
-
-    function normalizeUrl(value) {
-      const trimmed = value.trim();
-      if (!trimmed) return "";
-      return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
-    }
-
-    function titleFromUrl(value) {
-      try {
-        return new URL(normalizeUrl(value)).hostname.replace(/^www\./, "");
-      } catch {
-        return value;
-      }
-    }
-
-    function automaticPreviewUrl(sourceUrl) {
-      const normalized = normalizeUrl(sourceUrl);
-      return normalized ? `https://image.thum.io/get/width/1280/crop/720/noanimate/${encodeURIComponent(normalized)}` : "";
-    }
-
-    function effectivePreview(donor) {
-      return donor.previewUrl?.trim() || automaticPreviewUrl(donor.sourceUrl);
-    }
-
-    function previewSource(donor) {
-      return donor.previewUrl?.trim() ? "ручное превью" : `авто: ${SCREENSHOT_PROVIDER}`;
-    }
-
-    function statusLabel(status) {
-      return {
-        primary: "Основной",
-        partial: "Частичный",
-        rejected: "Отклонён",
-        undecided: "Не решено"
-      }[status] || status;
-    }
-
-    function renderPatterns(selected = []) {
-      patternBox.innerHTML = PATTERNS.map(pattern => `
-        <label><input type="checkbox" value="${pattern}" ${selected.includes(pattern) ? "checked" : ""}/> ${pattern}</label>
-      `).join("");
-    }
-
-    function getPatternSelection() {
-      return [...patternBox.querySelectorAll("input:checked")].map(x => x.value);
-    }
-
-    function render() {
-      const query = document.getElementById("search").value.trim().toLowerCase();
-      const status = document.getElementById("filterStatus").value;
-      const filtered = donors.filter(donor => {
-        const text = [donor.title, donor.sourceUrl, donor.projectType, ...(donor.styleTags || []), ...(donor.sectionTags || [])].join(" ").toLowerCase();
-        return text.includes(query) && (status === "all" || donor.decision === status);
-      });
-
-      if (!filtered.length) {
-        grid.innerHTML = `<div class="panel empty">Нет доноров под выбранный фильтр.</div>`;
-        return;
-      }
-
-      grid.innerHTML = filtered.map(donor => `
-        <article class="card">
-          <div class="preview">
-            ${effectivePreview(donor) ? `<img src="${escapeHtml(effectivePreview(donor))}" alt="Превью ${escapeHtml(donor.title)}" onerror="this.remove(); this.parentElement.innerHTML='<span>Не удалось получить превью</span>';">` : "Нет превью"}
-            <span class="preview-badge">${escapeHtml(previewSource(donor))}</span>
-          </div>
-          <div class="card-body">
-            <h3 class="card-title">${escapeHtml(donor.title)}</h3>
-            <a class="url" href="${escapeHtml(donor.sourceUrl)}" target="_blank" rel="noreferrer">${escapeHtml(donor.sourceUrl)}</a>
-            <div class="status status-${donor.decision}">${statusLabel(donor.decision)}</div>
-            <div class="tags">${[...(donor.styleTags || []), ...(donor.sectionTags || [])].map(tag => `<span class="tag">${escapeHtml(tag)}</span>`).join("")}</div>
-            <div class="small">Паттерны: ${(donor.patterns || []).join(", ") || "не выбраны"}</div>
-            <div>${escapeHtml(donor.notes || "")}</div>
-            <div class="row">
-              <button class="secondary" onclick="editDonor('${donor.id}')">Редактировать</button>
-              <button class="ghost" onclick="refreshPreview('${donor.id}')">Обновить превью</button>
-            </div>
-            <button class="ghost" onclick="removeDonor('${donor.id}')">Удалить</button>
-          </div>
-        </article>
-      `).join("");
-    }
-
-    function escapeHtml(value = "") {
-      return String(value).replace(/[&<>'"]/g, ch => ({"&":"&amp;", "<":"&lt;", ">":"&gt;", "'":"&#039;", '"':"&quot;"}[ch]));
-    }
-
-    function openEditor(donor = null) {
-      editingId = donor?.id || null;
-      document.getElementById("editorTitle").textContent = donor ? "Редактировать донора" : "Добавить донора";
-      document.getElementById("title").value = donor?.title || "";
-      document.getElementById("sourceUrl").value = donor?.sourceUrl || "";
-      document.getElementById("previewUrl").value = donor?.previewUrl || "";
-      document.getElementById("projectType").value = donor?.projectType || "";
-      document.getElementById("styleTags").value = (donor?.styleTags || []).join(", ");
-      document.getElementById("sectionTags").value = (donor?.sectionTags || []).join(", ");
-      document.getElementById("decision").value = donor?.decision || "undecided";
-      document.getElementById("notes").value = donor?.notes || "";
-      renderPatterns(donor?.patterns || []);
-      editor.showModal();
-    }
-
-    window.editDonor = id => openEditor(donors.find(x => x.id === id));
-    window.removeDonor = id => {
-      donors = donors.filter(x => x.id !== id);
-      persist();
-      render();
-    };
-    window.refreshPreview = id => {
-      donors = donors.map(donor => donor.id === id ? { ...donor, previewUrl: "", previewRefreshNonce: Date.now() } : donor);
-      persist();
-      render();
-    };
-
-    form.addEventListener("submit", event => {
-      const submitter = event.submitter?.value;
-      if (submitter !== "save") return;
-      event.preventDefault();
-      const sourceUrl = normalizeUrl(document.getElementById("sourceUrl").value);
-      const title = document.getElementById("title").value.trim() || titleFromUrl(sourceUrl);
-      const donor = {
-        id: editingId || crypto.randomUUID(),
-        title,
-        sourceUrl,
-        previewUrl: document.getElementById("previewUrl").value.trim(),
-        projectType: document.getElementById("projectType").value.trim(),
-        styleTags: splitTags(document.getElementById("styleTags").value),
-        sectionTags: splitTags(document.getElementById("sectionTags").value),
-        decision: document.getElementById("decision").value,
-        patterns: getPatternSelection(),
-        notes: document.getElementById("notes").value.trim(),
-        updatedAt: new Date().toISOString()
-      };
-      donors = editingId ? donors.map(x => x.id === editingId ? donor : x) : [donor, ...donors];
-      persist();
-      editor.close();
-      render();
-    });
-
-    function download(filename, content, type) {
-      const blob = new Blob([content], { type });
-      const link = document.createElement("a");
-      link.href = URL.createObjectURL(blob);
-      link.download = filename;
-      link.click();
-      URL.revokeObjectURL(link.href);
-    }
-
-    function toMarkdown() {
-      const primary = donors.filter(x => x.decision === "primary");
-      const partial = donors.filter(x => x.decision === "partial");
-      const rejected = donors.filter(x => x.decision === "rejected");
-      const section = (title, items) => `## ${title}\n\n${items.length ? items.map(x => `### ${x.title}\n- URL: ${x.sourceUrl}\n- Превью: ${effectivePreview(x)}\n- Источник превью: ${previewSource(x)}\n- Тип: ${x.projectType || "не указан"}\n- Паттерны: ${(x.patterns || []).join(", ") || "не выбраны"}\n- Заметки: ${x.notes || "нет"}\n`).join("\n") : "Нет записей.\n"}`;
-      return `# Design Selection Record\n\n${section("Primary Direction", primary)}\n${section("Borrow These Patterns", partial)}\n${section("Rejected Directions", rejected)}\n`;
-    }
-
-    document.getElementById("addBtn").addEventListener("click", () => openEditor());
-    document.getElementById("search").addEventListener("input", render);
-    document.getElementById("filterStatus").addEventListener("change", render);
-    document.getElementById("exportMdBtn").addEventListener("click", () => download("design-selection.md", toMarkdown(), "text/markdown"));
-    document.getElementById("exportJsonBtn").addEventListener("click", () => download("design-selection.json", JSON.stringify(donors.map(donor => ({ ...donor, effectivePreviewUrl: effectivePreview(donor), previewSource: previewSource(donor) })), null, 2), "application/json"));
-
-    renderPatterns();
-    render();
-  </script>
+  <script src="./app.js"></script>
 </body>
 </html>

--- a/projects/design-picker/index.html
+++ b/projects/design-picker/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ru">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -13,10 +13,10 @@
   <div class="shell">
     <header class="hero">
       <div class="hero-copy">
-        <p class="eyebrow">Internal design donor catalog</p>
-        <h1>Pick a direction visually, not from memory.</h1>
+        <p class="eyebrow">Внутренний каталог дизайн-доноров</p>
+        <h1>Выбирай направление визуально, а не по памяти.</h1>
         <p class="hero-text">
-          Paste a donor URL, get a preview card, mark what is worth reusing, and export a clean handoff for later design work.
+          Вставь URL донора, получи карточку с превью, отметь, что стоит переиспользовать, и экспортируй чистую основу для следующего дизайн-шага.
         </p>
       </div>
       <div class="hero-stats" id="heroStats"></div>
@@ -26,43 +26,43 @@
       <section class="panel panel-toolbar">
         <div class="panel-heading">
           <div>
-            <p class="section-kicker">Catalog</p>
-            <h2>Design donor board</h2>
+            <p class="section-kicker">Каталог</p>
+            <h2>Доска дизайн-доноров</h2>
           </div>
           <div class="toolbar-actions">
-            <button id="openCreateButton" class="button button-primary" type="button">Add donor</button>
-            <button id="exportMarkdownButton" class="button button-secondary" type="button">Export Markdown</button>
-            <button id="exportJsonButton" class="button button-ghost" type="button">Export JSON</button>
+            <button id="openCreateButton" class="button button-primary" type="button">Добавить донора</button>
+            <button id="exportMarkdownButton" class="button button-secondary" type="button">Экспорт Markdown</button>
+            <button id="exportJsonButton" class="button button-ghost" type="button">Экспорт JSON</button>
           </div>
         </div>
 
         <div class="toolbar-grid">
           <label class="field">
-            <span>Search</span>
-            <input id="searchInput" type="search" placeholder="Title, URL, notes, tags, patterns" />
+            <span>Поиск</span>
+            <input id="searchInput" type="search" placeholder="Название, URL, заметки, теги, паттерны" />
           </label>
           <label class="field">
-            <span>Status</span>
+            <span>Статус</span>
             <select id="statusFilter">
-              <option value="all">All statuses</option>
-              <option value="primary">Primary</option>
-              <option value="partial">Partial</option>
-              <option value="rejected">Rejected</option>
-              <option value="undecided">Undecided</option>
+              <option value="all">Все статусы</option>
+              <option value="primary">Основной</option>
+              <option value="partial">Частичный</option>
+              <option value="rejected">Отклонён</option>
+              <option value="undecided">Не решено</option>
             </select>
           </label>
           <label class="field">
-            <span>Pattern</span>
+            <span>Паттерн</span>
             <select id="patternFilter">
-              <option value="all">All patterns</option>
+              <option value="all">Все паттерны</option>
             </select>
           </label>
           <label class="field">
-            <span>Sort</span>
+            <span>Сортировка</span>
             <select id="sortMode">
-              <option value="recent">Most recent</option>
-              <option value="status">Status</option>
-              <option value="title">Title</option>
+              <option value="recent">Сначала новые</option>
+              <option value="status">По статусу</option>
+              <option value="title">По названию</option>
             </select>
           </label>
         </div>
@@ -78,83 +78,83 @@
     <form id="editorForm" method="dialog" class="editor-form">
       <div class="dialog-topbar">
         <div>
-          <p class="section-kicker">Editor</p>
-          <h2 id="dialogTitle">Add donor</h2>
+          <p class="section-kicker">Редактор</p>
+          <h2 id="dialogTitle">Добавить донора</h2>
         </div>
-        <button id="closeDialogButton" class="icon-button" type="button" aria-label="Close">×</button>
+        <button id="closeDialogButton" class="icon-button" type="button" aria-label="Закрыть">×</button>
       </div>
 
       <div class="dialog-grid">
         <label class="field field-wide">
-          <span>Source URL</span>
+          <span>URL источника</span>
           <input id="sourceUrlInput" type="url" placeholder="https://example.com" required />
-          <small>Required. If title is empty, the domain becomes the title automatically.</small>
+          <small>Обязательное поле. Если название пустое, приложение автоматически возьмёт домен.</small>
         </label>
 
         <label class="field">
-          <span>Title</span>
-          <input id="titleInput" type="text" placeholder="Optional custom title" />
+          <span>Название</span>
+          <input id="titleInput" type="text" placeholder="Необязательное название вручную" />
         </label>
 
         <label class="field">
-          <span>Project type</span>
+          <span>Тип проекта</span>
           <input id="projectTypeInput" type="text" placeholder="SaaS, dashboard, landing, onboarding" />
         </label>
 
         <label class="field field-wide">
-          <span>Manual preview override</span>
-          <input id="manualPreviewInput" type="url" placeholder="Optional image URL to replace automatic preview" />
-          <small>Leave empty to use the automatic preview provider adapter.</small>
+          <span>Ручная замена превью</span>
+          <input id="manualPreviewInput" type="url" placeholder="Необязательный URL картинки вместо автоматического превью" />
+          <small>Оставь пустым, чтобы использовать автоматический preview-provider adapter.</small>
         </label>
 
         <label class="field">
-          <span>Style tags</span>
+          <span>Теги стиля</span>
           <input id="styleTagsInput" type="text" placeholder="minimal, premium, playful" />
         </label>
 
         <label class="field">
-          <span>Section tags</span>
+          <span>Теги секций</span>
           <input id="sectionTagsInput" type="text" placeholder="hero, cards, pricing, onboarding" />
         </label>
 
         <label class="field">
-          <span>Decision status</span>
+          <span>Статус решения</span>
           <select id="decisionInput">
-            <option value="undecided">Undecided</option>
-            <option value="primary">Primary</option>
-            <option value="partial">Partial</option>
-            <option value="rejected">Rejected</option>
+            <option value="undecided">Не решено</option>
+            <option value="primary">Основной</option>
+            <option value="partial">Частичный</option>
+            <option value="rejected">Отклонён</option>
           </select>
         </label>
 
         <label class="field">
-          <span>Strong points</span>
-          <input id="strongPointsInput" type="text" placeholder="What is working well here?" />
+          <span>Сильные стороны</span>
+          <input id="strongPointsInput" type="text" placeholder="Что здесь работает хорошо?" />
         </label>
 
         <label class="field field-wide">
-          <span>Pattern selection</span>
+          <span>Выбор паттернов</span>
           <div id="patternChecklist" class="pattern-checklist"></div>
         </label>
 
         <label class="field field-wide">
-          <span>Notes</span>
-          <textarea id="notesInput" placeholder="What to borrow, what to avoid, what to simplify"></textarea>
+          <span>Заметки</span>
+          <textarea id="notesInput" placeholder="Что брать, чего избегать, что упростить"></textarea>
         </label>
       </div>
 
       <div class="dialog-actions">
-        <button id="saveButton" class="button button-primary" type="submit" value="save">Save donor</button>
-        <button id="cancelButton" class="button button-secondary" type="button">Cancel</button>
+        <button id="saveButton" class="button button-primary" type="submit" value="save">Сохранить донора</button>
+        <button id="cancelButton" class="button button-secondary" type="button">Отмена</button>
       </div>
     </form>
   </dialog>
 
   <template id="emptyStateTemplate">
     <article class="panel empty-state">
-      <p class="section-kicker">No donors yet</p>
-      <h3>Start with one public URL.</h3>
-      <p>Add a donor, mark what is reusable, and build a shortlist visually.</p>
+      <p class="section-kicker">Пока пусто</p>
+      <h3>Начни с одного публичного URL.</h3>
+      <p>Добавь донора, отметь, что стоит переиспользовать, и собери короткий визуальный shortlist.</p>
     </article>
   </template>
 

--- a/projects/design-picker/logs/latest.md
+++ b/projects/design-picker/logs/latest.md
@@ -1,0 +1,22 @@
+# Latest Log
+
+## Date
+2026-06-07
+
+## Executor
+Codex
+
+## Action
+Implemented the local Design Picker MVP as a polished static website with a preview-provider adapter, Windows launcher, local persistence, and export flow.
+
+## Result
+Upgraded the original one-file prototype into a multi-file local app with `index.html`, `styles.css`, `app.js`, and `Launch-Design-Picker.bat`. The app now supports URL-first donor creation, automatic title fallback, automatic preview generation through an adapter seam, manual preview override, edit/delete/refresh, status and pattern selection, search/filtering, and Markdown/JSON export.
+
+## Verification
+Validated the app in headless Chrome against the local `file://` launch path. Added two real public donor URLs, edited one donor, refreshed preview, confirmed `primary` and `partial` statuses, reloaded the page to confirm persistence, exported Markdown and JSON, confirmed both downloaded files contained expected records, and verified the layout at a 390px-wide viewport with no horizontal overflow.
+
+## Issues
+The MVP still relies on an external public screenshot endpoint for automatic preview generation and does not yet integrate with Linkwarden.
+
+## Next Action
+Commit the scoped `projects/design-picker/` changes, open the PR for issue `#25`, and post the required execution report with validation evidence.

--- a/projects/design-picker/logs/latest.md
+++ b/projects/design-picker/logs/latest.md
@@ -7,16 +7,16 @@
 Codex
 
 ## Action
-Implemented the local Design Picker MVP as a polished static website with a preview-provider adapter, Windows launcher, local persistence, and export flow.
+Implemented the local Design Picker MVP as a polished static website, then applied the required Russian owner-facing localization fix after review.
 
 ## Result
-Upgraded the original one-file prototype into a multi-file local app with `index.html`, `styles.css`, `app.js`, and `Launch-Design-Picker.bat`. The app now supports URL-first donor creation, automatic title fallback, automatic preview generation through an adapter seam, manual preview override, edit/delete/refresh, status and pattern selection, search/filtering, and Markdown/JSON export.
+Upgraded the original one-file prototype into a multi-file local app with `index.html`, `styles.css`, `app.js`, and `Launch-Design-Picker.bat`. The app now supports URL-first donor creation, automatic title fallback, automatic preview generation through an adapter seam, manual preview override, edit/delete/refresh, status and pattern selection, search/filtering, and Markdown/JSON export. The owner-facing interface is now localized into Russian while preserving internal machine values such as `primary`, `partial`, `hero`, `cards`, and other pattern/status ids.
 
 ## Verification
-Validated the app in headless Chrome against the local `file://` launch path. Added two real public donor URLs, edited one donor, refreshed preview, confirmed `primary` and `partial` statuses, reloaded the page to confirm persistence, exported Markdown and JSON, confirmed both downloaded files contained expected records, and verified the layout at a 390px-wide viewport with no horizontal overflow.
+Validated the app in headless Chrome against the local `file://` launch path. After the localization fix, confirmed Russian UI labels, launch through the local file path, donor creation and editing, status and pattern filters, preview refresh, persistence after reload, Markdown and JSON export, and a 390px-wide mobile viewport with no horizontal overflow.
 
 ## Issues
 The MVP still relies on an external public screenshot endpoint for automatic preview generation and does not yet integrate with Linkwarden.
 
 ## Next Action
-Commit the scoped `projects/design-picker/` changes, open the PR for issue `#25`, and post the required execution report with validation evidence.
+Push the localization fix to PR `#26` and post the new commit SHA plus validation note in issue `#25`.

--- a/projects/design-picker/styles.css
+++ b/projects/design-picker/styles.css
@@ -1,0 +1,567 @@
+:root {
+  --bg: #f5efe4;
+  --bg-strong: #fffaf0;
+  --panel: rgba(255, 250, 240, 0.86);
+  --panel-strong: #fffdf8;
+  --ink: #1f2a1f;
+  --muted: #5d6a5d;
+  --line: rgba(62, 77, 63, 0.14);
+  --accent: #24452f;
+  --accent-soft: #dce9dd;
+  --gold: #b88331;
+  --danger: #9e3b27;
+  --shadow: 0 18px 60px rgba(37, 54, 41, 0.12);
+  --radius-xl: 28px;
+  --radius-lg: 22px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --font-body: "Manrope", "Segoe UI", sans-serif;
+  --font-display: "Fraunces", Georgia, serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+  background:
+    radial-gradient(circle at top left, rgba(191, 214, 194, 0.7), transparent 34%),
+    radial-gradient(circle at right 18%, rgba(244, 205, 141, 0.34), transparent 25%),
+    linear-gradient(180deg, #f6f1e7 0%, #f2eadb 100%);
+}
+
+body {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-body);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+a {
+  color: inherit;
+}
+
+.shell {
+  max-width: 1480px;
+  margin: 0 auto;
+  padding: 28px 22px 48px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(320px, 0.9fr);
+  gap: 24px;
+  padding: 30px;
+  border: 1px solid rgba(56, 75, 59, 0.12);
+  border-radius: 34px;
+  background:
+    linear-gradient(135deg, rgba(255, 248, 237, 0.96), rgba(242, 234, 219, 0.94)),
+    linear-gradient(120deg, rgba(36, 69, 47, 0.05), rgba(184, 131, 49, 0.08));
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: auto -8% -34% auto;
+  width: 340px;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(36, 69, 47, 0.16), transparent 68%);
+  pointer-events: none;
+}
+
+.eyebrow,
+.section-kicker {
+  margin: 0 0 10px;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.hero h1,
+.panel-heading h2,
+.board-summary h3,
+.dialog-topbar h2,
+.empty-state h3,
+.donor-title {
+  margin: 0;
+  font-family: var(--font-display);
+  line-height: 0.94;
+  letter-spacing: -0.04em;
+}
+
+.hero h1 {
+  max-width: 11ch;
+  font-size: clamp(2.8rem, 6vw, 5rem);
+}
+
+.hero-text {
+  max-width: 60ch;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.hero-stats {
+  display: grid;
+  gap: 14px;
+  align-content: start;
+}
+
+.hero-stat {
+  padding: 16px 18px;
+  border: 1px solid rgba(62, 77, 63, 0.1);
+  border-radius: 22px;
+  background: rgba(255, 252, 246, 0.78);
+  backdrop-filter: blur(6px);
+}
+
+.hero-stat strong {
+  display: block;
+  font-size: 1.9rem;
+  line-height: 1;
+}
+
+.hero-stat span {
+  display: block;
+  margin-top: 6px;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.workspace {
+  margin-top: 22px;
+  display: grid;
+  gap: 18px;
+}
+
+.panel {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-xl);
+  background: var(--panel);
+  backdrop-filter: blur(12px);
+  box-shadow: var(--shadow);
+}
+
+.panel-toolbar,
+.board-summary {
+  padding: 22px;
+}
+
+.panel-heading {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.toolbar-actions,
+.dialog-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.button {
+  border-radius: 999px;
+  border: 1px solid transparent;
+  padding: 12px 18px;
+  font-weight: 800;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
+}
+
+.button:hover,
+.icon-button:hover {
+  transform: translateY(-1px);
+}
+
+.button-primary {
+  background: var(--accent);
+  color: white;
+  box-shadow: 0 12px 24px rgba(36, 69, 47, 0.18);
+}
+
+.button-secondary {
+  background: rgba(220, 233, 221, 0.95);
+  color: var(--accent);
+}
+
+.button-ghost {
+  background: transparent;
+  color: var(--ink);
+  border-color: rgba(36, 69, 47, 0.18);
+}
+
+.toolbar-grid {
+  margin-top: 20px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 14px;
+}
+
+.field {
+  display: grid;
+  gap: 8px;
+}
+
+.field span {
+  font-size: 0.83rem;
+  font-weight: 800;
+  color: var(--accent);
+}
+
+.field small {
+  color: var(--muted);
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
+.field input,
+.field select,
+.field textarea {
+  width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(36, 69, 47, 0.16);
+  background: var(--panel-strong);
+  padding: 12px 14px;
+  color: var(--ink);
+}
+
+.field textarea {
+  min-height: 132px;
+  resize: vertical;
+}
+
+.board-summary {
+  display: grid;
+  gap: 16px;
+}
+
+.board-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.summary-card {
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.62);
+  border: 1px solid rgba(36, 69, 47, 0.1);
+}
+
+.summary-card strong {
+  display: block;
+  font-size: 1.75rem;
+}
+
+.summary-card span {
+  display: block;
+  margin-top: 6px;
+  color: var(--muted);
+}
+
+.summary-card ul {
+  margin: 10px 0 0;
+  padding-left: 18px;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(310px, 1fr));
+  gap: 18px;
+}
+
+.donor-card {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-xl);
+  background: rgba(255, 252, 246, 0.86);
+  box-shadow: var(--shadow);
+}
+
+.donor-preview {
+  position: relative;
+  aspect-ratio: 16 / 10;
+  overflow: hidden;
+  background:
+    linear-gradient(135deg, rgba(36, 69, 47, 0.12), rgba(184, 131, 49, 0.16)),
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.78), transparent 40%);
+  border-bottom: 1px solid rgba(36, 69, 47, 0.09);
+}
+
+.donor-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.preview-overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 18px;
+  text-align: center;
+  color: var(--accent);
+  font-weight: 700;
+  background: linear-gradient(180deg, rgba(255, 252, 246, 0.14), rgba(255, 252, 246, 0.82));
+}
+
+.preview-overlay strong {
+  display: block;
+  font-size: 1.2rem;
+}
+
+.preview-chip-row {
+  position: absolute;
+  inset: auto 14px 14px 14px;
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 10px;
+  border-radius: 999px;
+  background: rgba(26, 33, 26, 0.72);
+  color: white;
+  font-size: 0.76rem;
+}
+
+.status-chip {
+  font-weight: 800;
+}
+
+.status-primary {
+  color: #0d6a48;
+}
+
+.status-partial {
+  color: #915100;
+}
+
+.status-rejected {
+  color: #9e3b27;
+}
+
+.status-undecided {
+  color: #4f5d50;
+}
+
+.donor-body {
+  padding: 18px;
+  display: grid;
+  gap: 14px;
+}
+
+.donor-header {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.donor-title {
+  font-size: 2rem;
+}
+
+.donor-url {
+  color: var(--accent);
+  text-decoration: none;
+  word-break: break-word;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.donor-copy {
+  color: var(--muted);
+  line-height: 1.55;
+  font-size: 0.94rem;
+}
+
+.meta-cluster,
+.tag-cluster,
+.pattern-cluster,
+.action-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.meta-pill,
+.tag-pill,
+.pattern-pill {
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  border: 1px solid rgba(36, 69, 47, 0.12);
+}
+
+.meta-pill {
+  background: rgba(36, 69, 47, 0.07);
+  color: var(--accent);
+}
+
+.tag-pill {
+  background: rgba(220, 233, 221, 0.64);
+}
+
+.pattern-pill {
+  background: rgba(244, 227, 193, 0.7);
+  color: #775118;
+}
+
+.subheading {
+  margin: 0;
+  font-size: 0.86rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.action-row .button {
+  flex: 1 1 140px;
+}
+
+.editor-dialog {
+  width: min(960px, calc(100vw - 32px));
+  border: 0;
+  border-radius: 28px;
+  padding: 0;
+  background: transparent;
+}
+
+.editor-dialog::backdrop {
+  background: rgba(22, 29, 24, 0.52);
+}
+
+.editor-form {
+  display: grid;
+  gap: 18px;
+  padding: 22px;
+  border-radius: 28px;
+  background: #fffaf2;
+  box-shadow: var(--shadow);
+}
+
+.dialog-topbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.dialog-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.field-wide {
+  grid-column: 1 / -1;
+}
+
+.pattern-checklist {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(145px, 1fr));
+  gap: 10px;
+}
+
+.pattern-toggle {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 11px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(36, 69, 47, 0.12);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.pattern-toggle input {
+  width: 18px;
+  height: 18px;
+}
+
+.icon-button {
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  border: 1px solid rgba(36, 69, 47, 0.14);
+  background: rgba(220, 233, 221, 0.72);
+  color: var(--accent);
+  font-size: 1.6rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.empty-state {
+  padding: 36px;
+  text-align: center;
+}
+
+@media (max-width: 1080px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .panel-heading,
+  .dialog-topbar {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 780px) {
+  .shell {
+    padding: 16px 14px 28px;
+  }
+
+  .hero,
+  .panel-toolbar,
+  .board-summary,
+  .editor-form {
+    padding: 18px;
+  }
+
+  .dialog-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero h1 {
+    max-width: none;
+  }
+
+  .toolbar-actions,
+  .dialog-actions,
+  .action-row {
+    flex-direction: column;
+  }
+
+  .button,
+  .action-row .button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- turn the design-picker prototype into a polished local static web app
- add a preview-provider adapter, donor editing flow, local persistence, export, and a Windows launcher
- update project-local state and logs for transfer-ready continuity

## Validation
- browser-validated local file launch path in Chrome
- added two real public donor URLs, edited one donor, refreshed preview, and confirmed persistence after reload
- exported Markdown and JSON and confirmed both files contained expected records
- checked a narrow 390px viewport with no horizontal overflow

Closes #25