### PR TITLE
Add Notion agent workspace block and live Notion pilot

### DIFF
--- a/blocks/PROJECT_INDEX.md
+++ b/blocks/PROJECT_INDEX.md
@@ -94,6 +94,20 @@ Current status:
 
 `candidate`
 
+### Notion Agent Workspace Block
+
+Path:
+
+`blocks/notion/`
+
+Purpose:
+
+Provide a reusable Notion workspace layer for stable `PROJECT_ID` routing, agent-compatible project pages, shared project databases, MCP/API access design, GitHub coordination boundaries, and fresh-agent re-entry.
+
+Current status:
+
+`candidate`
+
 ### Skill Creator Block
 
 Path:

--- a/blocks/notion/AGENT_RULES.md
+++ b/blocks/notion/AGENT_RULES.md
@@ -1,0 +1,92 @@
+# Notion Agent Rules
+
+## Purpose
+
+Define how authorized agents may read and write Notion project spaces connected to Project Execution OS.
+
+## Entry Rule
+
+An agent must not begin from a random Notion page.
+
+The valid entry sequence is:
+
+1. Project Execution OS `START_HERE.md`.
+2. `docs/ROUTER.md`.
+3. Relevant project entrypoint or system block.
+4. Matching Notion project page by `PROJECT_ID`.
+
+## Read Rule
+
+Read the smallest relevant Notion area:
+
+- task work -> Tasks + linked project Current State;
+- research -> Research + Links + relevant project Current State;
+- decision work -> Decisions + evidence links;
+- asset work -> Assets + linked task;
+- handoff -> Current State + Tasks + Logs + attached durable-layer entrypoints.
+
+Do not load the whole workspace by default.
+
+## Write Rule
+
+Write updates into the narrowest correct place:
+
+- new work item -> Tasks;
+- external source finding -> Research or Links;
+- accepted architectural or product choice -> Decisions;
+- file, reference, prompt, or media -> Assets;
+- execution trace -> Logs;
+- reusable insight -> Knowledge Extracted.
+
+## Conflict Rule
+
+If two durable layers disagree:
+
+1. Do not silently overwrite either side.
+2. Use the project's `Truth Map` to identify which layer owns that fact.
+3. Create a reconciliation task.
+4. Record the conflict in Logs.
+5. Update the non-owning mirror only after the owning layer is confirmed.
+
+## Agent Note Rule
+
+Agents may add short operational notes, but must not use Notion as a hidden scratchpad for rules that belong in Project Execution OS or in a project repository.
+
+## Secret Rule
+
+Never store API keys, OAuth tokens, passwords, personal documents, or confidential case details in the reusable Notion layer.
+
+Use credential pointers only, such as `stored in password manager`, when needed.
+
+## MCP and API Rule
+
+When using Notion MCP or API access:
+
+- use the least powerful connection that can complete the work;
+- prefer project-scoped access over workspace-wide access when supported;
+- respect pagination and partial reads;
+- validate exact available tools in the target agent environment;
+- do not assume hosted MCP, local MCP, ChatGPT connector, Codex connector, and raw API expose identical capabilities.
+
+## Sync Rule
+
+Do not design uncontrolled two-way sync.
+
+Allowed initial sync modes:
+
+- GitHub -> Notion mirror for visibility;
+- Notion -> GitHub issue creation for approved task intake;
+- manual reconciliation for decisions and truth-map state;
+- one-way export of reusable knowledge candidates for review.
+
+Any two-way sync must define:
+
+- owner layer per field;
+- conflict behavior;
+- rollback behavior;
+- evidence trail;
+- retry and duplicate handling.
+
+## Final Rule
+
+An agent using Notion must make the project clearer for the next agent, not create a second undocumented operating system.

--- a/blocks/notion/BLOCK.md
+++ b/blocks/notion/BLOCK.md
@@ -1,0 +1,76 @@
+# Notion Agent Workspace Block
+
+## Purpose
+
+Provide a reusable Notion workspace layer for Project Execution OS so any authorized agent can enter any project through the same project identity, page contract, database schema, agent rules, and synchronization boundaries.
+
+## Status
+
+`candidate`
+
+This block becomes active only after one real project validates the workspace contract and agent re-entry flow.
+
+## Core Principle
+
+Notion is a readable project-memory and management layer when a project needs it.
+
+It is not a second operating system and it does not replace layer-specific sources of truth.
+
+## When To Use
+
+Use this block for:
+
+- Notion workspace architecture for Project Execution OS projects;
+- agent-compatible project pages;
+- cross-project Project ID routing;
+- shared Notion databases for projects, tasks, research, decisions, assets, links, logs, and extracted knowledge;
+- Notion MCP or API access design;
+- GitHub and Notion coordination boundaries;
+- reusable Notion templates.
+
+## When Not To Use
+
+Do not use this block for:
+
+- one-off private notes;
+- projects that do not need durable Notion context;
+- storing secrets, tokens, passwords, or confidential documents;
+- replacing GitHub for code, commits, pull requests, or technical artifacts;
+- broad automation before repeated manual use proves the need.
+
+## Read Next
+
+Read only the smallest relevant file:
+
+1. Workspace architecture and identity: `WORKSPACE_CONTRACT.md`
+2. Databases and properties: `DATABASE_SCHEMA.md`
+3. Agent behavior: `AGENT_RULES.md`
+4. Ready donors and integration options: `READY_SOLUTIONS.md`
+5. Validation before activation: `VALIDATION_BACKLOG.md`
+6. Research evidence: `RESEARCH_REPORT_2026-06-09.md`
+7. Source URLs: `REFERENCES.md`
+
+## Typical Flow
+
+```text
+START_HERE.md
+-> docs/ROUTER.md
+-> project entrypoint
+-> resolve PROJECT_ID
+-> open matching Notion project page
+-> load only the smallest relevant linked database slice
+-> perform bounded work
+-> record status, decision, task, research, log, or knowledge candidate in the correct layer
+```
+
+## Boundary
+
+This block defines the reusable Notion layer only.
+
+It must not store project-specific state, credentials, private personal data, or active project decisions that belong inside an individual project workspace.
+
+## Final Rule
+
+Notion should make a project understandable to the next agent without owner explanation.
+
+It must never create duplicate truth.

--- a/blocks/notion/DATABASE_SCHEMA.md
+++ b/blocks/notion/DATABASE_SCHEMA.md
@@ -1,0 +1,138 @@
+# Notion Database Schema
+
+## Purpose
+
+Define the baseline Notion database schema for an agent-compatible Project Execution OS workspace.
+
+## Design Rule
+
+Prefer simple properties that agents can read and write reliably.
+
+Avoid decorative formulas and complex relations until repeated use proves they reduce real work.
+
+## Projects Database
+
+Required properties:
+
+- `Name` — title.
+- `PROJECT_ID` — stable text or unique ID.
+- `Status` — idea, candidate, active, paused, archived, deprecated.
+- `Project Type` — app, workflow, content, research, system, legal, personal, other.
+- `Current Mode` — new, continue, review, research, execution, handoff, archive.
+- `Owner` — people or text.
+- `Project Entrypoint` — URL.
+- `GitHub Repo` — URL.
+- `Drive Folder` — URL.
+- `Bublup Folder` — URL.
+- `Telegram Channel` — URL.
+- `Active Layers` — multi-select.
+- `Truth Map` — rich text.
+- `Next Practical Step` — rich text.
+- `Last Agent Touch` — date.
+- `Needs Review` — checkbox.
+
+## Tasks Database
+
+Required properties:
+
+- `Name` — title.
+- `PROJECT_ID` — text or relation to Projects.
+- `Status` — backlog, ready, in progress, blocked, review, done, canceled.
+- `Priority` — low, medium, high, urgent.
+- `Task Type` — research, design, implementation, review, bug, decision, handoff, admin.
+- `Assignee Agent` — text or people.
+- `Due` — date.
+- `GitHub Issue` — URL.
+- `Codex Handoff` — URL.
+- `Blocked By` — rich text or relation.
+- `Definition of Done` — rich text.
+- `Output URL` — URL.
+- `Needs Review` — checkbox.
+
+## Research Database
+
+Required properties:
+
+- `Name` — title.
+- `PROJECT_ID` — text or relation.
+- `Research Question` — rich text.
+- `Source Type` — official, vendor, open-source, professional, community, anecdotal.
+- `Source URL` — URL.
+- `Date Checked` — date.
+- `Freshness Risk` — low, medium, high.
+- `Finding` — rich text.
+- `Actionability` — candidate, validated, rejected, monitor.
+- `Related Task` — rich text or relation.
+
+## Decisions Database
+
+Required properties:
+
+- `Name` — title.
+- `PROJECT_ID` — text or relation.
+- `Decision Status` — proposed, accepted, rejected, superseded.
+- `Decision Date` — date.
+- `Context` — rich text.
+- `Decision` — rich text.
+- `Rationale` — rich text.
+- `Consequences` — rich text.
+- `GitHub Evidence` — URL.
+- `Needs Review` — checkbox.
+
+## Assets Database
+
+Required properties:
+
+- `Name` — title.
+- `PROJECT_ID` — text or relation.
+- `Asset Type` — file, image, video, prompt, design, dataset, credential-pointer, external-link.
+- `Location` — URL.
+- `Storage Layer` — GitHub, Notion, Google Drive, Bublup, local, other.
+- `Usage Rights` — owned, licensed, public, unknown, restricted.
+- `Related Task` — rich text or relation.
+
+## Links Database
+
+Required properties:
+
+- `Name` — title.
+- `PROJECT_ID` — text or relation.
+- `URL` — URL.
+- `Link Type` — official, tool, repo, article, video, competitor, template, reference.
+- `Why It Matters` — rich text.
+- `Date Checked` — date.
+
+## Logs Database
+
+Required properties:
+
+- `Name` — title.
+- `PROJECT_ID` — text or relation.
+- `Log Type` — agent run, owner note, meeting, handoff, error, sync.
+- `Timestamp` — date.
+- `Agent Author` — text or people.
+- `Summary` — rich text.
+- `Next Action` — rich text.
+- `Evidence URL` — URL.
+
+## Knowledge Extracted Database
+
+Required properties:
+
+- `Name` — title.
+- `PROJECT_ID` — text or relation.
+- `Knowledge Type` — reusable rule, pattern, source, warning, prompt, workflow.
+- `Candidate Text` — rich text.
+- `Promotion Status` — captured, researched, candidate, reviewed, active, rejected, retired.
+- `Target Location` — rich text or URL.
+- `Needs Review` — checkbox.
+
+## Initial MVP Rule
+
+Start with all eight databases, but use text `PROJECT_ID` fields first.
+
+Add relations only after the first practical test confirms that they improve navigation without making agent writes fragile.
+
+## Final Rule
+
+The schema succeeds only when different agents can use it consistently without losing project identity or confusing layer-specific truth.

--- a/blocks/notion/READY_SOLUTIONS.md
+++ b/blocks/notion/READY_SOLUTIONS.md
@@ -1,0 +1,112 @@
+# Ready Solutions
+
+## Purpose
+
+Track donor systems and implementation options that should be checked before building custom Notion infrastructure.
+
+## Official Notion Surfaces
+
+### Notion API
+
+Use for direct integrations that need pages, databases or data sources, blocks, users, comments, search, and controlled writes.
+
+Strengths:
+
+- official;
+- stable authentication model;
+- database and page primitives map well to Project Execution OS objects;
+- supports structured properties and pagination.
+
+Risks:
+
+- requires careful permission scope;
+- block editing can be verbose;
+- API versions and terminology may evolve.
+
+### Official Notion MCP
+
+Use for AI-agent access where a model needs to search, read, create, or update Notion content through agent-oriented tools.
+
+Strengths:
+
+- official agent path;
+- hosted OAuth flow reduces manual token handling;
+- Markdown-oriented editing reduces block-level friction.
+
+Risks:
+
+- exact capabilities differ by client and environment;
+- admin settings or workspace permissions may be required;
+- must validate project-scoped access behavior in each runtime.
+
+## GitHub and Notion Coordination Donors
+
+### Native Notion GitHub Integration
+
+Use first for visibility into GitHub pull requests and issues inside Notion.
+
+Best fit:
+
+- mirror engineering activity into a readable Notion management surface;
+- avoid custom synchronization for the first MVP.
+
+### Unito GitHub and Notion Sync
+
+Use as a donor pattern for two-way issue and task synchronization.
+
+Best fit:
+
+- teams that plan in Notion while engineering executes in GitHub.
+
+Risk:
+
+- paid vendor dependency;
+- two-way sync requires strict field ownership and conflict rules.
+
+### GitHub Marketplace: Notion 2 Issue
+
+Use as a donor pattern for approved Notion task intake that creates GitHub issues.
+
+Best fit:
+
+- Notion for planning intake;
+- GitHub for implementation evidence.
+
+### n8n Workflow Templates
+
+Use as a donor for low-code GitHub issue mirroring into Notion.
+
+Best fit:
+
+- fast prototype automation;
+- controllable custom logic before building a dedicated service.
+
+## Open Source and Community Donors
+
+### makenotion/notion-mcp-server
+
+Official Notion MCP repository. Use as a capability signal and implementation donor. Verify whether hosted MCP is preferable for the target agent.
+
+### awesome-notion
+
+Use as a discovery list for ecosystem tools, templates, and utilities.
+
+### Community MCP Servers
+
+Use only as research donors unless reviewed for permissions, maintenance, and security.
+
+## Selection Order
+
+Prefer this order:
+
+1. Existing Project Execution OS Notion standard and templates.
+2. Native Notion workspace features.
+3. Official Notion API or official MCP.
+4. Native Notion GitHub integration.
+5. Lightweight automation such as n8n or approved vendor sync.
+6. Open-source donor fork.
+7. Custom integration.
+
+## Final Rule
+
+Do not build custom synchronization until native Notion capability, official MCP or API, and lightweight automation options are proven insufficient.

--- a/blocks/notion/REFERENCES.md
+++ b/blocks/notion/REFERENCES.md
@@ -1,0 +1,37 @@
+# References
+
+Research date: 2026-06-09
+
+## Official Sources
+
+- https://www.notion.com/
+- https://developers.notion.com/reference/intro
+- https://developers.notion.com/reference/property-object
+- https://developers.notion.com/reference/post-database-query
+- https://www.notion.com/integrations/github
+- https://www.notion.com/help/mcp-connections-for-custom-agents
+- https://www.notion.com/blog/notions-hosted-mcp-server-an-inside-look
+- https://github.com/makenotion/notion-mcp-server
+
+## Donor and Ecosystem Sources
+
+- https://github.com/spencerpauly/awesome-notion
+- https://unito.io/blog/guide-how-to-sync-github-notion/
+- https://github.com/marketplace/actions/notion-2-issue
+- https://n8n.io/integrations/github/and/notion/
+- https://github.com/seonglae/mcp-notion
+
+## Source Hierarchy
+
+1. Official Notion documentation and product pages.
+2. Official Notion GitHub repositories.
+3. Native GitHub and Notion integration documentation.
+4. Maintained automation vendors and workflow platforms.
+5. Open-source repositories.
+6. Community examples and anecdotal patterns.
+
+## Freshness Rule
+
+Notion API, MCP, connector, and AI-agent capabilities are time-sensitive.
+
+Refresh this reference set before implementation changes or when changing the agent access layer.

--- a/blocks/notion/RESEARCH_REPORT_2026-06-09.md
+++ b/blocks/notion/RESEARCH_REPORT_2026-06-09.md
@@ -1,0 +1,147 @@
+# Notion Agent Workspace Research Report — 2026-06-09
+
+## Research Question
+
+What existing Notion, GitHub, MCP, and automation solutions can serve as donors for a Project Execution OS Notion layer where any authorized agent can connect to any project through a stable project identity and standard workspace contract?
+
+## Confirmed Existing Project State
+
+Project Execution OS already treated Notion as an optional readable management layer rather than as a universal mandatory layer.
+
+The repository already contained:
+
+- `docs/integrations/notion/README.md`
+- `workflow-templates/project-entrypoint/NOTION_PROJECT_TEMPLATE.md`
+- layer-aware source-of-truth rules in `docs/PROJECT_LIFECYCLE_MODEL.md`
+- mandatory reuse-first rules in `docs/EXISTING_SOLUTION_FIRST_STANDARD.md`
+
+This new block extends those existing rules. It does not replace them.
+
+## Confirmed External Donors
+
+### Official Notion API
+
+Notion provides an official API for pages, databases or data sources, blocks, comments, users, search, properties, and controlled writes.
+
+Implication:
+
+Use native Notion properties and keep schemas simple enough for reliable agent writes.
+
+### Official Notion MCP
+
+Notion provides an official MCP path for AI-agent access. Hosted OAuth and Markdown-oriented editing are suitable donors for agent re-entry and low-friction updates.
+
+Implication:
+
+Support MCP and raw API as alternative access paths, but validate exact runtime capabilities before promising parity across clients.
+
+### Native Notion GitHub Integration
+
+Notion provides a GitHub integration for issue and pull-request visibility.
+
+Implication:
+
+Start with native visibility before custom two-way synchronization.
+
+### Donor Automation Patterns
+
+Useful donor patterns exist through:
+
+- Unito GitHub and Notion sync;
+- GitHub Marketplace action `Notion 2 Issue`;
+- n8n GitHub and Notion workflows;
+- official and community MCP repositories.
+
+Implication:
+
+Do not build custom synchronization first. Define field ownership and conflict behavior before automation.
+
+## Architectural Decision
+
+Create a reusable `blocks/notion/` candidate block inside Project Execution OS.
+
+The block must preserve the existing layer-aware model:
+
+- Notion owns readable management truth when attached;
+- GitHub owns code, technical files, commits, pull requests, and Codex implementation evidence when attached;
+- local Git owns local execution history before GitHub attachment;
+- asset layers own heavy source files;
+- Chat owns current discussion only until a durable update is written.
+
+## Implemented MVP
+
+### GitHub Reusable Block
+
+Created:
+
+- `blocks/notion/BLOCK.md`
+- `blocks/notion/WORKSPACE_CONTRACT.md`
+- `blocks/notion/DATABASE_SCHEMA.md`
+- `blocks/notion/AGENT_RULES.md`
+- `blocks/notion/READY_SOLUTIONS.md`
+- `blocks/notion/VALIDATION_BACKLOG.md`
+- `blocks/notion/REFERENCES.md`
+- this research report
+
+### Live Notion Scaffold
+
+Created live Notion workspace page:
+
+- `Project Execution OS — Agent Workspace`
+
+Created live Notion databases:
+
+- Projects
+- Tasks
+- Research
+- Decisions
+- Assets
+- Links
+- Logs
+- Knowledge Extracted
+- Agent Notes
+
+Created initial Projects record:
+
+- `PROJECT_ID = project-execution-os`
+
+## What Was Reused
+
+- existing Project Execution OS layer-aware lifecycle model;
+- existing Notion integration standard;
+- existing Notion project entrypoint template;
+- official Notion API and MCP;
+- native Notion GitHub integration;
+- donor sync patterns from Unito, n8n, and GitHub Marketplace.
+
+## What Was Adapted
+
+- standardized `PROJECT_ID` as the stable cross-system key;
+- added workspace contract for fresh-agent re-entry;
+- added explicit truth-map field instead of forcing one global source of truth;
+- added lightweight central databases and an `Agent Notes` extension;
+- delayed complex relations and two-way sync until a real project validates the basic flow.
+
+## Risks
+
+- MCP and connector capabilities differ across clients.
+- Two-way sync can create conflicts and duplicate truth.
+- Overly complex database relations can make agent writes fragile.
+- Workspace-wide permissions can be broader than necessary.
+- Notion API and MCP behavior can change over time.
+
+## Recommended Next Test
+
+1. Review and merge the GitHub block PR.
+2. Use the live Notion `Projects` database to enter `project-execution-os` by `PROJECT_ID`.
+3. Ask a fresh agent to find the project, read the truth map, and identify the next safe action.
+4. Add one real task and one log entry.
+5. Decide whether native GitHub visibility is enough before adding sync automation.
+
+## Final Recommendation
+
+Proceed with Notion as the universal readable agent workspace layer for projects that need it.
+
+Do not create a separate Notion operating system.
+
+Project Execution OS remains the operating system.

--- a/blocks/notion/VALIDATION_BACKLOG.md
+++ b/blocks/notion/VALIDATION_BACKLOG.md
@@ -1,0 +1,42 @@
+# Validation Backlog
+
+## Purpose
+
+Track what must be proven before the Notion agent workspace block can move from `candidate` to `active`.
+
+## Required Validation
+
+- Create one real test Notion project page with `PROJECT_ID`.
+- Create the eight workspace databases.
+- Verify that an agent can find the project by `PROJECT_ID`.
+- Verify that an agent can read only the smallest relevant database slice.
+- Verify that a Notion project page and any attached GitHub entrypoint cross-link cleanly.
+- Verify conflict handling when two layers disagree.
+- Test native Notion GitHub integration for issue and pull-request visibility.
+- Test Notion MCP or connector availability in each target agent environment.
+- Test that required database properties can be written reliably.
+- Decide whether initial automation should remain manual, use native integration, use n8n, use a GitHub Action, or use custom code.
+- Confirm that no secrets or confidential documents are stored in the reusable block.
+
+## Open Questions
+
+- Should the central Projects database become the canonical Notion registry for all Notion-connected projects?
+- Should each project entrypoint store its Notion project URL even when the project is GitHub-backed?
+- Should approved Notion task intake be allowed to create GitHub issues automatically?
+- Which fields should be mirrored and which should remain single-layer only?
+- What is the minimum MCP capability set for agent re-entry?
+- Should Bublup links be stored directly on Projects, or only through Assets and Links?
+
+## Activation Criteria
+
+This block can become `active` only after:
+
+1. one real project uses the workspace contract;
+2. at least one fresh agent re-enters through `PROJECT_ID` without owner explanation;
+3. source-of-truth conflict handling is tested;
+4. the database schema is reviewed after practical use;
+5. the owner approves activation.
+
+## Final Rule
+
+Do not mark the Notion layer solved until it works across a real project without creating duplicate truth.

--- a/blocks/notion/WORKSPACE_CONTRACT.md
+++ b/blocks/notion/WORKSPACE_CONTRACT.md
@@ -1,0 +1,101 @@
+# Notion Workspace Contract
+
+## Purpose
+
+Define the minimum Notion structure that lets any authorized agent enter any Project Execution OS project without asking the owner to explain the workspace again.
+
+## Identity Contract
+
+Every Notion project page must expose these fields or visibly equivalent properties:
+
+- `PROJECT_ID` — stable machine-readable project key.
+- `PROJECT_NAME` — human-readable project name.
+- `PROJECT_STATUS` — idea, candidate, active, paused, archived, deprecated.
+- `PROJECT_TYPE` — app, workflow, content, research, system, legal, personal, other.
+- `PROJECT_ENTRYPOINT` — preferred project front door URL or repository path.
+- `GITHUB_REPO` — repository URL when GitHub exists.
+- `NOTION_PROJECT_URL` — self URL of the Notion project page.
+- `OWNER` — human owner.
+- `CURRENT_MODE` — new project, continue, review, research, execution, handoff, archive.
+- `LAST_AGENT_TOUCH` — last agent update date or timestamp.
+- `ACTIVE_LAYERS` — Chat, Local Git, GitHub, Notion, Drive, Bublup, Telegram, other.
+- `TRUTH_MAP` — brief explanation of what truth belongs to each active layer.
+
+## Important Correction
+
+There is no universal rule that GitHub is the source of truth for every project.
+
+The truth map depends on the attached layers:
+
+- readable status, high-level decisions, catalogue visibility, and coordination -> Notion when attached;
+- code, commits, pull requests, technical files, and Codex implementation evidence -> GitHub when attached;
+- local execution history before GitHub attachment -> local Git and project files;
+- heavy source assets -> Google Drive or another approved asset layer;
+- current discussion -> Chat until promoted into the correct durable layer.
+
+## Workspace Shape
+
+Minimum project page sections:
+
+- Overview
+- Current State
+- Next Practical Step
+- Tasks
+- Research
+- Decisions
+- Assets
+- Links
+- Logs
+- Knowledge Extracted
+- Agent Notes
+
+## Database Layer
+
+A durable multi-project workspace should use linked databases for recurring project data:
+
+- Projects
+- Tasks
+- Research
+- Decisions
+- Assets
+- Links
+- Logs
+- Knowledge Extracted
+
+A lightweight project may begin with one project page and inline sections, but it must preserve `PROJECT_ID`, the truth map, and links to attached layers.
+
+## Project Entry Flow
+
+When an agent enters a Notion-connected project:
+
+1. Read Project Execution OS `START_HERE.md`.
+2. Follow `docs/ROUTER.md`.
+3. Resolve the target `PROJECT_ID`.
+4. Open the project entrypoint.
+5. Open the matching Notion project page by `PROJECT_ID`.
+6. Read only the smallest relevant linked database slice.
+7. Compare the current task with the truth map.
+8. Write updates only into the correct layer.
+9. Record conflicts instead of silently overwriting them.
+
+## Naming Rule
+
+Use the same stable `PROJECT_ID` everywhere the project is represented:
+
+- GitHub repository or project folder
+- Notion project page
+- Google Drive folder
+- Bublup folder
+- Telegram channel or thread
+- local folder
+- agent handoff package
+
+## Permission Rule
+
+Agents must use only the access explicitly granted to them.
+
+Prefer project-scoped access over workspace-wide access whenever the tool permits it.
+
+## Final Rule
+
+The Notion workspace is valid only when a fresh authorized agent can identify the project, locate its durable layers, understand the current state, and take the next safe action without reconstructing chat history.

--- a/docs/ROUTER.md
+++ b/docs/ROUTER.md
@@ -31,6 +31,7 @@ Do not append an unrelated next-project question after answering the active requ
 - logic concepts, argument structure, cause-and-effect analysis, fallacy detection, assumption review, contradiction check, or decision-quality reasoning review -> `blocks/logic/BLOCK.md`
 - music generation, soundtrack design, adaptive music, real-time music, music-agent behavior, generated-music rights review, or music-tool evaluation -> `blocks/music/BLOCK.md`
 - Telegram bots, Telegram Mini Apps, Telegram Business or Secretary Bots, Managed Bots, Telegram Login, Telegram Gateway, Telegram Stars, Bot API, TDLib, MTProto, or Telegram integrations -> `blocks/telegram/BLOCK.md`
+- Notion workspace architecture, Notion project registry, Notion project template, PROJECT_ID routing, Notion agent re-entry, Notion MCP, Notion API, Notion database schema, Notion and GitHub coordination, or Notion synchronization design -> `blocks/notion/BLOCK.md`
 - immigration law, USCIS, Form I-485, marriage-based adjustment of status, consular processing, immigration interviews, RFEs, NOIDs, immigration travel risk, or USCIS PM-602-0199 -> `blocks/us-law/immigration/BLOCK.md`
 - United States law, federal or state legal research, statutes, regulations, court rules, case law, legal deadlines, legal-risk triage, attorney handoff preparation, or legal-source automation -> `blocks/us-law/BLOCK.md`
 - indexing or repository catalog work -> `docs/INDEXING_STANDARD.md`

--- a/knowledge-library/PROJECT_INDEX.md
+++ b/knowledge-library/PROJECT_INDEX.md
@@ -31,6 +31,7 @@ knowledge-library/
 | AI music creation stack | candidate | music deep research | knowledge-library/architecture-decisions/AI_MUSIC_CREATION_STACK.md |
 | US legal research stack | candidate | US law deep research | knowledge-library/architecture-decisions/US_LEGAL_RESEARCH_STACK.md |
 | Telegram product stack | candidate | Telegram deep research | knowledge-library/architecture-decisions/TELEGRAM_PRODUCT_STACK.md |
+| Notion agent workspace stack | candidate | Notion donor research and live pilot | knowledge-library/architecture-decisions/NOTION_AGENT_WORKSPACE_STACK.md |
 
 ## Current Workflow Lesson Entries
 

--- a/knowledge-library/architecture-decisions/NOTION_AGENT_WORKSPACE_STACK.md
+++ b/knowledge-library/architecture-decisions/NOTION_AGENT_WORKSPACE_STACK.md
@@ -1,0 +1,58 @@
+# Notion Agent Workspace Stack
+
+Type: `architecture-decision`
+Lifecycle status: `candidate`
+Captured: 2026-06-09
+
+## Reusable Lesson
+
+Notion should be used as a universal readable agent workspace layer for projects that need it, not as a second operating system and not as a mandatory layer for every project.
+
+Use:
+
+`START_HERE.md -> ROUTER -> PROJECT_ID -> project entrypoint -> matching Notion project page -> smallest relevant database slice -> bounded update in the correct truth-owning layer`
+
+## Key Rules
+
+- Reuse the same stable `PROJECT_ID` across GitHub, Notion, Drive, Bublup, Telegram, local folders, and agent handoffs.
+- Preserve the Project Execution OS layer-aware truth map.
+- Use Notion for readable management, coordination, and catalogue visibility when attached.
+- Use GitHub for code, technical artifacts, commits, pull requests, and Codex execution evidence when attached.
+- Do not build uncontrolled two-way synchronization before field ownership, conflict behavior, and rollback are defined.
+- Prefer official Notion MCP, API, and native GitHub integration before custom automation.
+
+## Entry Point
+
+Use:
+
+`blocks/notion/BLOCK.md`
+
+## Live Pilot
+
+A live Notion scaffold was created on 2026-06-09 with:
+
+- Projects
+- Tasks
+- Research
+- Decisions
+- Assets
+- Links
+- Logs
+- Knowledge Extracted
+- Agent Notes
+
+The initial test record uses:
+
+`PROJECT_ID = project-execution-os`
+
+## Validation Still Required
+
+- fresh-agent re-entry by `PROJECT_ID`;
+- one real task and log update;
+- conflict-handling test;
+- native GitHub integration review;
+- decision on whether automation is needed after practical use.
+
+## Final Rule
+
+Use Notion to make durable project context readable and agent-accessible without duplicating the operating system or creating duplicate truth.

--- a/workflow-templates/project-entrypoint/NOTION_PROJECT_TEMPLATE.md
+++ b/workflow-templates/project-entrypoint/NOTION_PROJECT_TEMPLATE.md
@@ -4,6 +4,7 @@ Use this as the top block or dedicated `Project Entrypoint` section/page inside 
 
 ## Project
 
+- PROJECT_ID:
 - Name:
 - Type:
 - Short description:
@@ -14,10 +15,34 @@ Use this as the top block or dedicated `Project Entrypoint` section/page inside 
 - Who it is for:
 - Current success target:
 
-## Source Of Truth
+## Active Layers
 
-- Primary source of truth:
+- Chat:
+- Local Git:
+- GitHub:
+- Notion:
+- Google Drive:
+- Bublup:
+- Telegram:
+- Other:
+
+## Truth Map
+
+State which layer owns which kind of truth.
+
+Minimum rule:
+
+- readable project status, high-level decisions, catalogue visibility, and coordination -> Notion when attached;
+- code, technical files, commits, pull requests, and Codex implementation evidence -> GitHub when attached;
+- local execution history before GitHub attachment -> local Git and project files;
+- heavy source assets -> Google Drive or another approved asset layer;
+- current discussion -> Chat until written into the correct durable layer.
+
+## Entry Links
+
+- Primary project entrypoint:
 - Related GitHub repository if any:
+- Notion project URL:
 - Supporting workspace/databases:
 - System entry point: `https://github.com/oleg3479881328-code/Project-Execution-OS/blob/main/START_HERE.md`
 
@@ -26,6 +51,7 @@ Use this as the top block or dedicated `Project Entrypoint` section/page inside 
 - Mode:
 - Current phase:
 - Status:
+- Last agent touch:
 
 ## Done So Far
 
@@ -53,12 +79,14 @@ Use this as the top block or dedicated `Project Entrypoint` section/page inside 
 1. current task list or task database
 2. current notes or working section
 3. linked project artifacts
-4. related knowledge or reference pages
+4. related research, decisions, and knowledge pages
 
 ## Notes
 
 This is the front door to the project, not the full history.
 
 Keep it short, current, and easy to scan.
+
+Use the same stable `PROJECT_ID` everywhere the project is represented.
 
 If the project is only initialized and the purpose is not yet defined, say that directly instead of guessing.


### PR DESCRIPTION
## Summary
- add `blocks/notion/` candidate reusable block for agent-compatible Notion workspaces
- define stable `PROJECT_ID` routing, workspace contract, database schema, agent rules, donor map, validation backlog, references, and research report
- register Notion workspace routing in `docs/ROUTER.md`
- register the Notion block in `blocks/PROJECT_INDEX.md`
- extend the existing Notion project entrypoint template with `PROJECT_ID`, active layers, and truth-map guidance
- capture the candidate architecture decision in `knowledge-library/architecture-decisions/NOTION_AGENT_WORKSPACE_STACK.md`
- register that decision in `knowledge-library/PROJECT_INDEX.md`

## Live Notion pilot created
A live Notion workspace scaffold was created:
- `Project Execution OS — Agent Workspace`
- Projects
- Tasks
- Research
- Decisions
- Assets
- Links
- Logs
- Knowledge Extracted
- Agent Notes

An initial Projects record was created with:
- `PROJECT_ID = project-execution-os`

## Architectural boundary
This PR preserves the existing Project Execution OS layer-aware model:
- Notion = readable management, coordination, and catalogue visibility when attached
- GitHub = code, technical files, commits, PRs, and Codex execution evidence when attached
- Chat = current discussion until promoted
- asset layers = heavy source assets

This PR does **not** make GitHub the universal source of truth for every project and does **not** introduce uncontrolled two-way sync.

## Validation still required
- review the PR before merge
- run fresh-agent re-entry by `PROJECT_ID`
- add one real task and one log entry
- test native Notion GitHub integration
- decide later whether automation is needed after practical use

## Note
A direct rewrite of `PROJECT_STATE.md` was intentionally not included because the connector safety layer blocked that write. The reusable block and live Notion pilot are complete and reviewable without that continuity-file rewrite.