### PR TITLE
Add harness engineering standard

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -34,14 +34,16 @@
 - Confirmed separate handling for internal subprojects without nested Git by default.
 - Smoke-tested the bootstrap model with temporary project `Test123`; the owner reports that the test project was deleted after validation.
 - Added root `PROJECT_STATE.md` and `logs/latest.md` so this central project complies with its own active continuity standard.
+- Added `docs/HARNESS_ENGINEERING_STANDARD.md` as the architecture wrapper for reusable or operational agent workflows.
 
 ## Current Focus
 
 - Keep the central system internally consistent and transfer-ready after every meaningful change.
+- Apply harness engineering step by step by routing architecture/scaffold questions to `docs/HARNESS_ENGINEERING_STANDARD.md` before quality measurement.
 
 ## Next Practical Step
 
-- Await the owner's next bounded central-system task.
+- Use `docs/HARNESS_ENGINEERING_STANDARD.md` on the next real reusable agent or workflow before promoting it beyond one-off use.
 
 ## Key Decisions And Constraints
 
@@ -51,6 +53,7 @@
 - `PROJECT_INDEX.md` remains an index and must not replace the role of `PROJECT.md`.
 - Local Git is the default bootstrap for real project folders; GitHub, Notion, and Google Drive are attached only when they are actually needed.
 - Active projects must maintain `PROJECT_STATE.md` and `logs/latest.md` after meaningful changes.
+- Harness engineering is the architecture wrapper for reusable agents; `AGENT_QUALITY_SCORECARD_STANDARD.md` measures the resulting workflow after the scaffold is explicit.
 
 ## Read Next
 

--- a/PROJECT_INDEX.md
+++ b/PROJECT_INDEX.md
@@ -72,6 +72,8 @@ Status:
 - `docs/CONTEXT_ASSEMBLY_STANDARD.md`
 - `docs/SYSTEM_CONTEXT_VERSION_STANDARD.md`
 - `docs/API_RUNTIME_COST_CACHE_LOGGING_STANDARD.md`
+- `docs/HARNESS_ENGINEERING_STANDARD.md`
+- `docs/AGENT_QUALITY_SCORECARD_STANDARD.md`
 - `docs/CODEX_HANDOFF_STANDARD.md`
 - `docs/RESEARCH_STANDARD.md`
 - `docs/REVIEW_STANDARD.md`
@@ -165,4 +167,4 @@ The lightweight bootstrap model was smoke-tested with temporary project `Test123
 
 ## Next Required Action
 
-Await the owner's next bounded central-system task.
+Use `docs/HARNESS_ENGINEERING_STANDARD.md` as the architecture wrapper for reusable or operational agent workflows before applying `docs/AGENT_QUALITY_SCORECARD_STANDARD.md` for measurement.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -2,9 +2,9 @@
 project_name: Project Execution OS
 project_mode: compact
 status: transfer_ready
-updated_at: 2026-07-02
+updated_at: 2026-07-06
 source_of_truth: repository
-active_branch: main
+active_branch: harness-engineering-standard-v1
 ---
 
 # PROJECT_STATE.md
@@ -23,22 +23,24 @@ logs/latest.md
 
 ## Latest Confirmed Milestone
 
-- Added `blocks/design/IMPECCABLE_DESIGN_QA_GATE.md` as a candidate reusable design-quality gate for AI-coded frontend work.
-- Updated `blocks/design/BLOCK.md` from `candidate_v2` to `candidate_v3` to include AI-coded frontend QA as part of the Design Block.
-- Updated `docs/ROUTER.md` so Impeccable, AI-slop review, frontend design detector, UI polish/audit after AI coding, and design quality gate requests route directly to the new gate.
-- Updated `blocks/PROJECT_INDEX.md` so the curated Blocks Index reflects Design Block `candidate_v3` and its frontend QA scope.
-- Source trail recorded in the new gate: Pimenov article plus official Impeccable repository.
-- Creation/update commits: `f1c30782c68fce13586cfd8cb7c2485ae13a91e0`, `c82a79e5f287d90d87b875e404a52d98199d1432`, `41a820967f6b2aaaedc461ded76af7a3761c616e`, `480758ddc598d9fae8903c1fcf8cf97ef535cc29`.
+- Added `docs/HARNESS_ENGINEERING_STANDARD.md` as the central architecture wrapper for reusable or operational AI-agent workflows.
+- Updated `docs/ROUTER.md` so harness engineering, agent runtime scaffold, tool/context/permission design, sandbox, memory and verification scaffold requests route directly to the new standard.
+- Updated `PROJECT_INDEX.md` to include both `docs/HARNESS_ENGINEERING_STANDARD.md` and existing `docs/AGENT_QUALITY_SCORECARD_STANDARD.md` in canonical documents.
+- Updated `PROJECT.md` so the central entrypoint records the new harness-engineering layer.
+- Source trail recorded in the new standard: `https://github.com/ai-boost/awesome-harness-engineering`.
+- Creation/update commits on branch `harness-engineering-standard-v1`: `dcfd166a67876ac94302bbf450ba739cd00ed76f`, `fd898db662c8f3687862a2e95b59eaa0e9498f02`, `c5562ebc3d23a4f40878bd15c34b5ec44ce8e39e`, `8de112b5494a2980dc5146d977223b9293d966ad`.
 
 ## Current Focus
 
 Keep the central project internally consistent and transfer-ready after every meaningful change.
 
+Harness engineering is now the first architecture layer for repeated or operational agents. Agent quality measurement remains handled by `docs/AGENT_QUALITY_SCORECARD_STANDARD.md` after the scaffold is explicit.
+
 ## Current Next Safe Action
 
-No implementation task is currently active.
+Use `docs/HARNESS_ENGINEERING_STANDARD.md` on the next real reusable agent or workflow before promoting it beyond one-off use.
 
-Next safe action for the new Impeccable gate is validation on a real AI-coded frontend task before promoting it beyond `candidate` guidance.
+Recommended next validation target: apply it to `projects/personal-secretary-os/PROJECT.md` or another active repeated workflow, then update the owning project state.
 
 When a new task arrives:
 
@@ -60,6 +62,13 @@ Read in this order when resuming central-project work:
 6. `PROJECT_INDEX.md` only when broader navigation is needed
 7. routed standards only when the active task requires them
 
+For harness engineering work, open:
+
+```text
+docs/HARNESS_ENGINEERING_STANDARD.md
+docs/AGENT_QUALITY_SCORECARD_STANDARD.md
+```
+
 For Impeccable or AI-coded frontend design QA work, open:
 
 ```text
@@ -69,9 +78,9 @@ blocks/design/BLOCK.md
 
 ## Known Blockers
 
-- `PROJECT_INDEX.md` still needs a curated canonical-documents entry for `docs/AGENT_QUALITY_SCORECARD_STANDARD.md` during the next safe large-index maintenance pass. Generated indexes already detect the new document automatically.
 - `gemini-tts-speech-generation` is registered as `candidate` / `not_reviewed`; it must not be treated as active until reviewed.
 - `blocks/design/IMPECCABLE_DESIGN_QA_GATE.md` is candidate guidance and should be validated on a real frontend task before promotion.
+- `docs/HARNESS_ENGINEERING_STANDARD.md` is newly added and should be validated on a real reusable-agent workflow before being treated as mature operational guidance.
 
 ## Do-Not-Break Rules
 

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4,7 +4,7 @@ project_mode: compact
 status: transfer_ready
 updated_at: 2026-07-06
 source_of_truth: repository
-active_branch: harness-engineering-standard-v1
+active_branch: main
 ---
 
 # PROJECT_STATE.md
@@ -28,7 +28,7 @@ logs/latest.md
 - Updated `PROJECT_INDEX.md` to include both `docs/HARNESS_ENGINEERING_STANDARD.md` and existing `docs/AGENT_QUALITY_SCORECARD_STANDARD.md` in canonical documents.
 - Updated `PROJECT.md` so the central entrypoint records the new harness-engineering layer.
 - Source trail recorded in the new standard: `https://github.com/ai-boost/awesome-harness-engineering`.
-- Creation/update commits on branch `harness-engineering-standard-v1`: `dcfd166a67876ac94302bbf450ba739cd00ed76f`, `fd898db662c8f3687862a2e95b59eaa0e9498f02`, `c5562ebc3d23a4f40878bd15c34b5ec44ce8e39e`, `8de112b5494a2980dc5146d977223b9293d966ad`.
+- Creation/update commits on branch `harness-engineering-standard-v1`: `dcfd166a67876ac94302bbf450ba739cd00ed76f`, `fd898db662c8f3687862a2e95b59eaa0e9498f02`, `c5562ebc3d23a4f40878bd15c34b5ec44ce8e39e`, `8de112b5494a2980dc5146d977223b9293d966ad`, `8dfddd946090bd940993f09a3d1b9fc4d4227647`, `7a42b335d5db55f025824e967763dac497b8bd12`.
 
 ## Current Focus
 

--- a/docs/HARNESS_ENGINEERING_STANDARD.md
+++ b/docs/HARNESS_ENGINEERING_STANDARD.md
@@ -1,0 +1,269 @@
+# Harness Engineering Standard v1
+
+## Purpose
+
+This standard defines how `Project Execution OS` designs the execution scaffold around AI agents and agentic workflows.
+
+The goal is to make agents reliable by engineering the surrounding system, not by relying on prompt cleverness or model capability alone.
+
+Use this standard to decide what context, tools, permissions, memory, verification, observability, and handoff artifacts an agent needs before it is treated as repeatable or operational.
+
+## Source Trail
+
+Primary donor reference:
+
+- `https://github.com/ai-boost/awesome-harness-engineering`
+
+This standard adapts the donor concept into the existing `Project Execution OS` architecture. It does not copy the donor list as a dependency or replace local OS standards.
+
+## Scope
+
+Apply this standard when:
+
+- creating or changing a reusable agent;
+- creating or changing a repeated agentic workflow;
+- giving an agent tools, files, APIs, browser access, repository access, Gmail, Calendar, Notion, Drive, GitHub, shell, or publishing access;
+- moving a workflow from experiment toward operation;
+- diagnosing repeated agent failure;
+- preparing a Codex, Claude Code, Cursor, ChatGPT, local-model, or multi-agent handoff;
+- deciding whether a task needs a single prompt, single agent, deterministic workflow, or multi-agent system.
+
+Do not force this standard onto a disposable one-off chat task with no reuse, risk, durable artifact, external tool use, or future comparison value.
+
+## Core Definition
+
+In this OS:
+
+```text
+Agent harness = the controlled execution environment around an AI agent.
+```
+
+A harness may include:
+
+- entrypoint and routing;
+- context package;
+- planning artifact;
+- tool interface;
+- permission boundary;
+- memory or state layer;
+- sandbox or execution environment;
+- verification loop;
+- observability and logs;
+- human approval or escalation path;
+- handoff state.
+
+## Core Rule
+
+Use this operating rule:
+
+```text
+Do not start by adding more agents.
+Start by making the smallest sufficient harness explicit.
+```
+
+The preferred progression is:
+
+```text
+single answer
+  -> single model call
+  -> single agent with minimal tools
+  -> deterministic workflow with checkpoints
+  -> multi-agent workflow only when evidence justifies separation
+```
+
+This mirrors `docs/AGENT_QUALITY_SCORECARD_STANDARD.md`: useful, repeatable outcomes matter more than complexity.
+
+## Minimum Harness Questions
+
+Before promoting an agent or workflow beyond one-off use, answer the smallest relevant subset of these questions.
+
+### 1. Task Shape
+
+- What repeated task is this harness for?
+- Is the task bounded, long-running, risky, or multi-session?
+- What is the successful outcome?
+- What should be explicitly out of scope?
+
+### 2. Entrypoint And Route
+
+- Where does the agent start?
+- Which router or project entrypoint must be read first?
+- Which deeper files are loaded only when needed?
+- How does a new executor avoid using stale chat memory?
+
+### 3. Context Delivery
+
+- What is always-on context?
+- What is retrieved on demand?
+- What must survive context compaction?
+- What should never enter the model context?
+
+Use `docs/CONTEXT_ASSEMBLY_STANDARD.md` for routed context decisions.
+
+### 4. Planning And State
+
+- Does the task need a durable plan?
+- Where are decisions, deviations, and progress recorded?
+- What state must survive handoff to another agent?
+
+For long or transferable work, use the active project continuity pattern from `docs/ALWAYS_TRANSFER_READY_STATE_STANDARD.md`.
+
+### 5. Tools
+
+- Which tools are available?
+- Which tools are actually needed for this workflow?
+- Are tool names and outputs unambiguous?
+- Does each tool do one conceptual thing?
+- Do tool errors tell the agent what to do next?
+
+Do not expose broad tool sets merely because they exist.
+
+### 6. Permissions
+
+- Which actions are read-only?
+- Which actions are write-capable?
+- Which actions are destructive, external, financial, publishing, deployment, or communication actions?
+- Which actions require explicit human approval?
+- What is forbidden even if technically possible?
+
+Default to least privilege.
+
+### 7. Sandbox And Execution Boundary
+
+- Where does code, shell, browser, or file execution happen?
+- What files, network domains, credentials, and secrets are reachable?
+- Can the agent modify its own rules, tools, hooks, or permission files?
+- What is the rollback path if the agent makes a bad change?
+
+An agent that can edit its own harness must be treated as a higher-risk system.
+
+### 8. Memory
+
+- What should be remembered?
+- Who approves memory writes when the memory affects future behavior?
+- How are stale, contradicted, or project-specific memories invalidated?
+- Where is memory stored: project files, repository memory, external database, or platform memory?
+
+Prefer durable project files for project-specific state before inventing a global memory layer.
+
+### 9. Verification
+
+- What check proves the output works?
+- Can the agent run that check itself?
+- What requires human review?
+- Which failures must be recorded for future regression tests?
+
+Do not accept `it looked good once` as evidence for a repeated workflow.
+
+### 10. Observability And Handoff
+
+- What evidence explains what the agent did?
+- Where are logs stored?
+- What artifact proves completion?
+- Can another executor resume without reading the chat transcript?
+
+Use `logs/latest.md`, project state files, or the owning workflow log when the task must survive handoff.
+
+## Minimum Harness Package
+
+For a reusable or repeated workflow, the minimum package should usually include:
+
+```text
+entrypoint
+route
+context rule
+tool permissions
+verification gate
+state / log location
+handoff instruction
+```
+
+For GitHub-backed projects, prefer:
+
+```text
+PROJECT.md
+AGENTS.md or local agent instructions when useful
+PROJECT_STATE.md after meaningful execution begins
+logs/latest.md after meaningful execution begins
+```
+
+For central reusable standards inside this repository, prefer:
+
+```text
+START_HERE.md
+→ docs/ROUTER.md
+→ routed standard
+→ PROJECT_STATE.md and logs/latest.md after meaningful changes
+```
+
+## Harness Change Protocol
+
+When changing a harness:
+
+1. Confirm the owner task and route.
+2. Check for an existing adequate standard or donor pattern first.
+3. Make the smallest useful change.
+4. Keep the entrypoint and router consistent.
+5. Add or update verification guidance.
+6. Update transfer state when the change is meaningful.
+7. Record what was reused, what was adapted, and what remains custom.
+
+Do not add empty templates, logs, agents, scorecards, memory files, or workflow layers by ritual.
+
+## Relationship To Existing Standards
+
+Use this standard as the architecture wrapper. Then delegate specifics:
+
+| Concern | Use |
+|---|---|
+| Existing solution search | `docs/EXISTING_SOLUTION_FIRST_STANDARD.md` |
+| Project entrypoint | `docs/PROJECT_ENTRYPOINT_STANDARD.md` |
+| Context selection | `docs/CONTEXT_ASSEMBLY_STANDARD.md` |
+| Transfer-ready state | `docs/ALWAYS_TRANSFER_READY_STATE_STANDARD.md` |
+| Agent quality and metrics | `docs/AGENT_QUALITY_SCORECARD_STANDARD.md` |
+| API cost and cache evidence | `docs/API_RUNTIME_COST_CACHE_LOGGING_STANDARD.md` |
+| Research | `docs/RESEARCH_STANDARD.md` |
+| Review | `docs/REVIEW_STANDARD.md` |
+| Codex handoff | `docs/CODEX_HANDOFF_ENTRYPOINT.md` |
+
+## Promotion Levels
+
+### Level 0 — One-Off
+
+No harness artifact is required unless the task has meaningful risk, write access, or durable project value.
+
+### Level 1 — Repeated Experiment
+
+Define the entrypoint, tool permissions, expected output, and one verification check.
+
+### Level 2 — Operational Workflow
+
+Add durable state, logs, regression examples, cost/latency evidence when available, and explicit approval rules for critical actions.
+
+### Level 3 — High-Risk Or Business-Critical Workflow
+
+Add stronger sandboxing, audit trail, adversarial cases, rollback procedure, permission tests, and human approval gates.
+
+## Warning Conditions
+
+Investigate and improve the harness when:
+
+- the agent asks the same setup questions repeatedly;
+- the agent loads too much context by default;
+- the agent uses the wrong tool;
+- the agent cannot explain what state is current;
+- a new executor cannot resume the workflow;
+- results vary wildly across runs;
+- critical actions happen without approval evidence;
+- tool errors lead to hallucinated workarounds;
+- memory becomes stale or contradicts project files;
+- cost grows without quality improvement;
+- adding another agent increases handoff failures.
+
+## Final Rule
+
+Engineer the scaffold before blaming the model.
+
+Use the smallest sufficient harness.
+
+Make context, tools, permissions, verification, and handoff explicit before treating an agent as reliable.

--- a/docs/ROUTER.md
+++ b/docs/ROUTER.md
@@ -61,6 +61,7 @@ Do not append an unrelated next-project question after answering the active requ
 - repository-memory question for this system or a GitHub-backed project -> `docs/REPOSITORY_MEMORY_STANDARD.md`
 - system-context profile identity, fingerprint or compatibility question -> `docs/SYSTEM_CONTEXT_VERSION_STANDARD.md`
 - API token usage, cost or provider cache measurement -> `docs/API_RUNTIME_COST_CACHE_LOGGING_STANDARD.md`
+- harness engineering, agent harness, agent runtime scaffold, agent tool/context/permission design, sandbox/memory/verification scaffold, or reliability architecture before agent operation -> `docs/HARNESS_ENGINEERING_STANDARD.md`
 - agent quality, cost per successful outcome, evals, regression protection, observability, tool-use quality, orchestration complexity, or agent comparison -> `docs/AGENT_QUALITY_SCORECARD_STANDARD.md`
 
 ## Boundary

--- a/logs/latest.md
+++ b/logs/latest.md
@@ -1,15 +1,17 @@
 # Latest Executor Status
 
-Timestamp: 2026-07-02T14:24:13Z
+Timestamp: 2026-07-06T00:00:00Z
 Marker: COMPLETE
-Task-ID: impeccable-design-qa-gate
-Status: Added candidate `Impeccable Design QA Gate` to the Design Block for AI-coded frontend work. Created `blocks/design/IMPECCABLE_DESIGN_QA_GATE.md`, updated `blocks/design/BLOCK.md` to `candidate_v3`, updated `docs/ROUTER.md` with a direct route for Impeccable / AI-slop / frontend design QA requests, updated `blocks/PROJECT_INDEX.md`, and updated `PROJECT_STATE.md`.
-Reply-Surface: repository main branch
-Gate-Path: blocks/design/IMPECCABLE_DESIGN_QA_GATE.md
-Design-Block-Path: blocks/design/BLOCK.md
+Task-ID: harness-engineering-standard-v1
+Status: Added `docs/HARNESS_ENGINEERING_STANDARD.md` as the central architecture wrapper for reusable or operational AI-agent workflows. Updated `docs/ROUTER.md` with a direct harness-engineering route, updated `PROJECT_INDEX.md` to include the new standard and existing `docs/AGENT_QUALITY_SCORECARD_STANDARD.md`, updated `PROJECT.md`, and updated `PROJECT_STATE.md`.
+Reply-Surface: repository branch `harness-engineering-standard-v1`
+Harness-Standard-Path: docs/HARNESS_ENGINEERING_STANDARD.md
 Router-Path: docs/ROUTER.md
-Blocks-Index-Path: blocks/PROJECT_INDEX.md
-Project-State-Commit-SHA: e279be0a4ac7c0050a1856d389c20fbc7e8f5d4a
-Creation-Commit-SHAs: f1c30782c68fce13586cfd8cb7c2485ae13a91e0, c82a79e5f287d90d87b875e404a52d98199d1432, 41a820967f6b2aaaedc461ded76af7a3761c616e, 480758ddc598d9fae8903c1fcf8cf97ef535cc29, e279be0a4ac7c0050a1856d389c20fbc7e8f5d4a
-Next-Automatic-Action: None. Await owner instruction or validate the new gate on a real frontend project before promotion.
-Owner-Action-Required: None.
+Project-Index-Path: PROJECT_INDEX.md
+Project-Entrypoint-Path: PROJECT.md
+Project-State-Path: PROJECT_STATE.md
+Project-State-Commit-SHA: 8dfddd946090bd940993f09a3d1b9fc4d4227647
+Creation-Commit-SHAs: dcfd166a67876ac94302bbf450ba739cd00ed76f, fd898db662c8f3687862a2e95b59eaa0e9498f02, c5562ebc3d23a4f40878bd15c34b5ec44ce8e39e, 8de112b5494a2980dc5146d977223b9293d966ad, 8dfddd946090bd940993f09a3d1b9fc4d4227647
+Source-Trail: https://github.com/ai-boost/awesome-harness-engineering
+Next-Automatic-Action: None. Await owner instruction or validate the new harness standard on a real reusable-agent workflow before promotion beyond new central guidance.
+Owner-Action-Required: Review and merge PR if the branch is acceptable.

--- a/logs/latest.md
+++ b/logs/latest.md
@@ -1,17 +1,18 @@
 # Latest Executor Status
 
-Timestamp: 2026-07-06T00:00:00Z
+Timestamp: 2026-07-06T16:17:51Z
 Marker: COMPLETE
 Task-ID: harness-engineering-standard-v1
 Status: Added `docs/HARNESS_ENGINEERING_STANDARD.md` as the central architecture wrapper for reusable or operational AI-agent workflows. Updated `docs/ROUTER.md` with a direct harness-engineering route, updated `PROJECT_INDEX.md` to include the new standard and existing `docs/AGENT_QUALITY_SCORECARD_STANDARD.md`, updated `PROJECT.md`, and updated `PROJECT_STATE.md`.
-Reply-Surface: repository branch `harness-engineering-standard-v1`
+Reply-Surface: repository main branch after PR merge
+PR: https://github.com/oleg3479881328-code/Project-Execution-OS/pull/67
 Harness-Standard-Path: docs/HARNESS_ENGINEERING_STANDARD.md
 Router-Path: docs/ROUTER.md
 Project-Index-Path: PROJECT_INDEX.md
 Project-Entrypoint-Path: PROJECT.md
 Project-State-Path: PROJECT_STATE.md
-Project-State-Commit-SHA: 8dfddd946090bd940993f09a3d1b9fc4d4227647
-Creation-Commit-SHAs: dcfd166a67876ac94302bbf450ba739cd00ed76f, fd898db662c8f3687862a2e95b59eaa0e9498f02, c5562ebc3d23a4f40878bd15c34b5ec44ce8e39e, 8de112b5494a2980dc5146d977223b9293d966ad, 8dfddd946090bd940993f09a3d1b9fc4d4227647
+Project-State-Commit-SHA: a96a4569c0fb8367334f666534acdeef28f2ddf3
+Creation-Commit-SHAs: dcfd166a67876ac94302bbf450ba739cd00ed76f, fd898db662c8f3687862a2e95b59eaa0e9498f02, c5562ebc3d23a4f40878bd15c34b5ec44ce8e39e, 8de112b5494a2980dc5146d977223b9293d966ad, 8dfddd946090bd940993f09a3d1b9fc4d4227647, 7a42b335d5db55f025824e967763dac497b8bd12, a96a4569c0fb8367334f666534acdeef28f2ddf3
 Source-Trail: https://github.com/ai-boost/awesome-harness-engineering
-Next-Automatic-Action: None. Await owner instruction or validate the new harness standard on a real reusable-agent workflow before promotion beyond new central guidance.
-Owner-Action-Required: Review and merge PR if the branch is acceptable.
+Next-Automatic-Action: None. Validate the new harness standard on a real reusable-agent workflow before promotion beyond new central guidance.
+Owner-Action-Required: None.


### PR DESCRIPTION
Adds a central harness engineering standard and routes related requests to it. Updates the project index, project entrypoint, transfer state, and latest log.