### PR TITLE
Issue 32: integrate workstation hybrid execution route

### DIFF
--- a/tools/hybrid-agent/Invoke-Workstation-HybridRoute.ps1
+++ b/tools/hybrid-agent/Invoke-Workstation-HybridRoute.ps1
@@ -1,0 +1,46 @@
+param(
+    [ValidateSet('codex','deepseek')]
+    [string]$Executor = 'codex',
+
+    [ValidateSet('auto','cloud-only','local-only','preprocess-then-cloud')]
+    [string]$Mode = 'auto',
+
+    [Parameter(Mandatory = $true)]
+    [string]$Task,
+
+    [string[]]$LogPath = @(),
+    [string[]]$FilePath = @(),
+    [string]$RuntimeLog = 'logs/api-runtime/hybrid-agent.jsonl',
+    [double]$TimeoutSeconds = 240,
+    [switch]$DebugFullEvidence
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDir '..\..')
+$runner = Join-Path $scriptDir 'run_workstation_hybrid_route.py'
+
+$arguments = @(
+    $runner,
+    '--executor', $Executor,
+    '--mode', $Mode,
+    '--task', $Task,
+    '--runtime-log', $RuntimeLog,
+    '--timeout-seconds', [string]$TimeoutSeconds
+)
+
+foreach ($path in $LogPath) {
+    $arguments += @('--log-path', $path)
+}
+
+foreach ($path in $FilePath) {
+    $arguments += @('--file-path', $path)
+}
+
+if ($DebugFullEvidence) {
+    $arguments += '--debug-full-evidence'
+}
+
+& python @arguments

--- a/tools/hybrid-agent/Invoke-Workstation-HybridRoute.ps1
+++ b/tools/hybrid-agent/Invoke-Workstation-HybridRoute.ps1
@@ -12,7 +12,8 @@ param(
     [string[]]$FilePath = @(),
     [string]$RuntimeLog = 'logs/api-runtime/hybrid-agent.jsonl',
     [double]$TimeoutSeconds = 240,
-    [switch]$DebugFullEvidence
+    [switch]$DebugFullEvidence,
+    [switch]$NoLaunchExecutor
 )
 
 Set-StrictMode -Version Latest
@@ -22,25 +23,36 @@ $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = Resolve-Path (Join-Path $scriptDir '..\..')
 $runner = Join-Path $scriptDir 'run_workstation_hybrid_route.py'
 
-$arguments = @(
-    $runner,
-    '--executor', $Executor,
-    '--mode', $Mode,
-    '--task', $Task,
-    '--runtime-log', $RuntimeLog,
-    '--timeout-seconds', [string]$TimeoutSeconds
-)
+Push-Location $repoRoot
+try {
+    $arguments = @(
+        $runner,
+        '--executor', $Executor,
+        '--mode', $Mode,
+        '--task', $Task,
+        '--repo-root', $repoRoot,
+        '--runtime-log', $RuntimeLog,
+        '--timeout-seconds', [string]$TimeoutSeconds
+    )
 
-foreach ($path in $LogPath) {
-    $arguments += @('--log-path', $path)
+    foreach ($path in $LogPath) {
+        $arguments += @('--log-path', $path)
+    }
+
+    foreach ($path in $FilePath) {
+        $arguments += @('--file-path', $path)
+    }
+
+    if ($DebugFullEvidence) {
+        $arguments += '--debug-full-evidence'
+    }
+
+    if ($NoLaunchExecutor) {
+        $arguments += '--no-launch-executor'
+    }
+
+    & python @arguments
 }
-
-foreach ($path in $FilePath) {
-    $arguments += @('--file-path', $path)
+finally {
+    Pop-Location
 }
-
-if ($DebugFullEvidence) {
-    $arguments += '--debug-full-evidence'
-}
-
-& python @arguments

--- a/tools/hybrid-agent/README.md
+++ b/tools/hybrid-agent/README.md
@@ -77,6 +77,17 @@ The adapter discovers actual workstation seams before routing:
 - VS Code CLI path;
 - DeepSeek VS Code custom-endpoint config at `%APPDATA%\\Code\\User\\chatLanguageModels.json` when present.
 
+After routing, the adapter can launch a real workstation handoff path instead of stopping at side-by-side analysis only:
+
+- `deepseek` launches `code chat --mode agent` with the generated bounded handoff packet attached;
+- `codex` writes the same bounded handoff packet inside the repository and launches the registered Codex desktop entrypoint.
+
+The Codex boundary is intentionally honest:
+
+- this workstation exposes a registered Codex desktop executable and `codex://` protocol;
+- a documented prompt-injection CLI contract for Codex Desktop was not discoverable here;
+- therefore the saved packet file is the explicit Codex handoff boundary, while DeepSeek gets direct prompt+file injection through VS Code chat.
+
 ### Auto Policy
 
 `auto` mode is conservative:
@@ -85,6 +96,11 @@ The adapter discovers actual workstation seams before routing:
 - use `preprocess-then-cloud` when bounded evidence is large enough that local compression is likely to help and both local and cloud routes are available;
 - use `local-only` when bounded evidence is meaningful but no safe cloud config is present;
 - fall back automatically if local preprocessing fails.
+
+Explicit `cloud-only` is stricter:
+
+- it skips local preprocessing entirely;
+- it also skips Ollama availability probing, so a missing local runtime does not add latency to a forced cloud-only run.
 
 ### Timeout Strategy
 
@@ -189,6 +205,14 @@ powershell -ExecutionPolicy Bypass -File tools/hybrid-agent/Invoke-Workstation-H
   -LogPath tools/hybrid-agent/fixtures/synthetic_repetitive_log.txt
 ```
 
+This launcher now runs relative to the repository root even if you invoke it from another working directory.
+
+If you want analysis output without launching the downstream executor UI, pass:
+
+```powershell
+-NoLaunchExecutor
+```
+
 Workstation route for DeepSeek:
 
 ```powershell
@@ -224,6 +248,7 @@ Normal CLI runs can use that default path without dirtying review status because
 Each stage records:
 
 - `route_decision` when the workstation adapter chooses `auto`;
+- `executor_handoff` metadata in CLI output when the downstream workstation handoff launcher is used;
 - `stage`;
 - `provider`;
 - `model`;
@@ -261,3 +286,4 @@ The local stage returns a single JSON object with:
 - This prototype preserves evidence references, but it only sees the bounded excerpts that were passed in.
 - Compact local context is accepted only when excerpt paths, line ranges, and suspected file paths pass structural validation.
 - Fallback preserves continuity, but a failed local stage still adds some latency before the cloud stage continues.
+- Codex Desktop launch is now integrated, but prompt injection into Codex Desktop is not yet a known supported contract on this workstation; the generated packet file remains the explicit handoff artifact.

--- a/tools/hybrid-agent/README.md
+++ b/tools/hybrid-agent/README.md
@@ -75,18 +75,21 @@ The adapter discovers actual workstation seams before routing:
 - Codex CLI command path when available;
 - Codex desktop app path when derivable from the CLI install;
 - VS Code CLI path;
+- installed OpenAI VS Code Codex extension when present;
 - DeepSeek VS Code custom-endpoint config at `%APPDATA%\\Code\\User\\chatLanguageModels.json` when present.
 
 After routing, the adapter can launch a real workstation handoff path instead of stopping at side-by-side analysis only:
 
 - `deepseek` launches `code chat --mode agent` with the generated bounded handoff packet attached;
-- `codex` writes the same bounded handoff packet inside the repository and launches the registered Codex desktop entrypoint.
+- `codex` now prefers the installed OpenAI VS Code Codex integration and launches `code chat --mode agent` with the generated bounded handoff packet attached;
+- only if that VS Code Codex route is unavailable does `codex` fall back to the registered Codex desktop entrypoint.
 
 The Codex boundary is intentionally honest:
 
-- this workstation exposes a registered Codex desktop executable and `codex://` protocol;
-- a documented prompt-injection CLI contract for Codex Desktop was not discoverable here;
-- therefore the saved packet file is the explicit Codex handoff boundary, while DeepSeek gets direct prompt+file injection through VS Code chat.
+- this workstation has the `openai.chatgpt` VS Code extension installed, with display name `Codex – OpenAI's coding agent`;
+- that extension registers VS Code chat session type `openai-codex`;
+- the public `code chat` CLI gives a usable launch surface, but it does not expose a deterministic provider-selection flag for `openai-codex`;
+- therefore Codex now prefers the VS Code chat handoff path, but exact provider targeting remains extension/UI-managed on this workstation.
 
 ### Auto Policy
 
@@ -287,3 +290,4 @@ The local stage returns a single JSON object with:
 - Compact local context is accepted only when excerpt paths, line ranges, and suspected file paths pass structural validation.
 - Fallback preserves continuity, but a failed local stage still adds some latency before the cloud stage continues.
 - Codex Desktop launch is now integrated, but prompt injection into Codex Desktop is not yet a known supported contract on this workstation; the generated packet file remains the explicit handoff artifact.
+- Codex-in-VS-Code is the preferred practical route on this workstation, but its provider/session selection is not fully controllable from public CLI flags alone.

--- a/tools/hybrid-agent/README.md
+++ b/tools/hybrid-agent/README.md
@@ -24,6 +24,9 @@ It does not:
 tools/hybrid-agent/
 ├─ hybrid_agent.py
 ├─ run_hybrid_agent.py
+├─ workstation_route.py
+├─ run_workstation_hybrid_route.py
+├─ Invoke-Workstation-HybridRoute.ps1
 ├─ benchmark_fixture.py
 ├─ fixtures/
 └─ tests/
@@ -34,6 +37,7 @@ tools/hybrid-agent/
 - `local-only`: only run the bounded local preprocessing stage.
 - `preprocess-then-cloud`: run local preprocessing first, then send the compact local payload to the cloud stage by default.
 - `cloud-only`: skip local preprocessing entirely.
+- `auto`: choose conservatively based on bounded-evidence size, local Ollama availability, and safe cloud-config presence.
 
 Successful hybrid path:
 
@@ -49,6 +53,50 @@ Fallback or skip path:
 Debug path:
 
 - pass `--debug-full-evidence` if you want successful hybrid runs to include both the compact payload and the original bounded evidence for inspection.
+
+## Workstation Integration
+
+The practical workstation entrypoint for normal Codex or DeepSeek use is:
+
+```text
+tools/hybrid-agent/Invoke-Workstation-HybridRoute.ps1
+```
+
+It routes through:
+
+```text
+tools/hybrid-agent/run_workstation_hybrid_route.py
+→ tools/hybrid-agent/workstation_route.py
+→ tools/hybrid-agent/hybrid_agent.py
+```
+
+The adapter discovers actual workstation seams before routing:
+
+- Codex CLI command path when available;
+- Codex desktop app path when derivable from the CLI install;
+- VS Code CLI path;
+- DeepSeek VS Code custom-endpoint config at `%APPDATA%\\Code\\User\\chatLanguageModels.json` when present.
+
+### Auto Policy
+
+`auto` mode is conservative:
+
+- use `cloud-only` for tiny bounded evidence when a safe cloud config exists;
+- use `preprocess-then-cloud` when bounded evidence is large enough that local compression is likely to help and both local and cloud routes are available;
+- use `local-only` when bounded evidence is meaningful but no safe cloud config is present;
+- fall back automatically if local preprocessing fails.
+
+### Timeout Strategy
+
+Issue `#31` live validation showed that real local Ollama runs can exceed the base 60-second timeout on this workstation.
+
+The workstation adapter therefore defaults to:
+
+```text
+240 seconds
+```
+
+This applies to normal workstation launcher use and can still be overridden explicitly.
 
 ## Configuration
 
@@ -131,6 +179,26 @@ python tools/hybrid-agent/run_hybrid_agent.py `
   --log-path logs/latest.md
 ```
 
+Workstation route for Codex:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools/hybrid-agent/Invoke-Workstation-HybridRoute.ps1 `
+  -Executor codex `
+  -Mode auto `
+  -Task "Analyze this bounded task." `
+  -LogPath tools/hybrid-agent/fixtures/synthetic_repetitive_log.txt
+```
+
+Workstation route for DeepSeek:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File tools/hybrid-agent/Invoke-Workstation-HybridRoute.ps1 `
+  -Executor deepseek `
+  -Mode auto `
+  -Task "Analyze this bounded task." `
+  -LogPath tools/hybrid-agent/fixtures/synthetic_repetitive_log.txt
+```
+
 Benchmark fixture:
 
 ```powershell
@@ -155,6 +223,7 @@ Normal CLI runs can use that default path without dirtying review status because
 
 Each stage records:
 
+- `route_decision` when the workstation adapter chooses `auto`;
 - `stage`;
 - `provider`;
 - `model`;

--- a/tools/hybrid-agent/hybrid_agent.py
+++ b/tools/hybrid-agent/hybrid_agent.py
@@ -308,6 +308,10 @@ def evidence_index(input_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
 def repair_excerpt_path(path: str, evidence_by_path: dict[str, dict[str, Any]]) -> str:
     if path in evidence_by_path:
         return path
+    normalized = path.replace("\\", "/")
+    suffix_matches = [candidate for candidate in evidence_by_path if candidate.replace("\\", "/").endswith(normalized)]
+    if len(suffix_matches) == 1:
+        return suffix_matches[0]
     if len(evidence_by_path) != 1:
         return path
 
@@ -316,7 +320,6 @@ def repair_excerpt_path(path: str, evidence_by_path: dict[str, dict[str, Any]]) 
     if not isinstance(excerpts, list):
         return path
 
-    normalized = path.replace("\\", "/")
     for excerpt in excerpts:
         if not isinstance(excerpt, dict):
             continue
@@ -372,9 +375,38 @@ def validate_suspected_paths(
         if path in evidence_by_path:
             continue
 
+        resolved_path = resolve_repo_candidate_path(path)
+        if resolved_path is not None:
+            suspect["path"] = str(resolved_path.relative_to(REPO_ROOT))
+            continue
+
         resolved_path = REPO_ROOT / Path(path)
         if not resolved_path.exists():
             raise ValueError(f"Local payload suspect #{index} references a missing path: {path}")
+
+
+def resolve_repo_candidate_path(path: str) -> Path | None:
+    candidate = REPO_ROOT / Path(path)
+    if candidate.exists():
+        return candidate
+
+    base_variant = REPO_ROOT / Path(path)
+    candidates: list[Path] = [base_variant]
+
+    underscored_name = base_variant.with_name(base_variant.name.replace("-", "_"))
+    if underscored_name != base_variant:
+        candidates.append(underscored_name)
+
+    for variant in candidates:
+        if variant.exists():
+            return variant
+        if variant.suffix:
+            continue
+        for suffix in [".py", ".md", ".ps1", ".json"]:
+            with_suffix = variant.with_suffix(suffix)
+            if with_suffix.exists():
+                return with_suffix
+    return None
 
 
 def validate_local_references(

--- a/tools/hybrid-agent/hybrid_agent.py
+++ b/tools/hybrid-agent/hybrid_agent.py
@@ -234,7 +234,43 @@ def extract_json_object(text: str) -> dict[str, Any]:
     return parsed
 
 
+def normalize_evidence_path(path: str) -> str:
+    return str(Path(path))
+
+
+def normalize_local_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    recommendation = payload.get("escalation_recommendation")
+    if isinstance(recommendation, str):
+        normalized = recommendation.strip().lower().replace("-", "_").replace(" ", "_")
+        if normalized in {"cloud", "local_sufficient"}:
+            payload["escalation_recommendation"] = normalized
+
+    metadata = payload.get("local_stage_metadata")
+    if isinstance(metadata, dict):
+        confidence = metadata.get("confidence")
+        if isinstance(confidence, str):
+            metadata["confidence"] = confidence.strip().lower()
+
+    excerpts = payload.get("relevant_error_excerpts")
+    if isinstance(excerpts, list):
+        for item in excerpts:
+            if isinstance(item, dict):
+                path = item.get("path")
+                if isinstance(path, str) and path:
+                    item["path"] = normalize_evidence_path(path)
+
+    suspects = payload.get("suspected_files_modules")
+    if isinstance(suspects, list):
+        for item in suspects:
+            if isinstance(item, dict):
+                path = item.get("path")
+                if isinstance(path, str) and path:
+                    item["path"] = normalize_evidence_path(path)
+    return payload
+
+
 def validate_local_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    payload = normalize_local_payload(payload)
     summary = payload.get("summary")
     if not isinstance(summary, str) or not summary.strip():
         raise ValueError("Local payload is missing a string summary")
@@ -269,6 +305,27 @@ def evidence_index(input_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
     return index
 
 
+def repair_excerpt_path(path: str, evidence_by_path: dict[str, dict[str, Any]]) -> str:
+    if path in evidence_by_path:
+        return path
+    if len(evidence_by_path) != 1:
+        return path
+
+    only_path, only_item = next(iter(evidence_by_path.items()))
+    excerpts = only_item.get("excerpts")
+    if not isinstance(excerpts, list):
+        return path
+
+    normalized = path.replace("\\", "/")
+    for excerpt in excerpts:
+        if not isinstance(excerpt, dict):
+            continue
+        text = excerpt.get("text")
+        if isinstance(text, str) and normalized in text.replace("\\", "/"):
+            return only_path
+    return path
+
+
 def validate_excerpt_references(
     excerpts: list[Any],
     evidence_by_path: dict[str, dict[str, Any]],
@@ -282,6 +339,10 @@ def validate_excerpt_references(
         end_line = excerpt.get("end_line")
         if not isinstance(path, str) or not path:
             raise ValueError(f"Local payload excerpt #{index} is missing a valid path")
+        repaired_path = repair_excerpt_path(path, evidence_by_path)
+        if repaired_path != path:
+            excerpt["path"] = repaired_path
+            path = repaired_path
         if path not in evidence_by_path:
             raise ValueError(f"Local payload excerpt #{index} references unknown evidence path: {path}")
         if not isinstance(start_line, int) or not isinstance(end_line, int):

--- a/tools/hybrid-agent/hybrid_agent.py
+++ b/tools/hybrid-agent/hybrid_agent.py
@@ -375,6 +375,11 @@ def validate_suspected_paths(
         if path in evidence_by_path:
             continue
 
+        repaired_evidence_path = repair_suspect_path_to_evidence(path, evidence_by_path)
+        if repaired_evidence_path is not None:
+            suspect["path"] = repaired_evidence_path
+            continue
+
         resolved_path = resolve_repo_candidate_path(path)
         if resolved_path is not None:
             suspect["path"] = str(resolved_path.relative_to(REPO_ROOT))
@@ -383,6 +388,27 @@ def validate_suspected_paths(
         resolved_path = REPO_ROOT / Path(path)
         if not resolved_path.exists():
             raise ValueError(f"Local payload suspect #{index} references a missing path: {path}")
+
+
+def repair_suspect_path_to_evidence(path: str, evidence_by_path: dict[str, dict[str, Any]]) -> str | None:
+    normalized = path.replace("\\", "/")
+    suffix_matches = [candidate for candidate in evidence_by_path if candidate.replace("\\", "/").endswith(normalized)]
+    if len(suffix_matches) == 1:
+        return suffix_matches[0]
+    if len(evidence_by_path) != 1:
+        return None
+
+    only_path, only_item = next(iter(evidence_by_path.items()))
+    excerpts = only_item.get("excerpts")
+    if not isinstance(excerpts, list):
+        return None
+    for excerpt in excerpts:
+        if not isinstance(excerpt, dict):
+            continue
+        text = excerpt.get("text")
+        if isinstance(text, str) and normalized in text.replace("\\", "/"):
+            return only_path
+    return None
 
 
 def resolve_repo_candidate_path(path: str) -> Path | None:

--- a/tools/hybrid-agent/run_workstation_hybrid_route.py
+++ b/tools/hybrid-agent/run_workstation_hybrid_route.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from hybrid_agent import DEFAULT_LOG_PATH
+from run_hybrid_agent import parse_paths
+from workstation_route import DEFAULT_TIMEOUT_SECONDS, DEFAULT_WORKSTATION_ROUTE, run_workstation_route
+
+
+def main() -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+    parser = argparse.ArgumentParser(description="Run the workstation hybrid route for Codex or DeepSeek tasks.")
+    parser.add_argument("--executor", choices=["codex", "deepseek"], default="codex")
+    parser.add_argument(
+        "--mode",
+        choices=["auto", "cloud-only", "local-only", "preprocess-then-cloud"],
+        default="auto",
+    )
+    parser.add_argument("--task", required=True)
+    parser.add_argument("--log-path", action="append", default=[], help="Repeatable path to a bounded log input.")
+    parser.add_argument("--file-path", action="append", default=[], help="Repeatable path to a bounded file input.")
+    parser.add_argument("--runtime-log", type=Path, default=DEFAULT_LOG_PATH)
+    parser.add_argument("--selected-route", default=DEFAULT_WORKSTATION_ROUTE)
+    parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--debug-full-evidence", action="store_true")
+    args = parser.parse_args()
+
+    result = run_workstation_route(
+        executor=args.executor,
+        mode=args.mode,
+        task_text=args.task,
+        log_paths=parse_paths(args.log_path),
+        file_paths=parse_paths(args.file_path),
+        timeout_seconds=args.timeout_seconds,
+        log_path=args.runtime_log.resolve(),
+        selected_route=args.selected_route,
+        include_full_evidence=args.debug_full_evidence,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/hybrid-agent/run_workstation_hybrid_route.py
+++ b/tools/hybrid-agent/run_workstation_hybrid_route.py
@@ -6,8 +6,19 @@ import sys
 from pathlib import Path
 
 from hybrid_agent import DEFAULT_LOG_PATH
-from run_hybrid_agent import parse_paths
 from workstation_route import DEFAULT_TIMEOUT_SECONDS, DEFAULT_WORKSTATION_ROUTE, run_workstation_route
+
+
+DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def resolve_cli_path(raw_path: str, base_dir: Path) -> Path:
+    path = Path(raw_path)
+    return path.resolve() if path.is_absolute() else (base_dir / path).resolve()
+
+
+def parse_paths(raw_paths: list[str] | None, base_dir: Path) -> list[Path]:
+    return [resolve_cli_path(item, base_dir) for item in (raw_paths or [])]
 
 
 def main() -> int:
@@ -25,21 +36,26 @@ def main() -> int:
     parser.add_argument("--log-path", action="append", default=[], help="Repeatable path to a bounded log input.")
     parser.add_argument("--file-path", action="append", default=[], help="Repeatable path to a bounded file input.")
     parser.add_argument("--runtime-log", type=Path, default=DEFAULT_LOG_PATH)
+    parser.add_argument("--repo-root", type=Path, default=DEFAULT_REPO_ROOT)
     parser.add_argument("--selected-route", default=DEFAULT_WORKSTATION_ROUTE)
     parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS)
     parser.add_argument("--debug-full-evidence", action="store_true")
+    parser.add_argument("--no-launch-executor", action="store_true")
     args = parser.parse_args()
+    repo_root = args.repo_root.resolve()
 
     result = run_workstation_route(
         executor=args.executor,
         mode=args.mode,
         task_text=args.task,
-        log_paths=parse_paths(args.log_path),
-        file_paths=parse_paths(args.file_path),
+        log_paths=parse_paths(args.log_path, repo_root),
+        file_paths=parse_paths(args.file_path, repo_root),
         timeout_seconds=args.timeout_seconds,
-        log_path=args.runtime_log.resolve(),
+        log_path=resolve_cli_path(str(args.runtime_log), repo_root),
         selected_route=args.selected_route,
         include_full_evidence=args.debug_full_evidence,
+        launch_executor=not args.no_launch_executor,
+        repo_root=repo_root,
     )
     print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
     return 0

--- a/tools/hybrid-agent/tests/test_hybrid_agent.py
+++ b/tools/hybrid-agent/tests/test_hybrid_agent.py
@@ -626,6 +626,70 @@ class HybridAgentTests(unittest.TestCase):
             "tools\\hybrid-agent\\workstation_route.py",
         )
 
+    def test_local_only_repairs_single_source_suspect_path_mentioned_inside_log(self) -> None:
+        embedded_log = self.workdir / "embedded-build.log"
+        embedded_log.write_text(
+            "\n".join(
+                [
+                    "INFO start",
+                    "ERROR failure in scripts/build_semantic_store.py",
+                    "WARNING downstream validation skipped",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        MockHandler.routes = {
+            "/v1/chat/completions": [
+                {
+                    "body": {
+                        "id": "local-suspect-embedded-path",
+                        "choices": [
+                            {
+                                "message": {
+                                    "content": json.dumps(
+                                        {
+                                            "summary": "Repair suspect path that only appears inside the log.",
+                                            "relevant_error_excerpts": [
+                                                {
+                                                    "path": str(embedded_log),
+                                                    "start_line": 1,
+                                                    "end_line": 3,
+                                                    "reason": "keyword_match",
+                                                }
+                                            ],
+                                            "suspected_files_modules": [
+                                                {
+                                                    "path": "scripts/build_semantic_store.py",
+                                                    "module": "build_semantic_store",
+                                                    "reason": "mentioned inside the bounded evidence log",
+                                                }
+                                            ],
+                                            "escalation_recommendation": "local_sufficient",
+                                            "local_stage_metadata": {
+                                                "confidence": "medium",
+                                                "notes": "repair single-source suspect path",
+                                            },
+                                        }
+                                    )
+                                }
+                            }
+                        ],
+                        "usage": {},
+                    }
+                }
+            ]
+        }
+        result = run_hybrid_agent(
+            task_text="Repair suspect path mentioned only inside bounded evidence.",
+            mode="local-only",
+            log_paths=[embedded_log],
+            file_paths=[],
+            local_config=self.local_config(),
+            cloud_config=None,
+            log_path=self.log_path,
+        )
+        self.assertEqual(result["local"]["payload"]["suspected_files_modules"][0]["path"], str(embedded_log))
+
     def test_logging_fields_and_compression_ratio(self) -> None:
         MockHandler.routes = {
             "/v1/chat/completions": [

--- a/tools/hybrid-agent/tests/test_hybrid_agent.py
+++ b/tools/hybrid-agent/tests/test_hybrid_agent.py
@@ -570,6 +570,62 @@ class HybridAgentTests(unittest.TestCase):
         )
         self.assertEqual(result["local"]["payload"]["relevant_error_excerpts"][0]["path"], str(embedded_log))
 
+    def test_local_only_repairs_route_alias_suspect_path(self) -> None:
+        MockHandler.routes = {
+            "/v1/chat/completions": [
+                {
+                    "body": {
+                        "id": "local-route-alias",
+                        "choices": [
+                            {
+                                "message": {
+                                    "content": json.dumps(
+                                        {
+                                            "summary": "Route alias suspect path should be normalized to the real repo file.",
+                                            "relevant_error_excerpts": [
+                                                {
+                                                    "path": str(self.input_log),
+                                                    "start_line": 2,
+                                                    "end_line": 4,
+                                                    "reason": "keyword_match",
+                                                }
+                                            ],
+                                            "suspected_files_modules": [
+                                                {
+                                                    "path": "tools/hybrid-agent/workstation-route",
+                                                    "module": "route",
+                                                    "reason": "selected route alias",
+                                                }
+                                            ],
+                                            "escalation_recommendation": "local_sufficient",
+                                            "local_stage_metadata": {
+                                                "confidence": "medium",
+                                                "notes": "repair route alias",
+                                            },
+                                        }
+                                    )
+                                }
+                            }
+                        ],
+                        "usage": {},
+                    }
+                }
+            ]
+        }
+        result = run_hybrid_agent(
+            task_text="Repair route alias suspect path.",
+            mode="local-only",
+            log_paths=[self.input_log],
+            file_paths=[],
+            local_config=self.local_config(),
+            cloud_config=None,
+            log_path=self.log_path,
+        )
+        self.assertEqual(
+            result["local"]["payload"]["suspected_files_modules"][0]["path"],
+            "tools\\hybrid-agent\\workstation_route.py",
+        )
+
     def test_logging_fields_and_compression_ratio(self) -> None:
         MockHandler.routes = {
             "/v1/chat/completions": [

--- a/tools/hybrid-agent/tests/test_hybrid_agent.py
+++ b/tools/hybrid-agent/tests/test_hybrid_agent.py
@@ -12,7 +12,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(ROOT / "tools" / "hybrid-agent"))
 
-from hybrid_agent import EndpointConfig, run_hybrid_agent  # noqa: E402
+from hybrid_agent import EndpointConfig, run_hybrid_agent, validate_local_payload  # noqa: E402
 
 
 class MockHandler(BaseHTTPRequestHandler):
@@ -432,6 +432,39 @@ class HybridAgentTests(unittest.TestCase):
                 log_path=self.log_path,
             )
 
+    def test_validate_local_payload_normalizes_live_model_variants(self) -> None:
+        payload = validate_local_payload(
+            {
+                "summary": "Repeated SQLite lock failures detected.",
+                "relevant_error_excerpts": [
+                    {
+                        "path": "tools\\hybrid-agent\\fixtures\\synthetic_repetitive_log.txt",
+                        "start_line": 1,
+                        "end_line": 2,
+                        "reason": "keyword_match",
+                    }
+                ],
+                "suspected_files_modules": [
+                    {
+                        "path": "tools\\hybrid-agent\\fixtures\\synthetic_repetitive_log.txt",
+                        "module": "scripts/build_semantic_store.py",
+                        "reason": "sqlite lock",
+                    }
+                ],
+                "escalation_recommendation": "Local Sufficient",
+                "local_stage_metadata": {
+                    "confidence": "HIGH",
+                    "notes": "normalized for workstation local runs",
+                },
+            }
+        )
+        self.assertEqual(payload["escalation_recommendation"], "local_sufficient")
+        self.assertEqual(payload["local_stage_metadata"]["confidence"], "high")
+        self.assertEqual(
+            payload["relevant_error_excerpts"][0]["path"],
+            str(Path("tools\\hybrid-agent\\fixtures\\synthetic_repetitive_log.txt")),
+        )
+
     def test_local_only_rejects_unknown_excerpt_path(self) -> None:
         MockHandler.routes = {
             "/v1/chat/completions": [
@@ -478,6 +511,64 @@ class HybridAgentTests(unittest.TestCase):
                 cloud_config=None,
                 log_path=self.log_path,
             )
+
+    def test_local_only_repairs_embedded_excerpt_path_for_single_source_evidence(self) -> None:
+        embedded_log = self.workdir / "embedded.log"
+        embedded_log.write_text(
+            "\n".join(
+                [
+                    "INFO start",
+                    "ERROR sqlite3.OperationalError database is locked file=.local/semantic-index/semantic-index.sqlite3",
+                    "WARNING retry pending",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        MockHandler.routes = {
+            "/v1/chat/completions": [
+                {
+                    "body": {
+                        "id": "local-embedded-path",
+                        "choices": [
+                            {
+                                "message": {
+                                    "content": json.dumps(
+                                        {
+                                            "summary": "Embedded file path was selected instead of source evidence path.",
+                                            "relevant_error_excerpts": [
+                                                {
+                                                    "path": ".local\\semantic-index\\semantic-index.sqlite3",
+                                                    "start_line": 1,
+                                                    "end_line": 3,
+                                                    "reason": "mentioned inside log excerpt",
+                                                }
+                                            ],
+                                            "suspected_files_modules": [],
+                                            "escalation_recommendation": "local_sufficient",
+                                            "local_stage_metadata": {
+                                                "confidence": "medium",
+                                                "notes": "repair single-source excerpt path",
+                                            },
+                                        }
+                                    )
+                                }
+                            }
+                        ],
+                        "usage": {},
+                    }
+                }
+            ]
+        }
+        result = run_hybrid_agent(
+            task_text="Repair embedded excerpt path.",
+            mode="local-only",
+            log_paths=[embedded_log],
+            file_paths=[],
+            local_config=self.local_config(),
+            cloud_config=None,
+            log_path=self.log_path,
+        )
+        self.assertEqual(result["local"]["payload"]["relevant_error_excerpts"][0]["path"], str(embedded_log))
 
     def test_logging_fields_and_compression_ratio(self) -> None:
         MockHandler.routes = {

--- a/tools/hybrid-agent/tests/test_workstation_route.py
+++ b/tools/hybrid-agent/tests/test_workstation_route.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "tools" / "hybrid-agent"))
+
+from workstation_route import (  # noqa: E402
+    DEFAULT_WORKSTATION_ROUTE,
+    WorkstationEntrypoints,
+    choose_auto_mode,
+    discover_deepseek_vscode_config,
+    run_workstation_route,
+)
+from hybrid_agent import EndpointConfig  # noqa: E402
+
+
+class WorkstationRouteTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.workdir = Path(self.temp_dir.name)
+        self.log_file = self.workdir / "runtime.jsonl"
+        self.evidence_log = self.workdir / "evidence.log"
+        self.evidence_log.write_text("ERROR one\nWARNING two\n" * 80, encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def fake_config(self, provider: str) -> EndpointConfig:
+        return EndpointConfig(
+            provider=provider,
+            endpoint="http://localhost:11434/v1",
+            model="llama3.2:3b",
+            api_key="ollama",
+            timeout_seconds=30.0,
+        )
+
+    def test_deepseek_vscode_config_detection(self) -> None:
+        config_path = self.workdir / "chatLanguageModels.json"
+        config_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "DeepSeek",
+                        "models": [{"id": "deepseek-v4-pro"}],
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+        with patch.dict("os.environ", {"APPDATA": str(self.workdir)}):
+            user_dir = self.workdir / "Code" / "User"
+            user_dir.mkdir(parents=True, exist_ok=True)
+            target = user_dir / "chatLanguageModels.json"
+            target.write_text(config_path.read_text(encoding="utf-8"), encoding="utf-8")
+            detected_path, model_id = discover_deepseek_vscode_config()
+        self.assertEqual(detected_path, str(target))
+        self.assertEqual(model_id, "deepseek-v4-pro")
+
+    def test_auto_mode_prefers_cloud_only_for_tiny_evidence_with_cloud(self) -> None:
+        tiny = self.workdir / "tiny.log"
+        tiny.write_text("short\n", encoding="utf-8")
+        decision = choose_auto_mode(
+            task_text="tiny task",
+            log_paths=[tiny],
+            file_paths=[],
+            selected_route=DEFAULT_WORKSTATION_ROUTE,
+            executor="codex",
+            local_config=self.fake_config("local-openai-compatible"),
+            cloud_config=self.fake_config("cloud-openai-compatible"),
+        )
+        self.assertEqual(decision.chosen_mode, "cloud-only")
+
+    def test_auto_mode_prefers_preprocess_then_cloud_for_large_evidence(self) -> None:
+        decision = choose_auto_mode(
+            task_text="large task",
+            log_paths=[self.evidence_log],
+            file_paths=[],
+            selected_route=DEFAULT_WORKSTATION_ROUTE,
+            executor="codex",
+            local_config=self.fake_config("local-openai-compatible"),
+            cloud_config=self.fake_config("cloud-openai-compatible"),
+        )
+        self.assertEqual(decision.chosen_mode, "preprocess-then-cloud")
+
+    def test_auto_mode_uses_local_only_when_no_cloud_config(self) -> None:
+        decision = choose_auto_mode(
+            task_text="large task",
+            log_paths=[self.evidence_log],
+            file_paths=[],
+            selected_route=DEFAULT_WORKSTATION_ROUTE,
+            executor="deepseek",
+            local_config=self.fake_config("local-openai-compatible"),
+            cloud_config=None,
+        )
+        self.assertEqual(decision.chosen_mode, "local-only")
+
+    def test_run_workstation_route_logs_decision_and_passes_mode(self) -> None:
+        fake_entrypoints = WorkstationEntrypoints(
+            codex_cli_path="C:/codex.exe",
+            codex_desktop_path=None,
+            vscode_cli_path="C:/code.cmd",
+            deepseek_vscode_config_path="C:/chatLanguageModels.json",
+            deepseek_vscode_model_id="deepseek-v4-pro",
+        )
+        with (
+            patch("workstation_route.discover_workstation_entrypoints", return_value=fake_entrypoints),
+            patch("workstation_route.build_local_config", return_value=self.fake_config("local-openai-compatible")),
+            patch("workstation_route.build_cloud_config", return_value=None),
+            patch(
+                "workstation_route.run_hybrid_agent",
+                return_value={"mode": "local-only", "fallback_used": False, "input_payload": {"evidence": []}},
+            ) as run_mock,
+        ):
+            result = run_workstation_route(
+                executor="deepseek",
+                mode="auto",
+                task_text="large task",
+                log_paths=[self.evidence_log],
+                file_paths=[],
+                log_path=self.log_file,
+            )
+        self.assertEqual(result["route_decision"]["chosen_mode"], "local-only")
+        run_mock.assert_called_once()
+        log_lines = self.log_file.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(log_lines), 1)
+        entry = json.loads(log_lines[0])
+        self.assertEqual(entry["stage"], "route_decision")
+        self.assertEqual(entry["status"], "local-only")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/hybrid-agent/tests/test_workstation_route.py
+++ b/tools/hybrid-agent/tests/test_workstation_route.py
@@ -107,6 +107,8 @@ class WorkstationRouteTests(unittest.TestCase):
             codex_cli_path="C:/codex.exe",
             codex_desktop_path=None,
             vscode_cli_path="C:/code.cmd",
+            codex_vscode_extension_path="C:/Users/test/.vscode/extensions/openai.chatgpt",
+            codex_vscode_chat_session_type="openai-codex",
             deepseek_vscode_config_path="C:/chatLanguageModels.json",
             deepseek_vscode_model_id="deepseek-v4-pro",
         )
@@ -140,6 +142,8 @@ class WorkstationRouteTests(unittest.TestCase):
             codex_cli_path="C:/codex.exe",
             codex_desktop_path="C:/Codex.exe",
             vscode_cli_path="C:/code.cmd",
+            codex_vscode_extension_path="C:/Users/test/.vscode/extensions/openai.chatgpt",
+            codex_vscode_chat_session_type="openai-codex",
             deepseek_vscode_config_path=None,
             deepseek_vscode_model_id=None,
         )
@@ -178,6 +182,85 @@ class WorkstationRouteTests(unittest.TestCase):
             resolved_inputs[0],
             repo_root / "tools" / "hybrid-agent" / "fixtures" / "synthetic_repetitive_log.txt",
         )
+
+    def test_codex_prefers_vscode_handoff_when_extension_exists(self) -> None:
+        fake_entrypoints = WorkstationEntrypoints(
+            codex_cli_path="C:/codex.exe",
+            codex_desktop_path="C:/Codex.exe",
+            vscode_cli_path="C:/code.cmd",
+            codex_vscode_extension_path="C:/Users/test/.vscode/extensions/openai.chatgpt",
+            codex_vscode_chat_session_type="openai-codex",
+            deepseek_vscode_config_path=None,
+            deepseek_vscode_model_id=None,
+        )
+        with (
+            patch("workstation_route.discover_workstation_entrypoints", return_value=fake_entrypoints),
+            patch("workstation_route.build_local_config", return_value=self.fake_config("local-openai-compatible")),
+            patch("workstation_route.build_cloud_config", return_value=None),
+            patch(
+                "workstation_route.run_hybrid_agent",
+                return_value={
+                    "mode": "local-only",
+                    "fallback_used": False,
+                    "input_payload": {"evidence": []},
+                    "local": {"payload": {"summary": "ok"}},
+                },
+            ),
+            patch("workstation_route.subprocess.Popen") as popen_mock,
+        ):
+            result = run_workstation_route(
+                executor="codex",
+                mode="auto",
+                task_text="route codex via vscode",
+                log_paths=[self.evidence_log],
+                file_paths=[],
+                log_path=self.log_file,
+                launch_executor=True,
+                repo_root=self.workdir,
+            )
+        self.assertEqual(result["executor_handoff"]["launch_method"], "vscode-chat")
+        self.assertEqual(result["executor_handoff"]["launch_status"], "launched")
+        self.assertIn("code.cmd", " ".join(result["executor_handoff"]["launch_command"]))
+        popen_mock.assert_called_once()
+
+    def test_codex_falls_back_to_desktop_when_vscode_route_missing(self) -> None:
+        fake_entrypoints = WorkstationEntrypoints(
+            codex_cli_path="C:/codex.exe",
+            codex_desktop_path="C:/Codex.exe",
+            vscode_cli_path=None,
+            codex_vscode_extension_path=None,
+            codex_vscode_chat_session_type=None,
+            deepseek_vscode_config_path=None,
+            deepseek_vscode_model_id=None,
+        )
+        with (
+            patch("workstation_route.discover_workstation_entrypoints", return_value=fake_entrypoints),
+            patch("workstation_route.build_local_config", return_value=self.fake_config("local-openai-compatible")),
+            patch("workstation_route.build_cloud_config", return_value=None),
+            patch(
+                "workstation_route.run_hybrid_agent",
+                return_value={
+                    "mode": "local-only",
+                    "fallback_used": False,
+                    "input_payload": {"evidence": []},
+                    "local": {"payload": {"summary": "ok"}},
+                },
+            ),
+            patch("workstation_route.subprocess.Popen") as popen_mock,
+        ):
+            result = run_workstation_route(
+                executor="codex",
+                mode="auto",
+                task_text="route codex fallback desktop",
+                log_paths=[self.evidence_log],
+                file_paths=[],
+                log_path=self.log_file,
+                launch_executor=True,
+                repo_root=self.workdir,
+            )
+        self.assertEqual(result["executor_handoff"]["launch_method"], "codex-desktop-wrapper")
+        self.assertEqual(result["executor_handoff"]["launch_status"], "launched")
+        popen_mock.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tools/hybrid-agent/tests/test_workstation_route.py
+++ b/tools/hybrid-agent/tests/test_workstation_route.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(ROOT / "tools" / "hybrid-agent"))
 
+import run_workstation_hybrid_route  # noqa: E402
 from workstation_route import (  # noqa: E402
     DEFAULT_WORKSTATION_ROUTE,
     WorkstationEntrypoints,
@@ -133,6 +134,50 @@ class WorkstationRouteTests(unittest.TestCase):
         entry = json.loads(log_lines[0])
         self.assertEqual(entry["stage"], "route_decision")
         self.assertEqual(entry["status"], "local-only")
+
+    def test_cloud_only_does_not_probe_local_runtime(self) -> None:
+        fake_entrypoints = WorkstationEntrypoints(
+            codex_cli_path="C:/codex.exe",
+            codex_desktop_path="C:/Codex.exe",
+            vscode_cli_path="C:/code.cmd",
+            deepseek_vscode_config_path=None,
+            deepseek_vscode_model_id=None,
+        )
+        with (
+            patch("workstation_route.discover_workstation_entrypoints", return_value=fake_entrypoints),
+            patch("workstation_route.build_local_config") as local_mock,
+            patch("workstation_route.build_cloud_config", return_value=self.fake_config("cloud-openai-compatible")),
+            patch(
+                "workstation_route.run_hybrid_agent",
+                return_value={"mode": "cloud-only", "fallback_used": False, "input_payload": {"evidence": []}},
+            ) as run_mock,
+        ):
+            result = run_workstation_route(
+                executor="codex",
+                mode="cloud-only",
+                task_text="cloud only task",
+                log_paths=[self.evidence_log],
+                file_paths=[],
+                log_path=self.log_file,
+            )
+        local_mock.assert_not_called()
+        run_mock.assert_called_once()
+        self.assertFalse(result["local_config_present"])
+        self.assertTrue(result["cloud_config_present"])
+
+    def test_repo_root_resolution_keeps_relative_paths_inside_repo(self) -> None:
+        repo_root = self.workdir / "repo"
+        repo_root.mkdir()
+        resolved_log = run_workstation_hybrid_route.resolve_cli_path("logs/api-runtime/hybrid-agent.jsonl", repo_root)
+        resolved_inputs = run_workstation_hybrid_route.parse_paths(
+            ["tools/hybrid-agent/fixtures/synthetic_repetitive_log.txt"],
+            repo_root,
+        )
+        self.assertEqual(resolved_log, repo_root / "logs" / "api-runtime" / "hybrid-agent.jsonl")
+        self.assertEqual(
+            resolved_inputs[0],
+            repo_root / "tools" / "hybrid-agent" / "fixtures" / "synthetic_repetitive_log.txt",
+        )
 
 
 if __name__ == "__main__":

--- a/tools/hybrid-agent/workstation_route.py
+++ b/tools/hybrid-agent/workstation_route.py
@@ -37,6 +37,8 @@ class WorkstationEntrypoints:
     codex_cli_path: str | None
     codex_desktop_path: str | None
     vscode_cli_path: str | None
+    codex_vscode_extension_path: str | None
+    codex_vscode_chat_session_type: str | None
     deepseek_vscode_config_path: str | None
     deepseek_vscode_model_id: str | None
 
@@ -99,8 +101,32 @@ def discover_deepseek_vscode_config() -> tuple[str | None, str | None]:
     return str(config_path), None
 
 
+def discover_codex_vscode_extension() -> tuple[str | None, str | None]:
+    extensions_root = Path.home() / ".vscode" / "extensions"
+    matches = sorted(extensions_root.glob("openai.chatgpt-*"), reverse=True)
+    if not matches:
+        return None, None
+
+    package_json = matches[0] / "package.json"
+    if not package_json.exists():
+        return str(matches[0]), None
+
+    try:
+        content = json.loads(package_json.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return str(matches[0]), None
+
+    sessions = content.get("contributes", {}).get("chatSessions")
+    if isinstance(sessions, list):
+        for item in sessions:
+            if isinstance(item, dict) and item.get("type") == "openai-codex":
+                return str(matches[0]), "openai-codex"
+    return str(matches[0]), None
+
+
 def discover_workstation_entrypoints() -> WorkstationEntrypoints:
     deepseek_config_path, deepseek_model_id = discover_deepseek_vscode_config()
+    codex_extension_path, codex_chat_session_type = discover_codex_vscode_extension()
     codex_cli = command_path("codex")
     vscode_cli = command_path("code")
     codex_desktop = None
@@ -114,6 +140,8 @@ def discover_workstation_entrypoints() -> WorkstationEntrypoints:
         codex_cli_path=codex_cli,
         codex_desktop_path=codex_desktop,
         vscode_cli_path=vscode_cli,
+        codex_vscode_extension_path=codex_extension_path,
+        codex_vscode_chat_session_type=codex_chat_session_type,
         deepseek_vscode_config_path=deepseek_config_path,
         deepseek_vscode_model_id=deepseek_model_id,
     )
@@ -537,6 +565,50 @@ def launch_deepseek_handoff(
     )
 
 
+def launch_codex_vscode_handoff(
+    *,
+    entrypoints: WorkstationEntrypoints,
+    packet_path: Path,
+    repo_root: Path,
+    evidence_paths: list[Path],
+) -> ExecutorHandoff:
+    if not entrypoints.vscode_cli_path or not entrypoints.codex_vscode_extension_path:
+        return ExecutorHandoff(
+            executor="codex",
+            packet_path=str(packet_path),
+            launch_method="vscode-chat",
+            launch_boundary="VS Code Codex integration was not available, so this handoff path could not be launched.",
+            launch_status="not_available",
+            launch_target=entrypoints.vscode_cli_path,
+            launch_command=[],
+        )
+
+    command = [
+        entrypoints.vscode_cli_path,
+        "chat",
+        "--mode",
+        "agent",
+        "--reuse-window",
+        "--add-file",
+        str(packet_path),
+    ]
+    for path in evidence_paths[:4]:
+        command.extend(["--add-file", str(path)])
+    command.append(
+        "Continue from the attached workstation hybrid handoff packet in the installed OpenAI Codex VS Code integration and execute within that bounded scope."
+    )
+    subprocess.Popen(command, cwd=repo_root)
+    return ExecutorHandoff(
+        executor="codex",
+        packet_path=str(packet_path),
+        launch_method="vscode-chat",
+        launch_boundary="Codex handoff is launched through the installed OpenAI Codex VS Code integration. The extension registers chat session type `openai-codex`, but the public `code chat` CLI does not expose deterministic provider-selection flags, so provider targeting remains extension/UI-managed on this workstation.",
+        launch_status="launched",
+        launch_target=entrypoints.vscode_cli_path,
+        launch_command=command,
+    )
+
+
 def launch_codex_handoff(
     *,
     entrypoints: WorkstationEntrypoints,
@@ -560,7 +632,7 @@ def launch_codex_handoff(
         executor="codex",
         packet_path=str(packet_path),
         launch_method="codex-desktop-wrapper",
-        launch_boundary="The packet was written inside the repository and the registered Codex desktop entrypoint was launched. This workstation did not expose a documented prompt-injection CLI contract for Codex Desktop, so the packet file is the explicit handoff boundary.",
+        launch_boundary="VS Code Codex integration was unavailable for deterministic launch, so the packet was written inside the repository and the registered Codex desktop entrypoint was launched as a fallback. A documented prompt-injection CLI contract for Codex Desktop was not discoverable on this workstation, so the packet file remains the explicit handoff boundary.",
         launch_status=status,
         launch_target=launch_target,
         launch_command=command,
@@ -597,6 +669,14 @@ def maybe_launch_executor_handoff(
             repo_root=repo_root,
             evidence_paths=evidence_paths,
         )
+    codex_vscode = launch_codex_vscode_handoff(
+        entrypoints=entrypoints,
+        packet_path=packet_path,
+        repo_root=repo_root,
+        evidence_paths=evidence_paths,
+    )
+    if codex_vscode.launch_status == "launched":
+        return codex_vscode
     return launch_codex_handoff(
         entrypoints=entrypoints,
         packet_path=packet_path,

--- a/tools/hybrid-agent/workstation_route.py
+++ b/tools/hybrid-agent/workstation_route.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import subprocess
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
@@ -27,6 +28,8 @@ DEFAULT_LOCAL_API_KEY = "ollama"
 DEFAULT_TIMEOUT_SECONDS = 240.0
 DEFAULT_AUTO_MIN_EVIDENCE_BYTES = 1000
 DEFAULT_AUTO_MIN_EVIDENCE_COUNT = 1
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_HANDOFF_DIR = REPO_ROOT / "logs" / "api-runtime" / "hybrid-handoffs"
 
 
 @dataclass(slots=True)
@@ -49,6 +52,17 @@ class RouteDecision:
     cloud_available: bool
     selected_route: str
     executor: str
+
+
+@dataclass(slots=True)
+class ExecutorHandoff:
+    executor: str
+    packet_path: str
+    launch_method: str
+    launch_boundary: str
+    launch_status: str
+    launch_target: str | None
+    launch_command: list[str]
 
 
 def command_path(name: str) -> str | None:
@@ -213,6 +227,10 @@ def build_cloud_config(executor: str, timeout_seconds: float) -> EndpointConfig 
     return build_codex_cloud_config(timeout_seconds)
 
 
+def should_probe_local(mode: str) -> bool:
+    return mode in {"auto", "local-only", "preprocess-then-cloud"}
+
+
 def choose_auto_mode(
     *,
     task_text: str,
@@ -344,6 +362,248 @@ def log_route_decision(log_path: Path, decision: RouteDecision, entrypoints: Wor
     write_log_entry(log_path, entry)
 
 
+def compact_context_summary(result: dict[str, Any]) -> str:
+    local_payload = result.get("local", {}).get("payload") if isinstance(result.get("local"), dict) else None
+    if isinstance(local_payload, dict):
+        summary = local_payload.get("summary")
+        if isinstance(summary, str) and summary.strip():
+            return summary.strip()
+
+    cloud_content = result.get("cloud", {}).get("content") if isinstance(result.get("cloud"), dict) else None
+    if isinstance(cloud_content, str) and cloud_content.strip():
+        return cloud_content.strip()
+
+    return "No structured compact summary was produced. Use the attached bounded packet and evidence paths directly."
+
+
+def build_handoff_packet_text(
+    *,
+    executor: str,
+    task_text: str,
+    chosen_mode: str,
+    selected_route: str,
+    result: dict[str, Any],
+    log_paths: list[Path],
+    file_paths: list[Path],
+) -> str:
+    route_decision = result.get("route_decision", {})
+    compact_summary = compact_context_summary(result)
+    evidence_paths = [str(path) for path in [*log_paths, *file_paths]]
+    local_payload = result.get("local", {}).get("payload") if isinstance(result.get("local"), dict) else None
+    cloud_content = result.get("cloud", {}).get("content") if isinstance(result.get("cloud"), dict) else None
+
+    lines = [
+        "# Workstation Hybrid Executor Handoff",
+        "",
+        f"- executor: `{executor}`",
+        f"- chosen_mode: `{chosen_mode}`",
+        f"- selected_route: `{selected_route}`",
+        f"- repo_root: `{REPO_ROOT}`",
+        "",
+        "## Task",
+        "",
+        task_text,
+        "",
+        "## Compact Context",
+        "",
+        compact_summary,
+        "",
+    ]
+
+    if isinstance(local_payload, dict):
+        lines.extend(
+            [
+                "## Local Payload",
+                "",
+                "```json",
+                json.dumps(local_payload, ensure_ascii=False, indent=2, sort_keys=True),
+                "```",
+                "",
+            ]
+        )
+
+    if isinstance(cloud_content, str) and cloud_content.strip():
+        lines.extend(
+            [
+                "## Cloud Output",
+                "",
+                cloud_content.strip(),
+                "",
+            ]
+        )
+
+    evidence_lines = [f"- `{path}`" for path in evidence_paths] if evidence_paths else ["- none"]
+    lines.extend(
+        [
+            "## Evidence Paths",
+            "",
+            *evidence_lines,
+            "",
+            "## Route Metadata",
+            "",
+            "```json",
+            json.dumps(route_decision, ensure_ascii=False, indent=2, sort_keys=True),
+            "```",
+            "",
+            "## Execution Boundary",
+            "",
+        ]
+    )
+
+    if executor == "deepseek":
+        lines.extend(
+            [
+                "DeepSeek handoff is launched through VS Code chat with this packet attached as context.",
+                "The actual model/provider remains governed by the installed VS Code DeepSeek configuration on this workstation.",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "Codex handoff is launched through the locally registered Codex desktop entrypoint with this packet written inside the repository.",
+                "A direct prompt-injection CLI contract was not discoverable on this workstation, so the saved packet is the explicit handoff boundary.",
+            ]
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def write_handoff_packet(
+    *,
+    executor: str,
+    task_text: str,
+    chosen_mode: str,
+    selected_route: str,
+    result: dict[str, Any],
+    log_paths: list[Path],
+    file_paths: list[Path],
+    handoff_dir: Path,
+) -> Path:
+    handoff_dir.mkdir(parents=True, exist_ok=True)
+    safe_executor = executor.replace(" ", "-")
+    packet_path = handoff_dir / f"{utc_now_iso().replace(':', '-').replace('+00:00', 'Z')}-{safe_executor}.md"
+    packet_text = build_handoff_packet_text(
+        executor=executor,
+        task_text=task_text,
+        chosen_mode=chosen_mode,
+        selected_route=selected_route,
+        result=result,
+        log_paths=log_paths,
+        file_paths=file_paths,
+    )
+    packet_path.write_text(packet_text, encoding="utf-8")
+    return packet_path
+
+
+def launch_deepseek_handoff(
+    *,
+    entrypoints: WorkstationEntrypoints,
+    packet_path: Path,
+    repo_root: Path,
+    evidence_paths: list[Path],
+) -> ExecutorHandoff:
+    if not entrypoints.vscode_cli_path:
+        return ExecutorHandoff(
+            executor="deepseek",
+            packet_path=str(packet_path),
+            launch_method="vscode-chat",
+            launch_boundary="VS Code CLI was not available, so the handoff packet was written but not launched.",
+            launch_status="not_available",
+            launch_target=None,
+            launch_command=[],
+        )
+
+    command = [
+        entrypoints.vscode_cli_path,
+        "chat",
+        "--mode",
+        "agent",
+        "--reuse-window",
+        "--add-file",
+        str(packet_path),
+    ]
+    for path in evidence_paths[:4]:
+        command.extend(["--add-file", str(path)])
+    command.append("Continue from the attached workstation hybrid handoff packet and execute within that bounded scope.")
+    subprocess.Popen(command, cwd=repo_root)
+    return ExecutorHandoff(
+        executor="deepseek",
+        packet_path=str(packet_path),
+        launch_method="vscode-chat",
+        launch_boundary="Prompt and packet were injected through VS Code chat; the actual provider selection remains controlled by the installed DeepSeek VS Code configuration.",
+        launch_status="launched",
+        launch_target=entrypoints.vscode_cli_path,
+        launch_command=command,
+    )
+
+
+def launch_codex_handoff(
+    *,
+    entrypoints: WorkstationEntrypoints,
+    packet_path: Path,
+    repo_root: Path,
+) -> ExecutorHandoff:
+    launch_target = entrypoints.codex_desktop_path or "codex://"
+    command: list[str] = []
+    try:
+        if entrypoints.codex_desktop_path:
+            command = [entrypoints.codex_desktop_path, str(repo_root), str(packet_path)]
+            subprocess.Popen(command, cwd=repo_root)
+            status = "launched"
+        else:
+            os.startfile("codex://")  # type: ignore[attr-defined]
+            status = "launched"
+    except Exception:  # noqa: BLE001
+        status = "not_available"
+
+    return ExecutorHandoff(
+        executor="codex",
+        packet_path=str(packet_path),
+        launch_method="codex-desktop-wrapper",
+        launch_boundary="The packet was written inside the repository and the registered Codex desktop entrypoint was launched. This workstation did not expose a documented prompt-injection CLI contract for Codex Desktop, so the packet file is the explicit handoff boundary.",
+        launch_status=status,
+        launch_target=launch_target,
+        launch_command=command,
+    )
+
+
+def maybe_launch_executor_handoff(
+    *,
+    executor: str,
+    entrypoints: WorkstationEntrypoints,
+    task_text: str,
+    chosen_mode: str,
+    selected_route: str,
+    result: dict[str, Any],
+    log_paths: list[Path],
+    file_paths: list[Path],
+    repo_root: Path,
+) -> ExecutorHandoff:
+    packet_path = write_handoff_packet(
+        executor=executor,
+        task_text=task_text,
+        chosen_mode=chosen_mode,
+        selected_route=selected_route,
+        result=result,
+        log_paths=log_paths,
+        file_paths=file_paths,
+        handoff_dir=DEFAULT_HANDOFF_DIR,
+    )
+    evidence_paths = [*log_paths, *file_paths]
+    if executor == "deepseek":
+        return launch_deepseek_handoff(
+            entrypoints=entrypoints,
+            packet_path=packet_path,
+            repo_root=repo_root,
+            evidence_paths=evidence_paths,
+        )
+    return launch_codex_handoff(
+        entrypoints=entrypoints,
+        packet_path=packet_path,
+        repo_root=repo_root,
+    )
+
+
 def run_workstation_route(
     *,
     executor: str,
@@ -355,9 +615,11 @@ def run_workstation_route(
     log_path: Path = DEFAULT_LOG_PATH,
     selected_route: str = DEFAULT_WORKSTATION_ROUTE,
     include_full_evidence: bool = False,
+    launch_executor: bool = False,
+    repo_root: Path = REPO_ROOT,
 ) -> dict[str, Any]:
     entrypoints = discover_workstation_entrypoints()
-    local_config = build_local_config(timeout_seconds)
+    local_config = build_local_config(timeout_seconds) if should_probe_local(mode) else None
     cloud_config = build_cloud_config(executor, timeout_seconds)
     chosen_mode = mode
     route_decision: RouteDecision | None = None
@@ -406,4 +668,18 @@ def run_workstation_route(
             "executor": executor,
             "selected_route": selected_route,
         }
+    if launch_executor:
+        result["executor_handoff"] = asdict(
+            maybe_launch_executor_handoff(
+                executor=executor,
+                entrypoints=entrypoints,
+                task_text=task_text,
+                chosen_mode=chosen_mode,
+                selected_route=selected_route,
+                result=result,
+                log_paths=log_paths,
+                file_paths=file_paths,
+                repo_root=repo_root,
+            )
+        )
     return result

--- a/tools/hybrid-agent/workstation_route.py
+++ b/tools/hybrid-agent/workstation_route.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+from urllib import error, request
+
+from hybrid_agent import (
+    DEFAULT_LOG_PATH,
+    DEFAULT_SELECTED_ROUTE,
+    EndpointConfig,
+    build_input_payload,
+    json_size_metrics,
+    run_hybrid_agent,
+    utc_now_iso,
+    write_log_entry,
+)
+
+
+DEFAULT_WORKSTATION_ROUTE = "tools/hybrid-agent/workstation-route"
+DEFAULT_LOCAL_ENDPOINT = "http://localhost:11434/v1"
+DEFAULT_LOCAL_MODEL = "llama3.2:3b"
+DEFAULT_LOCAL_API_KEY = "ollama"
+DEFAULT_TIMEOUT_SECONDS = 240.0
+DEFAULT_AUTO_MIN_EVIDENCE_BYTES = 1000
+DEFAULT_AUTO_MIN_EVIDENCE_COUNT = 1
+
+
+@dataclass(slots=True)
+class WorkstationEntrypoints:
+    codex_cli_path: str | None
+    codex_desktop_path: str | None
+    vscode_cli_path: str | None
+    deepseek_vscode_config_path: str | None
+    deepseek_vscode_model_id: str | None
+
+
+@dataclass(slots=True)
+class RouteDecision:
+    requested_mode: str
+    chosen_mode: str
+    reason: str
+    evidence_count: int
+    evidence_bytes: int
+    local_available: bool
+    cloud_available: bool
+    selected_route: str
+    executor: str
+
+
+def command_path(name: str) -> str | None:
+    resolved = shutil.which(name)
+    return str(Path(resolved).resolve()) if resolved else None
+
+
+def discover_deepseek_vscode_config() -> tuple[str | None, str | None]:
+    config_path = Path(os.environ.get("APPDATA", "")) / "Code" / "User" / "chatLanguageModels.json"
+    if not config_path.exists():
+        return None, None
+
+    try:
+        content = json.loads(config_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return str(config_path), None
+
+    if not isinstance(content, list):
+        return str(config_path), None
+
+    for group in content:
+        if not isinstance(group, dict):
+            continue
+        if group.get("name") != "DeepSeek":
+            continue
+        models = group.get("models")
+        if not isinstance(models, list) or not models:
+            return str(config_path), None
+        first_model = models[0]
+        if isinstance(first_model, dict):
+            model_id = first_model.get("id")
+            if isinstance(model_id, str):
+                return str(config_path), model_id
+    return str(config_path), None
+
+
+def discover_workstation_entrypoints() -> WorkstationEntrypoints:
+    deepseek_config_path, deepseek_model_id = discover_deepseek_vscode_config()
+    codex_cli = command_path("codex")
+    vscode_cli = command_path("code")
+    codex_desktop = None
+    if codex_cli:
+        codex_cli_path = Path(codex_cli)
+        candidate = codex_cli_path.parents[2] / "app" / "Codex.exe"
+        if candidate.exists():
+            codex_desktop = str(candidate)
+
+    return WorkstationEntrypoints(
+        codex_cli_path=codex_cli,
+        codex_desktop_path=codex_desktop,
+        vscode_cli_path=vscode_cli,
+        deepseek_vscode_config_path=deepseek_config_path,
+        deepseek_vscode_model_id=deepseek_model_id,
+    )
+
+
+def local_endpoint_available(endpoint: str, timeout_seconds: float) -> bool:
+    url = endpoint.rstrip("/") + "/models"
+    req = request.Request(url, headers={"Authorization": f"Bearer {DEFAULT_LOCAL_API_KEY}"}, method="GET")
+    try:
+        with request.urlopen(req, timeout=timeout_seconds) as response:
+            return response.status == 200
+    except (error.HTTPError, error.URLError, TimeoutError):
+        return False
+
+
+def ollama_model_available(endpoint: str, model: str, timeout_seconds: float) -> bool:
+    url = endpoint.rstrip("/") + "/models"
+    req = request.Request(url, headers={"Authorization": f"Bearer {DEFAULT_LOCAL_API_KEY}"}, method="GET")
+    try:
+        with request.urlopen(req, timeout=timeout_seconds) as response:
+            body = json.loads(response.read().decode("utf-8"))
+    except (error.HTTPError, error.URLError, TimeoutError, json.JSONDecodeError):
+        return False
+
+    data = body.get("data")
+    if not isinstance(data, list):
+        return False
+    for item in data:
+        if isinstance(item, dict) and item.get("id") == model:
+            return True
+    return False
+
+
+def build_local_config(timeout_seconds: float) -> EndpointConfig | None:
+    endpoint = os.environ.get("HYBRID_AGENT_LOCAL_ENDPOINT", DEFAULT_LOCAL_ENDPOINT)
+    model = os.environ.get("HYBRID_AGENT_LOCAL_MODEL", DEFAULT_LOCAL_MODEL)
+    api_key = os.environ.get("HYBRID_AGENT_LOCAL_API_KEY", DEFAULT_LOCAL_API_KEY)
+    if endpoint.endswith(":11434"):
+        endpoint = endpoint + "/v1"
+    if not local_endpoint_available(endpoint, timeout_seconds):
+        endpoint = DEFAULT_LOCAL_ENDPOINT
+        if not local_endpoint_available(endpoint, timeout_seconds):
+            return None
+    if not ollama_model_available(endpoint, model, timeout_seconds):
+        return None
+    return EndpointConfig(
+        provider="local-openai-compatible",
+        endpoint=endpoint,
+        model=model,
+        api_key=api_key,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def build_codex_cloud_config(timeout_seconds: float) -> EndpointConfig | None:
+    endpoint = os.environ.get("HYBRID_AGENT_CLOUD_ENDPOINT")
+    model = os.environ.get("HYBRID_AGENT_CLOUD_MODEL")
+    api_key = os.environ.get("HYBRID_AGENT_CLOUD_API_KEY")
+    if endpoint and model and api_key:
+        return EndpointConfig(
+            provider="cloud-openai-compatible",
+            endpoint=endpoint,
+            model=model,
+            api_key=api_key,
+            timeout_seconds=timeout_seconds,
+        )
+
+    openai_api_key = os.environ.get("OPENAI_API_KEY")
+    if not openai_api_key:
+        return None
+    openai_model = os.environ.get("OPENAI_MODEL", "gpt-4.1-mini")
+    return EndpointConfig(
+        provider="openai",
+        endpoint="https://api.openai.com/v1",
+        model=openai_model,
+        api_key=openai_api_key,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def build_deepseek_cloud_config(timeout_seconds: float) -> EndpointConfig | None:
+    endpoint = os.environ.get("HYBRID_AGENT_CLOUD_ENDPOINT")
+    model = os.environ.get("HYBRID_AGENT_CLOUD_MODEL")
+    api_key = os.environ.get("HYBRID_AGENT_CLOUD_API_KEY")
+    if endpoint and model and api_key:
+        return EndpointConfig(
+            provider="cloud-openai-compatible",
+            endpoint=endpoint,
+            model=model,
+            api_key=api_key,
+            timeout_seconds=timeout_seconds,
+        )
+
+    deepseek_api_key = os.environ.get("DEEPSEEK_API_KEY")
+    if not deepseek_api_key:
+        return None
+    deepseek_endpoint = os.environ.get("DEEPSEEK_BASE_URL", "https://api.deepseek.com")
+    deepseek_model = os.environ.get("DEEPSEEK_MODEL", "deepseek-chat")
+    return EndpointConfig(
+        provider="deepseek",
+        endpoint=deepseek_endpoint,
+        model=deepseek_model,
+        api_key=deepseek_api_key,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def build_cloud_config(executor: str, timeout_seconds: float) -> EndpointConfig | None:
+    if executor == "deepseek":
+        return build_deepseek_cloud_config(timeout_seconds)
+    return build_codex_cloud_config(timeout_seconds)
+
+
+def choose_auto_mode(
+    *,
+    task_text: str,
+    log_paths: list[Path],
+    file_paths: list[Path],
+    selected_route: str,
+    executor: str,
+    local_config: EndpointConfig | None,
+    cloud_config: EndpointConfig | None,
+) -> RouteDecision:
+    input_payload = build_input_payload(
+        task_text=task_text,
+        log_paths=log_paths,
+        file_paths=file_paths,
+        selected_route=selected_route,
+    )
+    evidence = input_payload["evidence"]
+    evidence_count = len(evidence)
+    evidence_bytes = json_size_metrics(evidence)["bytes"]
+    local_available = local_config is not None
+    cloud_available = cloud_config is not None
+
+    if evidence_count < DEFAULT_AUTO_MIN_EVIDENCE_COUNT or evidence_bytes < DEFAULT_AUTO_MIN_EVIDENCE_BYTES:
+        if cloud_available:
+            return RouteDecision(
+                requested_mode="auto",
+                chosen_mode="cloud-only",
+                reason="tiny_or_no_meaningful_bounded_evidence",
+                evidence_count=evidence_count,
+                evidence_bytes=evidence_bytes,
+                local_available=local_available,
+                cloud_available=cloud_available,
+                selected_route=selected_route,
+                executor=executor,
+            )
+        if local_available:
+            return RouteDecision(
+                requested_mode="auto",
+                chosen_mode="local-only",
+                reason="tiny_evidence_but_no_cloud_config_present",
+                evidence_count=evidence_count,
+                evidence_bytes=evidence_bytes,
+                local_available=local_available,
+                cloud_available=cloud_available,
+                selected_route=selected_route,
+                executor=executor,
+            )
+
+    if local_available and cloud_available:
+        return RouteDecision(
+            requested_mode="auto",
+            chosen_mode="preprocess-then-cloud",
+            reason="bounded_evidence_large_enough_for_local_compression_before_cloud",
+            evidence_count=evidence_count,
+            evidence_bytes=evidence_bytes,
+            local_available=local_available,
+            cloud_available=cloud_available,
+            selected_route=selected_route,
+            executor=executor,
+        )
+
+    if local_available:
+        return RouteDecision(
+            requested_mode="auto",
+            chosen_mode="local-only",
+            reason="bounded_evidence_present_but_no_safe_cloud_config",
+            evidence_count=evidence_count,
+            evidence_bytes=evidence_bytes,
+            local_available=local_available,
+            cloud_available=cloud_available,
+            selected_route=selected_route,
+            executor=executor,
+        )
+
+    if cloud_available:
+        return RouteDecision(
+            requested_mode="auto",
+            chosen_mode="cloud-only",
+            reason="local_runtime_unavailable_fallback_to_cloud",
+            evidence_count=evidence_count,
+            evidence_bytes=evidence_bytes,
+            local_available=local_available,
+            cloud_available=cloud_available,
+            selected_route=selected_route,
+            executor=executor,
+        )
+
+    raise RuntimeError("Neither local Ollama nor a safe cloud configuration is available for auto mode.")
+
+
+def log_route_decision(log_path: Path, decision: RouteDecision, entrypoints: WorkstationEntrypoints) -> None:
+    entry = {
+        "timestamp_utc": utc_now_iso(),
+        "provider": "workstation-route",
+        "model": None,
+        "request_id": None,
+        "project_id": "project-execution-os",
+        "task_id": None,
+        "context_profile": None,
+        "context_fingerprint": None,
+        "selected_route": decision.selected_route,
+        "loaded_modules": [],
+        "input_tokens_total": None,
+        "input_tokens_cache_hit": None,
+        "input_tokens_cache_miss": None,
+        "output_tokens": None,
+        "total_tokens": None,
+        "estimated_cost_usd": None,
+        "billed_cost_usd": None,
+        "latency_ms": 0.0,
+        "status": decision.chosen_mode,
+        "stage": "route_decision",
+        "input_size_bytes": decision.evidence_bytes,
+        "input_size_chars": decision.evidence_bytes,
+        "output_size_bytes": 0,
+        "output_size_chars": 0,
+        "compression_ratio": None,
+        "notes": json.dumps(
+            {
+                "requested_mode": decision.requested_mode,
+                "reason": decision.reason,
+                "executor": decision.executor,
+                "entrypoints": asdict(entrypoints),
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        ),
+    }
+    write_log_entry(log_path, entry)
+
+
+def run_workstation_route(
+    *,
+    executor: str,
+    mode: str,
+    task_text: str,
+    log_paths: list[Path],
+    file_paths: list[Path],
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    log_path: Path = DEFAULT_LOG_PATH,
+    selected_route: str = DEFAULT_WORKSTATION_ROUTE,
+    include_full_evidence: bool = False,
+) -> dict[str, Any]:
+    entrypoints = discover_workstation_entrypoints()
+    local_config = build_local_config(timeout_seconds)
+    cloud_config = build_cloud_config(executor, timeout_seconds)
+    chosen_mode = mode
+    route_decision: RouteDecision | None = None
+
+    if mode == "auto":
+        route_decision = choose_auto_mode(
+            task_text=task_text,
+            log_paths=log_paths,
+            file_paths=file_paths,
+            selected_route=selected_route,
+            executor=executor,
+            local_config=local_config,
+            cloud_config=cloud_config,
+        )
+        chosen_mode = route_decision.chosen_mode
+        log_route_decision(log_path, route_decision, entrypoints)
+
+    result = run_hybrid_agent(
+        task_text=task_text,
+        mode=chosen_mode,
+        log_paths=log_paths,
+        file_paths=file_paths,
+        local_config=local_config,
+        cloud_config=cloud_config,
+        log_path=log_path,
+        selected_route=selected_route,
+        include_full_evidence=include_full_evidence,
+    )
+    result["executor"] = executor
+    result["entrypoints"] = asdict(entrypoints)
+    result["local_config_present"] = local_config is not None
+    result["cloud_config_present"] = cloud_config is not None
+    if local_config is not None:
+        result["local_model"] = local_config.model
+        result["local_endpoint"] = local_config.endpoint
+    if cloud_config is not None:
+        result["cloud_model"] = cloud_config.model
+        result["cloud_endpoint"] = cloud_config.endpoint
+    if route_decision is not None:
+        result["route_decision"] = asdict(route_decision)
+    else:
+        result["route_decision"] = {
+            "requested_mode": mode,
+            "chosen_mode": chosen_mode,
+            "reason": "explicit_mode_override",
+            "executor": executor,
+            "selected_route": selected_route,
+        }
+    return result


### PR DESCRIPTION
## Summary
- add a workstation hybrid route adapter for Codex and DeepSeek execution paths
- add a Windows launcher and real workstation discovery for Codex, VS Code, DeepSeek config, and Ollama
- harden local payload normalization and traceability repair based on live Ollama validation

## Validation
- python -m unittest discover -s tools/hybrid-agent/tests -p "test_*.py" -v
- python tools/hybrid-agent/benchmark_fixture.py
- python tools/hybrid-agent/run_workstation_hybrid_route.py --executor codex --mode auto --task "Analyze repeated sqlite lock failures and propose the next safe step." --log-path tools/hybrid-agent/fixtures/synthetic_repetitive_log.txt
- python tools/hybrid-agent/run_workstation_hybrid_route.py --executor deepseek --mode auto --task "Summarize repeated sqlite lock failures for the DeepSeek route." --log-path tools/hybrid-agent/fixtures/synthetic_repetitive_log.txt
- python tools/hybrid-agent/run_workstation_hybrid_route.py --executor codex --mode preprocess-then-cloud --task "Use fallback to analyze repeated sqlite lock failures." --log-path tools/hybrid-agent/fixtures/synthetic_repetitive_log.txt with cloud env vars pointed at local Ollama
- powershell -ExecutionPolicy Bypass -File tools/hybrid-agent/Invoke-Workstation-HybridRoute.ps1 -Executor codex -Mode auto -Task "Launcher smoke check for repeated sqlite lock failures." -LogPath tools/hybrid-agent/fixtures/synthetic_repetitive_log.txt
