### PR TITLE
Add one link handoff rule

### DIFF
--- a/docs/ONE_LINK_HANDOFF_RULE.md
+++ b/docs/ONE_LINK_HANDOFF_RULE.md
@@ -1,0 +1,11 @@
+# One Link Handoff Rule
+
+Date added: 2026-06-20
+
+Rule: for work handoff messages, the owner-facing answer should use one primary link by default.
+
+The linked page should contain the complete work packet: goal, work mode, repository context, first file to read, instructions, boundaries, acceptance criteria, checks to run, and report format.
+
+Default owner-facing answer: Готово. Одна ссылка: followed by the primary link.
+
+Do not send a bundle of separate links unless the owner explicitly asks for more. If multiple artifacts exist, package them behind the primary link first.


### PR DESCRIPTION
Adds a rule for handoff messages: package full context behind one primary link and return that one link by default.