### PR TITLE
Add commercial intelligence agent candidate module

### DIFF
--- a/agent-modules/commercial-intelligence-agent/README.md
+++ b/agent-modules/commercial-intelligence-agent/README.md
@@ -1,0 +1,185 @@
+# Commercial Intelligence Agent
+
+## Purpose
+
+This candidate module helps an AI operator turn **minimal customer input** — ideally only a company website — into a practical commercial intelligence report focused on sales growth.
+
+The module is not a magic sales button. It is a structured research and diagnosis workflow for finding:
+
+- what the customer sells;
+- where the customer likely operates;
+- who the real competitors are;
+- what the market and audience care about;
+- where the customer's offer, website, funnel, visibility, and distribution are weak;
+- which actions should be tested first to increase leads, replies, calls, sales, or revenue.
+
+## When To Use
+
+Use this module when the owner asks for an agent or workflow that can analyze a business, customer, client, website, market, competitor set, sales channel, offer, lead list, or growth opportunity.
+
+Typical trigger phrases:
+
+- "дам сайт заказчика, пусть агент сам поймёт нишу и страну";
+- "исследуй конкурентов и продажи";
+- "найди, как увеличить продажи";
+- "сделай коммерческую разведку";
+- "найди офферы, лиды, каналы, SEO, слабые места";
+- "подготовь growth report".
+
+## When Not To Use
+
+Do not use this module for:
+
+- legal, medical, financial, immigration, or other high-stakes advice without a domain-specific standard;
+- pure copywriting when no market or competitor research is needed;
+- automated spam, credential harvesting, or scraping private/non-consensual personal data;
+- claims that sales will increase with certainty;
+- autonomous contacting of leads without explicit owner approval and compliance review;
+- stealth scraping or anti-bot bypass that violates target-site terms or applicable law.
+
+## Core Product Shape
+
+Working name: **AI Growth Scout**.
+
+One-line product definition:
+
+> Given a customer website, infer the business context, research the market and competitors, diagnose commercial weak points, and produce a prioritized sales-growth action plan.
+
+Primary input:
+
+```text
+customer_website: required
+```
+
+Optional inputs:
+
+```text
+known_country
+known_city_or_region
+known_language
+known_competitors
+known_offer
+known_target_customer
+known_goal
+budget_or_channel_constraints
+```
+
+The workflow must operate without optional fields when possible. Missing fields are inferred and labeled as assumptions.
+
+## Minimal-Input Inference Contract
+
+From a website alone, the module should attempt to infer:
+
+1. Company identity: name, domain, brand names, products, services.
+2. Geography: country, city, service area, phone prefix, address, currency, TLD, language, hreflang, schema.org markup, legal pages, map links.
+3. Business model: B2B, B2C, local service, SaaS, ecommerce, agency, marketplace, consulting, creator/business media, etc.
+4. Target customer: buyer roles, segments, pains, intent level.
+5. Offer type: productized service, custom service, subscription, one-time project, local appointment, quote-based sale.
+6. Funnel type: direct contact, booking, checkout, lead form, phone call, email, free audit, demo, consultation.
+7. Current visibility: SEO pages, blog, Google Business Profile hints, social profiles, marketplaces, directories, content channels.
+8. Competitor discovery query set: generated from inferred category, location, service phrases, audience language, and commercial modifiers.
+
+Every inferred field must be tagged:
+
+```text
+confidence: high | medium | low
+source: website | search | competitor | directory | assumption
+```
+
+## Workflow Overview
+
+```text
+1. Intake
+   Input only the customer website when possible.
+
+2. Website Understanding
+   Crawl/scrape the site, extract pages, offers, metadata, schema, services, contact details, social links, and funnel elements.
+
+3. Context Inference
+   Infer country, market, business model, language, likely buyer, current offer, and goal hypotheses.
+
+4. Competitor Discovery
+   Search for direct, local, SEO, ad-like, directory, marketplace, and substitute competitors.
+
+5. Competitor Analysis
+   Analyze positioning, pricing signals, messaging, guarantees, trust proof, landing pages, content, lead magnets, reviews, and conversion path.
+
+6. Customer Voice Research
+   Extract customer language, pains, objections, triggers, comparisons, review patterns, and buying criteria.
+
+7. Offer Diagnosis
+   Compare the customer's offer against market language and competitor promises. Generate stronger offer angles.
+
+8. Funnel / Website Audit
+   Diagnose conversion blockers: unclear first screen, weak CTA, missing proof, friction, poor mobile flow, slow pages, weak service pages, bad forms.
+
+9. Distribution Map
+   Recommend channels based on business model and geography: SEO, local SEO, Google Business Profile, cold B2B outreach, directories, partnerships, communities, content, paid search, retargeting, marketplaces.
+
+10. Lead / Account Research
+   For B2B and local-service-compatible use cases, propose legally usable lead sources and lead qualification criteria. Do not auto-contact.
+
+11. Prioritized Growth Plan
+   Output quick wins, 30-day tests, mid-term build items, do-not-do list, and validation metrics.
+```
+
+## Output Contract
+
+The final report should be concise enough for a business owner but structured enough for execution.
+
+Required sections:
+
+1. **Executive Diagnosis** — what likely blocks growth now.
+2. **Inferred Business Context** — company, geography, market, audience, business model, confidence levels.
+3. **Competitor Map** — direct competitors, SEO competitors, substitute competitors, directories/marketplaces.
+4. **Competitor Patterns** — offers, promises, pricing signals, trust proof, funnel patterns.
+5. **Customer Voice** — pains, objections, desired outcomes, exact market language.
+6. **Offer Doctor** — weak points in the current offer and stronger offer variants.
+7. **Website / Funnel Audit** — conversion issues and fixes.
+8. **Distribution Opportunities** — channels ranked by fit, effort, speed, and likely impact.
+9. **Lead Strategy** — who to target first and why; no automated outreach unless separately approved.
+10. **30-Day Action Plan** — prioritized actions with expected evidence to collect.
+11. **Risks / Assumptions / Unknowns** — what needs verification.
+
+## Available Skills
+
+- `skills/commercial-intelligence-research/SKILL.md` — commercial research, competitor analysis, market diagnosis, offer/funnel/channel recommendations.
+
+## Available Commands
+
+- `commands/run-commercial-intelligence-audit.md` — run the explicit audit workflow from a website or short customer description.
+
+## Connector Requirements
+
+Declared in `connectors.json`.
+
+Important: connectors are capability declarations only. This module must never assume API keys, private data access, browser execution, or write permissions are available until verified at runtime.
+
+## Evidence / Source Pattern
+
+This module adapts patterns from:
+
+- Project Execution OS reuse-first and research standards;
+- WAT-style separation: workflows, agents, deterministic tools;
+- Firecrawl / Tavily / Apify-style web data acquisition;
+- LangGraph / CrewAI-style agent orchestration;
+- public donor repos for competitor reports, lead enrichment, contractor sales intelligence, and SEO audit flows.
+
+See `references/sources.md`.
+
+## Status
+
+`candidate`.
+
+This module is drafted but not yet validated on a real customer website.
+
+## Validation Record
+
+No validation run has been completed yet.
+
+First validation target:
+
+```text
+Input: one customer website only.
+Expected result: first usable commercial intelligence report with explicit assumptions, competitor map, offer diagnosis, channel plan, and 30-day actions.
+```

--- a/agent-modules/commercial-intelligence-agent/commands/run-commercial-intelligence-audit.md
+++ b/agent-modules/commercial-intelligence-agent/commands/run-commercial-intelligence-audit.md
@@ -1,0 +1,143 @@
+---
+description: Run a commercial intelligence audit from a customer website or short customer description.
+argument-hint: "<customer website URL> [optional: country, niche, competitors, goal]"
+status: candidate
+version: 0.1.0
+---
+
+# /run-commercial-intelligence-audit
+
+## Purpose
+
+Run a minimal-input commercial intelligence audit for a customer or prospect.
+
+Primary goal:
+
+```text
+Find what can most plausibly improve the customer's leads, replies, calls, conversions, sales, or revenue.
+```
+
+## Usage
+
+Preferred input:
+
+```text
+/run-commercial-intelligence-audit https://example.com
+```
+
+Optional richer input:
+
+```text
+/run-commercial-intelligence-audit https://example.com country=US goal="more local service leads" known_competitors="competitor1.com, competitor2.com"
+```
+
+## Preconditions
+
+At least one of the following must be available:
+
+- customer website URL;
+- customer name + market + country;
+- short business description + market + country.
+
+If only a website is provided, the workflow must infer everything possible and label confidence.
+
+## Workflow
+
+1. **Normalize input**
+   - Validate URL.
+   - Resolve homepage.
+   - Record missing optional data.
+
+2. **Extract customer website**
+   - Crawl/scrape key pages.
+   - Extract offer, services/products, CTAs, proof, contact details, language, geography, and funnel path.
+
+3. **Infer business context**
+   - Infer company identity, country, city/region, business model, target audience, offer type, and main conversion path.
+   - Mark confidence for every inferred field.
+
+4. **Generate search plan**
+   - Create competitor discovery queries.
+   - Create customer-voice queries.
+   - Create distribution-channel queries.
+   - Create SEO/content opportunity queries.
+
+5. **Discover competitors**
+   - Collect direct competitors.
+   - Collect SEO competitors.
+   - Collect directory/marketplace competitors.
+   - Collect substitute solutions.
+
+6. **Analyze competitors**
+   - Extract positioning, offers, promises, pricing signals, proof, guarantees, funnel, and content patterns.
+   - Identify what to adapt and what not to copy.
+
+7. **Research customer voice**
+   - Extract pains, objections, vocabulary, desired outcomes, buying triggers, and complaints.
+
+8. **Diagnose offer and funnel**
+   - Identify weak message, weak proof, weak CTA, weak service pages, missing comparison pages, and conversion blockers.
+
+9. **Recommend distribution**
+   - Rank channels by fit, speed, effort, and likely impact.
+   - Prioritize channels that match the inferred business model.
+
+10. **Create action plan**
+    - Quick wins.
+    - 30-day experiments.
+    - Mid-term build tasks.
+    - Do-not-do list.
+    - Validation metrics.
+
+## Output Contract
+
+Return:
+
+```markdown
+# Commercial Intelligence Report — <customer/domain>
+
+## Input Received
+
+## Inference Summary
+
+## Executive Diagnosis
+
+## Competitor Map
+
+## Competitor Patterns
+
+## Customer Voice
+
+## Offer Doctor
+
+## Website / Funnel Audit
+
+## Distribution Opportunities
+
+## Lead Strategy
+
+## 30-Day Action Plan
+
+## Assumptions / Unknowns / Risks
+
+## Suggested Next Test
+```
+
+## Stop Conditions
+
+Stop and return a partial report when:
+
+- the website is unreachable;
+- the site contains too little public information;
+- the inferred geography remains low confidence after search;
+- no relevant competitors can be found;
+- sources require login or private access;
+- data collection would cross compliance or ethical boundaries.
+
+## Related Skills
+
+- `commercial-intelligence-research`
+
+## Validation Status
+
+`candidate` — this command must be validated on a real customer website before promotion.

--- a/agent-modules/commercial-intelligence-agent/connectors.json
+++ b/agent-modules/commercial-intelligence-agent/connectors.json
@@ -1,0 +1,44 @@
+{
+  "connectors": [
+    {
+      "name": "web_search",
+      "purpose": "Discover competitors, market language, customer voice, distribution channels, SEO opportunities, and public evidence.",
+      "required": true,
+      "access_assumption": "must_be_verified_at_runtime"
+    },
+    {
+      "name": "website_scraper_or_crawler",
+      "purpose": "Extract customer and competitor website content, metadata, links, CTAs, structured data, and page text.",
+      "required": true,
+      "access_assumption": "must_be_verified_at_runtime",
+      "candidate_tools": ["Firecrawl", "Tavily Extract/Crawl", "Apify Actors", "Playwright", "BeautifulSoup"]
+    },
+    {
+      "name": "browser_automation",
+      "purpose": "Inspect JavaScript-rendered pages, forms, search results, competitor pages, screenshots, and dynamic content when simple extraction is insufficient.",
+      "required": false,
+      "access_assumption": "must_be_verified_at_runtime",
+      "candidate_tools": ["Playwright", "Apify Actors", "Firecrawl Interact"]
+    },
+    {
+      "name": "structured_storage",
+      "purpose": "Store extracted customer, competitor, lead, source, and report evidence for repeatable runs and comparisons.",
+      "required": false,
+      "access_assumption": "must_be_verified_at_runtime",
+      "candidate_tools": ["SQLite", "PostgreSQL", "Google Sheets"]
+    },
+    {
+      "name": "report_export",
+      "purpose": "Export client-ready outputs as Markdown, HTML, PDF, CSV, or dashboard views.",
+      "required": false,
+      "access_assumption": "must_be_verified_at_runtime",
+      "candidate_tools": ["Markdown", "HTML", "PDF generator", "Google Sheets", "FastAPI dashboard"]
+    },
+    {
+      "name": "github",
+      "purpose": "Read or write versioned module artifacts and Codex handoff packets when authorized.",
+      "required": false,
+      "access_assumption": "must_be_verified_at_runtime"
+    }
+  ]
+}

--- a/agent-modules/commercial-intelligence-agent/examples/minimal-input-example.md
+++ b/agent-modules/commercial-intelligence-agent/examples/minimal-input-example.md
@@ -1,0 +1,95 @@
+# Minimal Input Example
+
+## Input
+
+```text
+customer_website: https://example.com
+```
+
+No other customer information is provided.
+
+## Expected Behavior
+
+The module should not ask a long questionnaire first.
+
+It should infer what it can, label uncertainty, then proceed with the smallest useful research run.
+
+## Inference Fields
+
+```text
+company_name: inferred from website title/logo/schema/contact page
+country: inferred from address/phone/TLD/language/currency/legal pages/search results
+city_or_region: inferred from contact page/service area/map links/search snippets
+language: inferred from page text/hreflang
+business_model: inferred from product/service pages and conversion path
+target_customer: inferred from messaging, use cases, testimonials, pricing, audience words
+main_offer: inferred from homepage and service/product pages
+conversion_goal: inferred from CTA/form/phone/booking/checkout
+known_competitors: discovered through search, directories, and market queries
+```
+
+## Expected Report Sections
+
+```markdown
+# Commercial Intelligence Report — example.com
+
+## 1. Executive Diagnosis
+The clearest likely sales blocker is ...
+
+## 2. Inferred Business Context
+| Field | Value | Confidence | Source | Note |
+
+## 3. Competitor Map
+| Competitor | Type | Why relevant | Key strength | Weakness | Source |
+
+## 4. Competitor Patterns Worth Adapting
+
+## 5. Customer Voice
+
+## 6. Offer Doctor
+
+## 7. Website / Funnel Audit
+
+## 8. Distribution Opportunities
+
+## 9. Lead Strategy
+
+## 10. 30-Day Action Plan
+
+## 11. Assumptions, Risks, Unknowns
+```
+
+## Good Output
+
+A good output is specific and action-ready:
+
+```text
+Your homepage says what you do, but not why this buyer should choose you now.
+Top competitors promise fixed timelines, visible proof, and a low-friction quote path.
+Your first 30-day test should be: rebuild the first screen offer, create 3 service pages, add proof blocks, and test a direct outreach list of 50 qualified accounts.
+```
+
+## Bad Output
+
+A bad output is generic:
+
+```text
+Improve SEO, post more content, use social media, and optimize your website.
+```
+
+## Validation Notes Template
+
+After a real run, record:
+
+```text
+run_date:
+website:
+what_was_inferred_correctly:
+what_was_inferred_wrong:
+best_sources:
+worst_sources:
+most_useful_report_section:
+least_useful_report_section:
+next_module_change:
+status_after_run: candidate | tested
+```

--- a/agent-modules/commercial-intelligence-agent/handoff-contracts/build-mvp.md
+++ b/agent-modules/commercial-intelligence-agent/handoff-contracts/build-mvp.md
@@ -1,0 +1,307 @@
+# Codex Handoff Contract — Build Commercial Intelligence Agent MVP
+
+Packet Type: Implementation handoff contract
+Status: candidate
+
+## Objective
+
+Build the first runnable MVP for the Commercial Intelligence Agent.
+
+The MVP must accept minimal input — preferably a single customer website URL — infer business context, discover competitors, analyze the customer's offer/funnel/visibility, and produce a Markdown report plus structured JSON output.
+
+## Source Decision / Design
+
+Use the candidate module in:
+
+```text
+agent-modules/commercial-intelligence-agent/
+```
+
+Required source docs:
+
+```text
+agent-modules/commercial-intelligence-agent/README.md
+agent-modules/commercial-intelligence-agent/skills/commercial-intelligence-research/SKILL.md
+agent-modules/commercial-intelligence-agent/commands/run-commercial-intelligence-audit.md
+agent-modules/commercial-intelligence-agent/references/sources.md
+docs/EXISTING_SOLUTION_FIRST_STANDARD.md
+docs/RESEARCH_STANDARD.md
+docs/CODEX_HANDOFF_STANDARD.md
+```
+
+## Allowed Scope
+
+Create an MVP in a new bounded project folder or approved module subfolder selected by the maintainer.
+
+Preferred MVP scope:
+
+```text
+commercial-intelligence-mvp/
+├── README.md
+├── AGENTS.md
+├── PROJECT.md
+├── .env.example
+├── requirements.txt
+├── src/
+│   ├── cli.py
+│   ├── models.py
+│   ├── extract_site.py
+│   ├── infer_context.py
+│   ├── discover_competitors.py
+│   ├── analyze_competitors.py
+│   ├── diagnose_offer.py
+│   ├── plan_distribution.py
+│   └── render_report.py
+├── examples/
+│   └── sample_input.json
+├── reports/
+│   └── .gitkeep
+└── tests/
+    └── test_models.py
+```
+
+If Project Execution OS requires a different folder location, follow the current repository standard and record the decision.
+
+## Out Of Scope
+
+Do not build:
+
+- a SaaS app;
+- payments;
+- login/accounts;
+- autonomous outreach;
+- CRM sync;
+- email sending;
+- browser stealth bypass as a default;
+- uncontrolled scraping of private data;
+- a huge multi-agent runtime;
+- vector database unless proven necessary;
+- production dashboard in v1.
+
+## Repository Context
+
+Repository:
+
+```text
+oleg3479881328-code/Project-Execution-OS
+```
+
+This handoff must follow Project Execution OS rules.
+
+## Files Allowed To Change
+
+Allowed:
+
+```text
+agent-modules/commercial-intelligence-agent/**
+commercial-intelligence-mvp/**
+```
+
+Optional only if repository standards require indexing:
+
+```text
+indexes/**
+PROJECT_INDEX.md
+CHANGELOG.md
+```
+
+## Forbidden Changes
+
+Do not modify unrelated Project Execution OS standards.
+Do not change global routing rules.
+Do not rename existing folders.
+Do not add secrets.
+Do not commit API keys.
+Do not claim validation unless commands were run.
+
+## Existing Solution Search Required
+
+Yes.
+
+Before implementation, inspect and record adaptation decisions for:
+
+- Firecrawl docs/API or SDK if used;
+- Tavily docs/API or SDK if used;
+- Apify Actors / Crawlee only if chosen;
+- LangGraph or CrewAI only if orchestration is actually needed;
+- donor repos listed in `references/sources.md`;
+- simple Python alternatives before heavy frameworks.
+
+Use the smallest adequate solution.
+
+Recommended v1 default:
+
+```text
+Python CLI + Pydantic models + requests/BeautifulSoup or Firecrawl/Tavily adapter + Markdown/JSON report.
+```
+
+Do not choose LangGraph or CrewAI for v1 unless there is a concrete stateful workflow need.
+
+## Implementation Instructions
+
+### 1. Build CLI
+
+Command shape:
+
+```bash
+python -m src.cli audit --url https://example.com --out reports/example
+```
+
+Optional arguments:
+
+```bash
+--country
+--language
+--known-competitor
+--goal
+--max-competitors
+--no-web
+```
+
+### 2. Data Models
+
+Create Pydantic models for:
+
+- CustomerInput;
+- ExtractedWebsite;
+- InferredContext;
+- CompetitorCandidate;
+- CompetitorAnalysis;
+- CustomerVoiceFinding;
+- OfferDiagnosis;
+- FunnelIssue;
+- DistributionOpportunity;
+- GrowthAction;
+- CommercialIntelligenceReport.
+
+Every inferred field must carry confidence and source.
+
+### 3. Website Extraction
+
+Implement a simple extraction layer:
+
+- homepage fetch;
+- title/meta/headings extraction;
+- links extraction;
+- contact and service page detection;
+- CTA detection using simple patterns;
+- schema/JSON-LD extraction when present;
+- language/country/currency/phone/address hints.
+
+Support adapter interface so Firecrawl/Tavily can replace simple extraction later.
+
+### 4. Context Inference
+
+Infer:
+
+- company name;
+- country;
+- region/city;
+- language;
+- business model;
+- main offer;
+- likely target customer;
+- conversion goal.
+
+Label each field with confidence and evidence.
+
+### 5. Competitor Discovery
+
+If web search API key is available, use it.
+If not, create query plan and mark competitor discovery as not executed.
+
+Do not fake search results.
+
+### 6. Analysis
+
+Generate structured analysis from extracted website and competitor evidence.
+
+For v1, acceptable implementation:
+
+- deterministic heuristics first;
+- optional LLM call only if API key is present;
+- no claim of full market coverage.
+
+### 7. Report Rendering
+
+Output:
+
+```text
+report.md
+report.json
+sources.json
+```
+
+Markdown report must follow the command output contract.
+
+### 8. Logging
+
+Log:
+
+- input;
+- sources attempted;
+- sources succeeded/failed;
+- assumptions;
+- API usage if available;
+- execution timestamp.
+
+## Execution Mode
+
+- Begin implementation immediately.
+- Do not pause for optional clarification questions before starting work.
+- Resolve minor, reversible ambiguity with the smallest reasonable implementation and record assumptions.
+- Ask only if a real blocker prevents safe execution.
+
+## Acceptance Criteria
+
+- The MVP accepts a URL from the command line.
+- It creates `report.md`, `report.json`, and `sources.json`.
+- It does not fabricate executed web searches when no search connector/key exists.
+- It infers at least company name, likely country/language when evidence exists, business model hypothesis, and conversion goal hypothesis.
+- It produces a competitor query plan even when live competitor discovery is unavailable.
+- It separates confirmed facts, assumptions, recommendations, and risks.
+- It includes tests for model validation and confidence/source tagging.
+- It includes `.env.example` with no secrets.
+- README explains setup, run command, limitations, and next steps.
+
+## Validation Commands / Checks
+
+Run what applies:
+
+```bash
+python -m compileall src
+pytest
+python -m src.cli audit --url https://example.com --out reports/example --no-web
+```
+
+If network/API validation is unavailable, state that clearly in the execution report.
+
+## Rollback Notes
+
+The MVP should be removable by deleting:
+
+```text
+commercial-intelligence-mvp/
+```
+
+Do not couple it to global Project Execution OS runtime.
+
+## Execution Report Contract
+
+Return:
+
+```text
+EXECUTION REPORT
+
+Status:
+Files Changed:
+Existing Solutions Checked:
+Solution Reused Or Adapted:
+Why Custom Implementation Was Necessary:
+Validation Performed:
+Validation Not Performed:
+Blockers:
+Assumptions Made:
+Risks / Follow-Up:
+Ready For Review: Yes / No
+```

--- a/agent-modules/commercial-intelligence-agent/module.json
+++ b/agent-modules/commercial-intelligence-agent/module.json
@@ -1,0 +1,29 @@
+{
+  "name": "commercial-intelligence-agent",
+  "version": "0.1.0",
+  "status": "candidate",
+  "description": "Minimal-input commercial intelligence module that turns a customer website into competitor, market, offer, funnel, SEO, lead, and sales-growth recommendations.",
+  "source_patterns": [
+    "https://github.com/asadcs/ai-competitor-analysis-agent-workflow",
+    "https://github.com/sneha1012/prospector-ai",
+    "https://github.com/GURPREETKAURJETHRA/AI-Lead-Generation-Agent",
+    "https://github.com/aman-ali65/AURA-SEO-Intelligence-Agent",
+    "https://docs.firecrawl.dev/introduction",
+    "https://docs.tavily.com/welcome",
+    "https://docs.apify.com/platform/actors",
+    "https://docs.langchain.com/oss/python/langgraph/overview",
+    "https://docs.crewai.com/"
+  ],
+  "owners": ["Oleg Povalyukhin"],
+  "applies_to": ["Project Execution OS", "commercial research", "sales growth diagnostics", "agent product discovery"],
+  "skills": [
+    "skills/commercial-intelligence-research/SKILL.md"
+  ],
+  "commands": [
+    "commands/run-commercial-intelligence-audit.md"
+  ],
+  "connectors_file": "connectors.json",
+  "handoff_contracts": [
+    "handoff-contracts/build-mvp.md"
+  ]
+}

--- a/agent-modules/commercial-intelligence-agent/references/sources.md
+++ b/agent-modules/commercial-intelligence-agent/references/sources.md
@@ -1,0 +1,301 @@
+# Sources — Commercial Intelligence Agent
+
+Inspected date: 2026-06-20
+Status: candidate evidence, not validation evidence
+
+## Project Execution OS standards used
+
+### Start New Project
+
+URL: https://github.com/oleg3479881328-code/Project-Execution-OS/blob/main/Start%20New%20Project.md
+
+Pattern used:
+
+- classify the work before expanding into a project;
+- do not restart a questionnaire when the idea is already clear;
+- route into the lightest correct path.
+
+### Project Lifecycle Model
+
+URL: https://github.com/oleg3479881328-code/Project-Execution-OS/blob/main/docs/PROJECT_LIFECYCLE_MODEL.md
+
+Pattern used:
+
+- ChatGPT performs research, comparison, classification, architecture reasoning, and decision preparation;
+- Codex performs bounded technical execution only after the decision is clear;
+- do not spend Codex on open-ended thinking.
+
+### Existing Solution First Standard
+
+URL: https://github.com/oleg3479881328-code/Project-Execution-OS/blob/main/docs/EXISTING_SOLUTION_FIRST_STANDARD.md
+
+Pattern used:
+
+- search before invention;
+- adapt before rebuilding;
+- build from scratch only when no adequate donor exists or adaptation is worse.
+
+### Research Standard
+
+URL: https://github.com/oleg3479881328-code/Project-Execution-OS/blob/main/docs/RESEARCH_STANDARD.md
+
+Pattern used:
+
+- separate confirmed facts, donor solutions, assumptions, recommendations, custom work, and risks;
+- use publicly verifiable external sources before new synthesis.
+
+### Agent Module Format Standard
+
+URL: https://github.com/oleg3479881328-code/Project-Execution-OS/blob/main/docs/AGENT_MODULE_FORMAT_STANDARD.md
+
+Pattern used:
+
+- file-based reusable module;
+- manifest + README + skills + commands + connectors + references + handoff contracts;
+- candidate status until real validation.
+
+## Donor repositories checked
+
+### asadcs/ai-competitor-analysis-agent-workflow
+
+URL: https://github.com/asadcs/ai-competitor-analysis-agent-workflow
+
+Observed pattern:
+
+- modular architecture for competitor research;
+- competitor discovery;
+- positioning, pricing, and messaging analysis;
+- opportunity and gap identification;
+- branded report generation;
+- monthly monitoring idea;
+- WAT separation: Workflows, Agents, Tools.
+
+Adapted:
+
+- WAT-style separation into workflow/skill/command/tool responsibilities;
+- branded report as an optional later output;
+- competitor discovery and opportunity/gap sections.
+
+Not copied:
+
+- exact wording;
+- project-specific structure;
+- branding implementation details;
+- any unvalidated execution claims.
+
+### sneha1012/prospector-ai
+
+URL: https://github.com/sneha1012/prospector-ai
+
+Observed pattern:
+
+- end-to-end B2B sales intelligence pipeline;
+- scrape -> store -> enrich -> serve architecture;
+- SQLite storage;
+- FastAPI dashboard;
+- structured lead scoring and recommended actions;
+- demo mode and audit trail concepts.
+
+Adapted:
+
+- pipeline stages as a future MVP architecture;
+- structured lead scoring and insight schema;
+- store/enrich/report loop;
+- separation between data acquisition and AI enrichment.
+
+Not copied:
+
+- contractor-specific data model;
+- stealth scraping assumptions;
+- industry-specific prompts;
+- implementation claims without local validation.
+
+### GURPREETKAURJETHRA/AI-Lead-Generation-Agent
+
+URL: https://github.com/GURPREETKAURJETHRA/AI-Lead-Generation-Agent
+
+Observed pattern:
+
+- lead generation from public discussions;
+- Firecrawl extraction;
+- agent orchestration;
+- Google Sheets output;
+- lead qualification with LLM.
+
+Adapted:
+
+- public-discussion lead discovery pattern;
+- structured lead output;
+- Google Sheets as optional lightweight output;
+- qualification criteria concept.
+
+Not copied:
+
+- Quora-only source assumption;
+- autonomous lead contacting;
+- any spam workflow;
+- API key setup details.
+
+### aman-ali65/AURA-SEO-Intelligence-Agent
+
+URL: https://github.com/aman-ali65/AURA-SEO-Intelligence-Agent
+
+Observed pattern:
+
+- website SEO audit from URL;
+- title/meta/headings/link/image extraction;
+- competitor-style search discovery;
+- PageSpeed/performance checks;
+- PDF reporting.
+
+Adapted:
+
+- website audit coverage;
+- SEO + competitor discovery combination;
+- report export as optional future capability.
+
+Not copied:
+
+- exact code stack;
+- Gemini-specific dependency;
+- CLI-only behavior;
+- PDF generation implementation.
+
+## Tool/platform donors checked
+
+### Firecrawl
+
+URL: https://docs.firecrawl.dev/introduction
+
+Observed capability:
+
+- search the web;
+- scrape pages into markdown/HTML/structured JSON;
+- interact with pages;
+- map/crawl websites;
+- agent and MCP support;
+- LLM-ready output, JS rendering, dynamic content handling.
+
+Candidate use:
+
+- customer website extraction;
+- competitor page extraction;
+- search + scrape pipeline;
+- dynamic page inspection when simple scraping fails.
+
+### Tavily
+
+URL: https://docs.tavily.com/welcome
+
+Observed capability:
+
+- web search;
+- extract webpages;
+- crawl webpages;
+- map webpages;
+- create research tasks;
+- Python and JavaScript SDKs.
+
+Candidate use:
+
+- competitor discovery;
+- customer voice research;
+- topic/market research;
+- quick search-to-evidence pipeline.
+
+### Apify Actors
+
+URL: https://docs.apify.com/platform/actors
+
+Observed capability:
+
+- serverless programs for workflow automation, scraping, browser automation, and data processing;
+- structured JSON input/output;
+- manual, API, scheduled, and composed runs;
+- storage, schemas, and Actor Store.
+
+Candidate use:
+
+- reusable scraping/extraction actors;
+- scheduled monitoring;
+- marketplace/directory crawling;
+- future packaged scraping tools.
+
+### LangGraph
+
+URL: https://docs.langchain.com/oss/python/langgraph/overview
+
+Observed capability:
+
+- low-level orchestration framework for long-running, stateful agents;
+- durable execution;
+- streaming;
+- human-in-the-loop;
+- memory and persistence;
+- observability with LangSmith.
+
+Candidate use:
+
+- stateful research workflow;
+- resumable multi-step commercial intelligence runs;
+- human review gates before risky lead/outreach steps.
+
+### CrewAI
+
+URL: https://docs.crewai.com/
+
+Observed capability:
+
+- collaborative AI agents, crews, and flows;
+- guardrails, memory, knowledge, observability;
+- agents, tasks, processes, human-in-the-loop triggers;
+- enterprise integrations.
+
+Candidate use:
+
+- simpler multi-agent prototype;
+- role-based specialist agents: market researcher, competitor analyst, offer doctor, funnel auditor, lead strategist.
+
+## Adaptation decision
+
+Do not copy a full donor repo directly.
+
+Recommended architecture:
+
+```text
+Commercial Intelligence Agent Module
+→ explicit audit command
+→ commercial research skill
+→ deterministic extraction/storage/reporting tools later
+→ Codex handoff only after module shape is accepted
+```
+
+Future implementation should borrow:
+
+- WAT separation from `ai-competitor-analysis-agent-workflow`;
+- scrape/store/enrich/serve pipeline from `prospector-ai`;
+- lead qualification and Google Sheets output pattern from `AI-Lead-Generation-Agent`;
+- SEO audit coverage from `AURA-SEO-Intelligence-Agent`;
+- extraction/crawl/search capabilities from Firecrawl/Tavily/Apify;
+- stateful orchestration from LangGraph or simpler role orchestration from CrewAI.
+
+## Risks
+
+- Search and scraping results can become stale.
+- Competitor discovery quality depends on geography inference.
+- Minimal input can create false assumptions; confidence tagging is mandatory.
+- Lead research can become spammy if not bounded; no auto-contact by default.
+- Some sites prohibit scraping; tool use must respect applicable terms and law.
+- Paid APIs may create hidden cost; MVP must include cost logging.
+- LLM reports can sound confident without evidence; all claims need source tagging.
+
+## Next validation target
+
+Use one real customer website and produce a complete first report.
+Record:
+
+- what was inferred correctly;
+- what was wrong or low confidence;
+- which sources were actually useful;
+- what sections of the report produced action-ready insight;
+- what should be removed from the module as bloat.

--- a/agent-modules/commercial-intelligence-agent/skills/commercial-intelligence-research/SKILL.md
+++ b/agent-modules/commercial-intelligence-agent/skills/commercial-intelligence-research/SKILL.md
@@ -1,0 +1,340 @@
+---
+name: commercial-intelligence-research
+description: Use when a task asks to analyze a customer, website, niche, market, competitor set, sales growth, offers, leads, SEO, funnel, or distribution using minimal input such as a single website URL.
+status: candidate
+version: 0.1.0
+scope: commercial research and sales-growth diagnosis
+---
+
+# Commercial Intelligence Research
+
+## Purpose
+
+Produce a practical commercial intelligence diagnosis from minimal customer input, ideally a website URL.
+
+The skill converts web research and market evidence into prioritized recommendations for improving leads, replies, calls, conversions, sales, or revenue.
+
+## Use When
+
+Use this skill when the task includes one or more of:
+
+- customer website analysis;
+- competitor research;
+- market research for sales growth;
+- offer improvement;
+- funnel or landing-page diagnosis;
+- lead or account research;
+- SEO / local SEO / AI visibility recommendations;
+- distribution-channel selection;
+- growth plan creation.
+
+## Do Not Use When
+
+Do not use this skill when:
+
+- the user only wants a short opinion without research;
+- the task is pure creative copywriting;
+- the requested action is automated spam or non-compliant scraping;
+- the output would require private data that is not available;
+- the task is high-stakes advice outside commercial growth;
+- the user expects guaranteed sales results.
+
+## Inputs Required
+
+Minimum:
+
+```text
+customer_website
+```
+
+Optional:
+
+```text
+known_country
+known_region_or_city
+known_language
+known_competitors
+known_offer
+known_target_customer
+known_goal
+known_budget
+known_constraints
+```
+
+When optional data is missing, infer it and label the confidence.
+
+## Workflow
+
+### 1. Normalize Input
+
+- Clean the URL.
+- Resolve the domain.
+- Identify homepage, main navigation, service/product pages, pricing pages, contact pages, blog/resources, case studies, reviews/testimonials, legal pages, and social links.
+
+### 2. Website Extraction
+
+Extract and structure:
+
+- page titles and meta descriptions;
+- H1/H2 headings;
+- product/service names;
+- offer claims;
+- CTAs;
+- proof elements;
+- testimonials/reviews;
+- pricing or quote signals;
+- lead forms and booking/contact paths;
+- phone, email, address, maps, service areas;
+- schema.org markup when available;
+- language, currency, hreflang, TLD, legal/compliance signals.
+
+### 3. Context Inference
+
+Infer:
+
+- country / region / city;
+- language and customer geography;
+- business model;
+- audience segments;
+- likely purchase intent;
+- main conversion action;
+- primary revenue path;
+- likely sales cycle.
+
+Tag each inference:
+
+```text
+field:
+value:
+confidence: high | medium | low
+source:
+reasoning_note:
+```
+
+### 4. Competitor Discovery
+
+Generate competitor searches from:
+
+- inferred service/product category;
+- region/city/country;
+- customer language;
+- commercial modifiers: price, best, near me, agency, service, provider, software, alternative, reviews, comparison;
+- competitor pages and directories surfaced from search results.
+
+Competitor classes:
+
+- direct competitors;
+- SEO competitors;
+- local competitors;
+- paid-search-like competitors;
+- directory / marketplace competitors;
+- substitute solutions.
+
+### 5. Competitor Analysis
+
+For each useful competitor, extract:
+
+- positioning;
+- headline / first-screen promise;
+- offer structure;
+- pricing signals;
+- guarantees / risk reversal;
+- trust proof;
+- case studies;
+- reviews;
+- CTA path;
+- lead magnet;
+- content/SEO structure;
+- obvious strengths;
+- obvious weaknesses;
+- ideas worth adapting;
+- ideas not worth copying.
+
+### 6. Customer Voice Research
+
+Search for market language and buyer pain through:
+
+- reviews;
+- comments;
+- forums;
+- Reddit/Quora when relevant;
+- niche communities;
+- directories;
+- social profiles;
+- marketplace reviews;
+- competitor testimonials;
+- search snippets and People Also Ask-style questions.
+
+Extract:
+
+- pains;
+- desired outcomes;
+- objections;
+- decision criteria;
+- trust concerns;
+- vocabulary;
+- repeated complaints;
+- emotional triggers;
+- urgent purchase triggers.
+
+### 7. Offer Diagnosis
+
+Evaluate the customer's offer against market evidence:
+
+- Is the target buyer clear?
+- Is the result concrete?
+- Is the proof strong?
+- Is the risk reduced?
+- Is there a reason to act now?
+- Is the differentiator real?
+- Does the offer match how customers describe the problem?
+- Is the CTA aligned with purchase intent?
+
+Generate:
+
+- 5 stronger offer angles;
+- 5 headline variants;
+- 5 CTA variants;
+- trust-proof improvements;
+- guarantee or risk-reversal ideas when appropriate.
+
+### 8. Funnel / Website Audit
+
+Diagnose:
+
+- first-screen clarity;
+- conversion path;
+- CTA visibility;
+- page hierarchy;
+- mobile friction;
+- lead form friction;
+- missing proof;
+- missing pricing/range clarity;
+- weak local trust;
+- poor service-page structure;
+- missing comparison/content pages;
+- slow or technically weak pages when performance data is available.
+
+### 9. Distribution Recommendation
+
+Rank channels by fit, speed, effort, and likely impact.
+
+Channel classes:
+
+- local SEO / Google Business Profile;
+- SEO service pages;
+- comparison pages;
+- programmatic directory pages;
+- cold B2B outreach;
+- partnerships;
+- marketplace/directory listing optimization;
+- content engine;
+- short video;
+- paid search;
+- retargeting;
+- LinkedIn / Telegram / Reddit / VC / niche communities;
+- email nurture;
+- referral loops.
+
+### 10. Lead Strategy
+
+For B2B-compatible businesses, propose:
+
+- ideal customer profile;
+- lead-source categories;
+- qualification signals;
+- disqualification signals;
+- first-contact angle;
+- CSV fields for lead list;
+- compliance limits.
+
+Do not auto-contact leads. Do not collect sensitive personal data unless explicitly permitted and lawful.
+
+### 11. Prioritize Actions
+
+Use a simple scoring table:
+
+```text
+impact: 1-5
+effort: 1-5
+speed: 1-5
+confidence: 1-5
+priority_score = impact + speed + confidence - effort
+```
+
+Output:
+
+- quick wins;
+- 30-day experiments;
+- mid-term build tasks;
+- do-not-do list;
+- validation metrics.
+
+## Output Contract
+
+Return this structure:
+
+```markdown
+# Commercial Intelligence Report
+
+## 1. Executive Diagnosis
+
+## 2. Inferred Business Context
+| Field | Value | Confidence | Source | Note |
+
+## 3. Competitor Map
+| Competitor | Type | Why relevant | Key strength | Weakness | Source |
+
+## 4. Competitor Patterns Worth Adapting
+
+## 5. Customer Voice
+| Theme | Evidence | Exact language / paraphrase | Sales implication |
+
+## 6. Offer Doctor
+### Current Offer Problems
+### Stronger Offer Angles
+### Headline / CTA Ideas
+
+## 7. Website / Funnel Audit
+| Issue | Why it hurts sales | Fix | Priority |
+
+## 8. Distribution Opportunities
+| Channel | Fit | Why now | First test | Priority |
+
+## 9. Lead Strategy
+
+## 10. 30-Day Action Plan
+| Week | Action | Owner | Evidence to collect |
+
+## 11. Assumptions, Risks, Unknowns
+```
+
+## Constraints and Stop Conditions
+
+Stop or downgrade output when:
+
+- the website cannot be reached and no alternate source exists;
+- the geography cannot be inferred with at least medium confidence;
+- competitor discovery returns irrelevant results;
+- the niche is regulated and recommendations require legal/compliance review;
+- data sources forbid extraction or access;
+- the report would rely mostly on assumptions.
+
+Always separate:
+
+- confirmed facts;
+- assumptions;
+- recommendations;
+- risks.
+
+Do not claim a tool was used unless it actually was used.
+Do not claim research is complete when only a small sample was checked.
+Do not promise revenue growth.
+
+## Evidence / References
+
+See `../../references/sources.md`.
+
+## Validation Status
+
+`candidate` — not yet validated on a real customer website.


### PR DESCRIPTION
## Purpose

Adds a candidate Project Execution OS agent module for a minimal-input commercial intelligence / sales-growth research agent.

The module is designed for the workflow Oleg described: provide as little as a customer website, then infer country, niche, business model, competitors, offer weaknesses, funnel issues, distribution opportunities, lead strategy, and a 30-day sales-growth action plan.

## What is included

- `module.json` — candidate module manifest.
- `README.md` — module purpose, boundaries, minimal-input inference contract, workflow, output contract.
- `skills/commercial-intelligence-research/SKILL.md` — reusable bounded skill for commercial research and growth diagnosis.
- `commands/run-commercial-intelligence-audit.md` — explicit command workflow from website URL to report.
- `connectors.json` — declared connector needs without assuming credentials or access.
- `references/sources.md` — donor/source research and adaptation decisions.
- `examples/minimal-input-example.md` — example of website-only input and expected behavior.
- `handoff-contracts/build-mvp.md` — bounded Codex implementation contract for a future runnable MVP.

## Reuse-first research summary

Checked and adapted patterns from:

- `asadcs/ai-competitor-analysis-agent-workflow` — WAT-style workflow/agent/tool separation and competitor-report pattern.
- `sneha1012/prospector-ai` — scrape → store → enrich → serve sales-intelligence pipeline.
- `GURPREETKAURJETHRA/AI-Lead-Generation-Agent` — public discussion lead discovery and structured lead output pattern.
- `aman-ali65/AURA-SEO-Intelligence-Agent` — website SEO audit + competitor discovery + report export pattern.
- Firecrawl, Tavily, Apify, LangGraph, CrewAI docs as candidate tool/platform donors.

## Status

Candidate only. Not validated yet on a real customer website.

## Validation

Repository file creation only. No runtime validation was performed because this PR adds a module/spec, not an executable MVP.

## Next step after review

Use `handoff-contracts/build-mvp.md` to hand Codex a bounded implementation task for the first runnable MVP, or first run the module manually on one real customer website and record validation notes.