### PR TITLE
Add TikTok hashtag discovery scanning v0.3.0

### DIFF
--- a/.github/workflows/tiktok-research-sorter-ci.yml
+++ b/.github/workflows/tiktok-research-sorter-ci.yml
@@ -66,16 +66,16 @@ jobs:
         run: |
           set -euo pipefail
           cd .output/chrome-mv3
-          zip -qr ../../tiktok-research-sorter-extension-0.2.0.zip .
+          zip -qr ../../tiktok-research-sorter-extension-v0.3.0.zip .
           cd ../..
-          zip -qr tiktok-sorter-auto-updater-setup-0.2.0.zip automation/windows
-          zip -qr tiktok-research-sorter-source-0.2.0.zip . \
+          zip -qr tiktok-sorter-auto-updater-setup-v0.3.0.zip automation/windows
+          zip -qr tiktok-research-sorter-source-v0.3.0.zip . \
             -x 'node_modules/*' '.output/*' '.wxt/*' '*.zip'
 
       - name: Upload unpacked extension
         uses: actions/upload-artifact@v4
         with:
-          name: tiktok-research-sorter-chrome-mv3-${{ github.sha }}
+          name: tiktok-research-sorter-chrome-mv3-v0.3.0-${{ github.sha }}
           path: projects/tiktok-research-sorter/.output/chrome-mv3/
           retention-days: 14
           if-no-files-found: error
@@ -83,11 +83,11 @@ jobs:
       - name: Upload packaged files
         uses: actions/upload-artifact@v4
         with:
-          name: tiktok-research-sorter-packages-${{ github.sha }}
+          name: tiktok-research-sorter-packages-v0.3.0-${{ github.sha }}
           path: |
-            projects/tiktok-research-sorter/tiktok-research-sorter-extension-0.2.0.zip
-            projects/tiktok-research-sorter/tiktok-sorter-auto-updater-setup-0.2.0.zip
-            projects/tiktok-research-sorter/tiktok-research-sorter-source-0.2.0.zip
+            projects/tiktok-research-sorter/tiktok-research-sorter-extension-v0.3.0.zip
+            projects/tiktok-research-sorter/tiktok-sorter-auto-updater-setup-v0.3.0.zip
+            projects/tiktok-research-sorter/tiktok-research-sorter-source-v0.3.0.zip
           retention-days: 30
           if-no-files-found: error
 
@@ -128,4 +128,4 @@ jobs:
           $manifest = Join-Path $env:LOCALAPPDATA 'TikTokResearchSorterDev\source\.output\chrome-mv3\manifest.json'
           if (-not (Test-Path $manifest)) { throw "Manifest not found: $manifest" }
           $json = Get-Content $manifest -Raw | ConvertFrom-Json
-          if ($json.version -ne '0.2.0') { throw "Unexpected manifest version: $($json.version)" }
+          if ($json.version -ne '0.3.0') { throw "Unexpected manifest version: $($json.version)" }

--- a/projects/tiktok-research-sorter/PROJECT.md
+++ b/projects/tiktok-research-sorter/PROJECT.md
@@ -4,13 +4,17 @@
 
 - Project name: `TikTok Research Sorter`
 - Project type: `Chrome Extension / local social-content research tool`
-- Short description: a Manifest V3 browser extension that scans publicly visible TikTok profile videos, stores their metrics locally, identifies unusually successful videos, and exports research data.
+- Current version: `0.3.0`
+- Short description: a Manifest V3 browser extension that scans publicly visible TikTok profile and hashtag pages, stores metrics locally, selects unusually successful or highest-viewed videos, and exports research data.
 
 ## 2. Purpose
 
-The project exists to replace fragile “sort the current TikTok grid” extensions with a reliable research workflow:
+Supported workflows:
 
-`open public profile -> start scan -> collect loaded videos -> calculate normalized metrics -> filter and sort -> export`
+```text
+public profile -> scan loaded profile videos -> calculate normalized metrics -> filter/sort -> export
+public hashtag -> scan loaded hashtag videos -> group by account -> top N per account + minimum views -> export
+```
 
 Primary users:
 
@@ -19,70 +23,53 @@ Primary users:
 - local-business marketers;
 - the owner’s TikTok and Reels research workflows.
 
-Current-stage success means a loadable Chrome extension that can scan a public profile page, preserve collected records locally, show outlier and velocity analytics, and export CSV/JSON without a backend.
+## 3. Source of truth
 
-## 3. Source Of Truth
+- Durable source: `projects/tiktok-research-sorter/` inside `oleg3479881328-code/Project-Execution-OS`.
+- Stable distribution branch: `main`.
+- Active feature branch: `agent/tiktok-research-sorter-tag-scan-v0.3.0` until Issue #82 is merged.
+- Active issue: `#82`.
 
-- Current durable source of truth: this internal project tree inside `oleg3479881328-code/Project-Execution-OS`.
-- Active implementation branch: `agent/tiktok-research-sorter-mvp`.
-- The project should later be extracted into a standalone repository when repository creation is available.
+## 4. Architecture
 
-## 4. Source Trail
+```text
+TikTok public page
+→ selected fetch/XHR payload observer + embedded JSON + DOM fallback
+→ isolated content script
+→ serialized background persistence
+→ chrome.storage.local
+→ React side panel
+```
 
-Primary product reference:
+## 5. Current status
 
-- https://chromewebstore.google.com/detail/sort-for-tiktok-videos-by/dpfmkbcoaddghkkhebjcjaoaiaefigln
+- Mode: `implementation / automated validation`
+- Phase: `v0.3.0 hashtag discovery scan`
+- Status: profile workflow stable; hashtag workflow implemented and awaiting final branch CI/merge.
 
-Canonical Project Execution OS routes:
+## 6. Key decisions and constraints
 
-- https://github.com/oleg3479881328-code/Project-Execution-OS/blob/main/START_HERE.md
-- https://github.com/oleg3479881328-code/Project-Execution-OS/blob/main/blocks/chrome-extension/BLOCK.md
-
-Implementation sources and decisions are summarized in `docs/RESEARCH_AND_DECISIONS.md`.
-
-## 5. Current Status
-
-- Mode: `implementation / validation handoff`
-- Phase: `desktop browser validation`
-- Status: `buildable MVP; real TikTok smoke test still required`
-- Confidence: high for extension architecture, build, unit-tested normalization, and local analytics; medium for long-term TikTok payload compatibility until real browser validation is completed.
-
-## 6. Done So Far
-
-- Confirmed the product direction and MVP scope.
-- Applied Existing Solution First and selected WXT instead of custom build tooling.
-- Created the Manifest V3 WXT/React/TypeScript project.
-- Added a MAIN-world fetch/XHR observer for relevant TikTok responses.
-- Added an isolated collector with initial-state parsing, DOM fallback, controlled auto-scroll, stop handling, and CAPTCHA stop condition.
-- Added heuristic payload normalization and per-profile deduplication.
-- Added local persistence through `chrome.storage.local`.
-- Added views/day, Engagement Rate, Outlier Score, filters, CSV/JSON export, and a Chrome side panel UI.
-- Added 5 passing unit tests.
-- Passed TypeScript validation, WXT production build, ZIP build, and runtime dependency audit.
-- Added a bounded desktop Chrome validation handoff.
-
-## 7. Current Focus
-
-Validate the built extension against real public TikTok profiles and harden parser adapters using captured, sanitized payload fixtures.
-
-## 8. Next Practical Step
-
-Load the production build as an unpacked extension in Chrome, execute `docs/IMPLEMENTATION_HANDOFF.md`, save sanitized failing payload examples, and update the TikTok adapter without expanding permissions.
-
-## 9. Key Decisions And Constraints
-
-- Existing Solution First is mandatory.
 - Stack: `WXT + TypeScript + React + Manifest V3`.
-- Architecture: local utility + content scripts + Chrome side panel.
-- No backend, accounts, AI calls, payments, or cloud sync in MVP.
-- Data remains in `chrome.storage.local` unless measured storage pressure or history requirements justify IndexedDB.
-- Host access is limited to `https://www.tiktok.com/*`.
-- Do not bypass login, private accounts, CAPTCHA, rate limits, or TikTok access controls.
+- No backend, accounts, AI calls, payments, remote executable code, or cloud sync.
+- Host access remains limited to TikTok.
+- Do not bypass login, private accounts, CAPTCHA, rate limits, paywalls, or access controls.
 - Prefer structured JSON payloads; DOM selectors are fallback only.
-- Preserve raw sanitized fixtures during validation, but never commit cookies, tokens, headers, signatures, or personal account data.
-- The generated `package-lock.json` must be committed by the desktop executor because the current connector cannot upload the local lock file directly.
+- Hashtag results represent videos actually loaded from the open hashtag page; the extension does not silently crawl every profile.
+- Preserve only sanitized fixtures. Never commit cookies, tokens, authorization headers, browser profiles, signatures, or raw identifying traffic.
+- Keep generated deliverables versioned.
 
-## 10. Read Next
+## 7. Current validation gate
+
+Before v0.3.0 is integrated:
+
+- strict TypeScript check passes;
+- all unit and regression tests pass;
+- Linux build and versioned packaging pass;
+- Windows updater validation passes;
+- Project Execution OS integrity validation passes;
+- downloadable `v0.3.0` artifacts exist.
+
+## 8. Read next
 
 1. `PROJECT_STATE.md`
 2. `logs/latest.md`

--- a/projects/tiktok-research-sorter/PROJECT_STATE.md
+++ b/projects/tiktok-research-sorter/PROJECT_STATE.md
@@ -1,57 +1,54 @@
 ---
 project_mode: internal
-status: stable
-version: 0.2.0
-branch: main
-active_issue: 72
-pull_request: 71
+status: active
+version: 0.3.0
+branch: agent/tiktok-research-sorter-tag-scan-v0.3.0
+active_issue: 82
+pull_request: pending
 ---
 
 # TikTok Research Sorter — Project State
 
 ## Current phase
 
-Version 0.2.0 is integrated into `main`. The automatic Windows updater follows `main`, so future approved changes can be delivered through the desktop shortcut without manual extension reinstallation.
+Version 0.3.0 adds public hashtag-page research while preserving the existing profile workflow. The feature branch is under automated validation before integration into `main`.
 
 ## Working implementation
 
 - WXT Manifest V3 extension with a React side panel.
-- Public TikTok profile scanning initiated by the user.
-- Full profile card with avatar, name, bio, verification, followers, following, profile likes, video count, scan time, coverage, publication frequency, median views, and strongest hashtags.
-- Video cards with cover, views, velocity, engagement, and outlier score.
-- Selected TikTok API observation plus embedded-state and DOM fallbacks.
-- Local per-profile storage, filters, CSV, and JSON export.
-- Atomic Windows one-click updater with a dedicated persistent Chrome profile.
+- Automatic detection of public profile pages and `/tag/<hashtag>` pages.
+- Public profile scanning with profile card, outlier analytics, filtering, and export.
+- Public hashtag scanning with automatic scrolling and selected TikTok challenge/search payload observation.
+- Hashtag videos grouped by account.
+- User-selectable top videos per account: 1, 2, 3, 5, or 10.
+- User-selectable minimum view threshold.
+- Local hashtag snapshots that can be re-filtered after scanning.
+- Versioned CSV and JSON export.
+- Atomic Windows one-click updater following `main`.
 
-## Stabilization completed
+## Boundaries
 
-- Background dashboard mutations are serialized to prevent lost updates.
-- Stale scans recover automatically.
-- Content-script scan locks are released through `try/catch/finally`.
-- Source precedence is API → embedded JSON → DOM.
-- External URLs are restricted to HTTP(S).
-- Publication frequency, average engagement, localized counts, duration normalization, and CSV formula safety are covered.
-- The updater validates in an isolated candidate directory, preserves the current build on failure, and keeps one previous version for rollback.
+- Hashtag mode selects top videos among items actually discovered on the open hashtag page.
+- It does not silently open every creator profile.
+- No login, CAPTCHA, private-profile, paywall, rate-limit, or access-control bypass.
+- No additional host permissions beyond TikTok.
+- No Chrome Web Store submission or public GitHub Release is authorized.
 
-## Automated validation
+## Validation status
 
-- 40 unit and regression tests pass.
-- Strict TypeScript check passes.
-- Linux production build and packaging pass.
-- Windows updater dry-run and full local-source validation pass.
-- Project Execution OS structure and system-context manifest validation pass.
+Local implementation validation completed before push:
 
-## Distribution
+- strict TypeScript check passed;
+- hashtag selection fixture tests passed;
+- production Chrome MV3 build passed.
 
-The updater default is `main`. Successful CI produces:
+Final GitHub Linux, Windows, Project Execution OS integrity, artifact, and merge evidence remain pending on the feature branch.
+
+## Distribution target
+
+Successful CI must produce:
 
 - unpacked Chrome MV3 extension;
-- `tiktok-research-sorter-extension-0.2.0.zip`;
-- `tiktok-sorter-auto-updater-setup-0.2.0.zip`;
-- `tiktok-research-sorter-source-0.2.0.zip`.
-
-## Remaining boundaries
-
-- No Chrome Web Store submission or public GitHub Release is authorized.
-- TikTok may change public payloads or DOM structure.
-- Very large future datasets may require IndexedDB instead of `chrome.storage.local`.
+- `tiktok-research-sorter-extension-v0.3.0.zip`;
+- `tiktok-sorter-auto-updater-setup-v0.3.0.zip`;
+- `tiktok-research-sorter-source-v0.3.0.zip`.

--- a/projects/tiktok-research-sorter/PROJECT_STATE.md
+++ b/projects/tiktok-research-sorter/PROJECT_STATE.md
@@ -4,14 +4,14 @@ status: active
 version: 0.3.0
 branch: agent/tiktok-research-sorter-tag-scan-v0.3.0
 active_issue: 82
-pull_request: pending
+pull_request: 83
 ---
 
 # TikTok Research Sorter — Project State
 
 ## Current phase
 
-Version 0.3.0 adds public hashtag-page research while preserving the existing profile workflow. The feature branch is under automated validation before integration into `main`.
+Version 0.3.0 adds public hashtag-page research while preserving the existing profile workflow. PR #83 is under automated validation before integration into `main`.
 
 ## Working implementation
 
@@ -42,7 +42,7 @@ Local implementation validation completed before push:
 - hashtag selection fixture tests passed;
 - production Chrome MV3 build passed.
 
-Final GitHub Linux, Windows, Project Execution OS integrity, artifact, and merge evidence remain pending on the feature branch.
+Final GitHub Linux, Windows, Project Execution OS integrity, artifact, and merge evidence remain pending on PR #83.
 
 ## Distribution target
 

--- a/projects/tiktok-research-sorter/README.md
+++ b/projects/tiktok-research-sorter/README.md
@@ -1,25 +1,44 @@
 # TikTok Research Sorter
 
-Local-first Manifest V3 extension for scanning public TikTok profile pages, ranking videos, calculating outlier metrics, and exporting research data.
+Local-first Manifest V3 extension for scanning public TikTok profile pages and public TikTok hashtag pages, ranking videos, and exporting research data.
 
-## Version 0.2.0
+## Version 0.3.0
+
+### Profile research
 
 - Full profile card with avatar, display name, biography, verification status, followers, following, profile likes, and public video count.
 - Scan metadata: last scan, collected coverage, estimated posting frequency, median views, and strongest hashtags.
 - Video cards with cover, rank, views, views/day, outlier score, engagement, and hashtags.
+- Sorting, search, outlier filtering, CSV export, and JSON export.
+
+### Hashtag research
+
+Open a public page such as:
+
+```text
+https://www.tiktok.com/tag/weddingphotography
+```
+
+The side panel automatically detects hashtag mode. Choose:
+
+- how many videos to scan from the hashtag page;
+- how many highest-viewed videos to keep from each account: 1, 2, 3, 5, or 10;
+- the minimum required view count.
+
+The extension groups discovered videos by account and keeps the requested top videos from each account. Results can be adjusted after scanning because the locally stored hashtag snapshot retains all videos collected during that scan.
+
+Important: hashtag mode ranks videos found on the open hashtag page. It does not silently visit every creator profile or claim to inspect videos that TikTok did not load.
+
+### Reliability and safety
+
 - Side Panel interface opened from the extension toolbar.
-- User-initiated profile scan with automatic scrolling and explicit stop/error recovery.
+- User-initiated automatic scrolling with explicit stop, challenge detection, and error recovery.
 - Hybrid collection from embedded JSON, selected TikTok page requests, and loaded DOM cards.
-- Serialized per-profile persistence to prevent lost updates.
+- Serialized local persistence to prevent lost updates.
 - Strict data-source precedence: API → embedded JSON → DOM fallback.
-- Sorting by views, likes, comments, shares, date, views/day, engagement rate, and outlier score.
-- Text/hashtag filters.
-- CSV and JSON export with spreadsheet-formula protection.
-- CAPTCHA detection without bypass attempts.
-- One-click Windows updater and launcher under `automation/windows/`.
-- 40 automated tests covering parser, profile extraction, analytics, localized numbers, merge logic, duration normalization, cyclic payloads, and CSV safety.
-- Linux CI for TypeScript, tests, production build, and downloadable packages.
-- Windows CI for zero-side-effect dry run and full updater validation.
+- CSV export with spreadsheet-formula protection.
+- No login, CAPTCHA, private-profile, rate-limit, paywall, or access-control bypass.
+- Host permissions remain limited to TikTok.
 
 ## One-click Windows workflow
 
@@ -29,17 +48,9 @@ Open `automation/windows/README-RU.md` and run:
 Install-TikTok-Sorter.cmd
 ```
 
-The installer creates a desktop shortcut. Every shortcut launch:
+The installer creates a desktop shortcut. Every shortcut launch downloads `main`, builds in an isolated candidate directory, runs checks and tests, validates the generated manifest, preserves the current build on failure, keeps one previous build for rollback, and starts a dedicated persistent Chrome profile only after success.
 
-1. downloads or reads the selected source;
-2. builds in an isolated candidate directory;
-3. runs TypeScript checks and unit tests;
-4. validates the generated manifest;
-5. replaces the active build only after all checks pass;
-6. preserves the previous build for rollback;
-7. starts a dedicated persistent Chrome profile.
-
-Supported test and automation parameters:
+Supported automation parameters:
 
 ```powershell
 -DryRun
@@ -52,12 +63,6 @@ Supported test and automation parameters:
 
 ```bash
 npm ci
-npm run dev
-```
-
-Build and validate:
-
-```bash
 npm run check
 npm test
 npm run build
@@ -68,13 +73,13 @@ Load `.output/chrome-mv3` through `chrome://extensions` with Developer mode enab
 
 ## CI artifacts
 
-Each successful branch or pull-request run uploads:
+Each successful branch or pull-request run uploads versioned files:
 
 - unpacked Chrome MV3 extension;
-- `tiktok-research-sorter-extension-0.2.0.zip`;
-- `tiktok-sorter-auto-updater-setup-0.2.0.zip`;
-- `tiktok-research-sorter-source-0.2.0.zip`.
+- `tiktok-research-sorter-extension-v0.3.0.zip`;
+- `tiktok-sorter-auto-updater-setup-v0.3.0.zip`;
+- `tiktok-research-sorter-source-v0.3.0.zip`.
 
 ## Product boundary
 
-This project analyzes data already visible to the user on a public TikTok profile page. It does not bypass authentication, CAPTCHA, paywalls, private profiles, rate limits, or access controls. Data remains local in the browser unless the user explicitly exports it.
+This project analyzes data already visible to the user on public TikTok pages. Data remains local in the browser unless the user explicitly exports it. TikTok can change public payloads and page structure, so platform parsing remains isolated and regression-tested.

--- a/projects/tiktok-research-sorter/entrypoints/background.ts
+++ b/projects/tiktok-research-sorter/entrypoints/background.ts
@@ -1,5 +1,14 @@
 import { browser } from 'wxt/browser';
-import { clearProfile, loadDashboard, mergeProfileData, mergeVideoBatch, updateScanState } from '../lib/store';
+import {
+  beginTagResearch,
+  clearProfile,
+  clearTagResearch,
+  loadDashboard,
+  mergeProfileData,
+  mergeTagVideoBatch,
+  mergeVideoBatch,
+  updateScanState,
+} from '../lib/store';
 import type { DashboardData, RuntimeMessage } from '../lib/types';
 
 export default defineBackground(() => {
@@ -26,10 +35,16 @@ export default defineBackground(() => {
         return publish(() => mergeProfileData(message.profile));
       case 'VIDEO_BATCH':
         return publish(() => mergeVideoBatch(message.username, message.profileUrl, message.videos));
+      case 'TAG_SCAN_BEGIN':
+        return publish(() => beginTagResearch(message.tag, message.tagUrl, message.options));
+      case 'TAG_VIDEO_BATCH':
+        return publish(() => mergeTagVideoBatch(message.tag, message.tagUrl, message.videos));
       case 'SCAN_STATE':
         return publish(() => updateScanState(message.state));
       case 'CLEAR_PROFILE':
         return publish(() => clearProfile(message.username));
+      case 'CLEAR_TAG_RESEARCH':
+        return publish(() => clearTagResearch(message.tag));
       default:
         return undefined;
     }

--- a/projects/tiktok-research-sorter/entrypoints/content.ts
+++ b/projects/tiktok-research-sorter/entrypoints/content.ts
@@ -2,20 +2,41 @@ import { browser } from 'wxt/browser';
 import {
   extractProfileFromDom,
   extractProfileFromPayload,
+  extractVideosFromDiscoveryDom,
   extractVideosFromDom,
   extractVideosFromPayload,
+  mergeVideoRecords,
 } from '../lib/tiktok-parser';
-import type { ProfileRecord, RuntimeMessage, ScanOptions, ScanState, VideoRecord } from '../lib/types';
+import type {
+  ProfilePageContext,
+  ProfileRecord,
+  RuntimeMessage,
+  ScanOptions,
+  ScanState,
+  TagPageContext,
+  TikTokPageContext,
+  VideoRecord,
+} from '../lib/types';
 
 let scanning = false;
 let stopRequested = false;
-let currentUsername = '';
+let currentContext: TikTokPageContext | undefined;
+let currentTagVideos: Map<string, VideoRecord> | undefined;
 
-function getProfileContext(): { username: string; profileUrl: string } | undefined {
-  const match = location.pathname.match(/^\/@([^/]+)/);
-  const username = match?.[1]?.replace(/^@/, '');
-  if (!username) return undefined;
-  return { username, profileUrl: `https://www.tiktok.com/@${username}` };
+function getPageContext(): TikTokPageContext | undefined {
+  const profileMatch = location.pathname.match(/^\/@([^/]+)/i);
+  const username = profileMatch?.[1]?.replace(/^@/, '');
+  if (username) {
+    return { kind: 'profile', username, profileUrl: `https://www.tiktok.com/@${username}` };
+  }
+
+  const tagMatch = location.pathname.match(/^\/tag\/([^/?#]+)/i);
+  const tag = tagMatch?.[1] ? decodeURIComponent(tagMatch[1]).replace(/^#/, '') : '';
+  if (tag) {
+    return { kind: 'tag', tag, tagUrl: `https://www.tiktok.com/tag/${encodeURIComponent(tag)}` };
+  }
+
+  return undefined;
 }
 
 function injectPageHook(): void {
@@ -33,14 +54,39 @@ function injectPageHook(): void {
   (document.head || document.documentElement).append(script);
 }
 
-async function sendBatch(username: string, profileUrl: string, videos: VideoRecord[]): Promise<void> {
+async function sendProfileBatch(context: ProfilePageContext, videos: VideoRecord[]): Promise<void> {
   if (!videos.length) return;
-  await browser.runtime.sendMessage({ type: 'VIDEO_BATCH', username, profileUrl, videos } satisfies RuntimeMessage);
+  await browser.runtime.sendMessage({
+    type: 'VIDEO_BATCH',
+    username: context.username,
+    profileUrl: context.profileUrl,
+    videos,
+  } satisfies RuntimeMessage);
 }
 
 async function sendProfile(profile: ProfileRecord | undefined): Promise<void> {
   if (!profile) return;
   await browser.runtime.sendMessage({ type: 'PROFILE_DATA', profile } satisfies RuntimeMessage);
+}
+
+function mergeCurrentTagVideos(videos: VideoRecord[]): void {
+  if (!currentTagVideos) return;
+  for (const video of videos) {
+    const key = `${video.author.toLowerCase()}:${video.id}`;
+    const existing = currentTagVideos.get(key);
+    currentTagVideos.set(key, existing ? mergeVideoRecords(existing, video) : video);
+  }
+}
+
+async function sendTagBatch(context: TagPageContext, videos: VideoRecord[]): Promise<void> {
+  if (!videos.length) return;
+  mergeCurrentTagVideos(videos);
+  await browser.runtime.sendMessage({
+    type: 'TAG_VIDEO_BATCH',
+    tag: context.tag,
+    tagUrl: context.tagUrl,
+    videos,
+  } satisfies RuntimeMessage);
 }
 
 async function sendState(state: Omit<ScanState, 'updatedAt'>): Promise<void> {
@@ -53,149 +99,270 @@ async function sendState(state: Omit<ScanState, 'updatedAt'>): Promise<void> {
 function detectChallenge(): boolean {
   const text = document.body?.innerText.toLowerCase() ?? '';
   return Boolean(
-    document.querySelector('[id*="captcha" i], iframe[src*="captcha" i], [class*="captcha" i]') ||
-    text.includes('verify to continue') ||
-    text.includes('подтвердите, что вы человек')
+    document.querySelector('[id*="captcha" i], iframe[src*="captcha" i], [class*="captcha" i]')
+    || text.includes('verify to continue')
+    || text.includes('подтвердите, что вы человек')
   );
 }
 
-async function collectEmbeddedJson(username: string, profileUrl: string): Promise<void> {
+function embeddedPayloads(): unknown[] {
   const candidates = [
     document.querySelector<HTMLScriptElement>('#__UNIVERSAL_DATA_FOR_REHYDRATION__'),
     document.querySelector<HTMLScriptElement>('#SIGI_STATE'),
   ].filter(Boolean) as HTMLScriptElement[];
 
-  for (const script of candidates) {
+  return candidates.flatMap((script) => {
     try {
-      const payload = JSON.parse(script.textContent ?? '{}');
-      await Promise.all([
-        sendBatch(username, profileUrl, extractVideosFromPayload(payload, username, 'embedded-json')),
-        sendProfile(extractProfileFromPayload(payload, username, 'embedded-json')),
-      ]);
+      return [JSON.parse(script.textContent ?? '{}')];
     } catch {
-      // A changed or non-JSON bootstrap payload is not fatal.
+      return [];
     }
+  });
+}
+
+async function collectProfileEmbedded(context: ProfilePageContext): Promise<void> {
+  for (const payload of embeddedPayloads()) {
+    await Promise.all([
+      sendProfileBatch(context, extractVideosFromPayload(payload, context.username, 'embedded-json')),
+      sendProfile(extractProfileFromPayload(payload, context.username, 'embedded-json')),
+    ]);
   }
 }
 
-async function collectProfileDom(username: string): Promise<void> {
-  await sendProfile(extractProfileFromDom(username));
+async function collectTagEmbedded(context: TagPageContext): Promise<void> {
+  for (const payload of embeddedPayloads()) {
+    await sendTagBatch(context, extractVideosFromPayload(payload, '', 'embedded-json'));
+  }
 }
 
-async function startScan(options: ScanOptions): Promise<void> {
-  if (scanning) return;
-  const context = getProfileContext();
-  if (!context) {
-    await sendState({ status: 'error', videosFound: 0, message: 'Откройте публичный профиль TikTok.' });
-    return;
-  }
+async function collectProfileDom(context: ProfilePageContext): Promise<void> {
+  await sendProfile(extractProfileFromDom(context.username));
+}
 
-  scanning = true;
-  stopRequested = false;
-  currentUsername = context.username;
+async function startProfileScan(context: ProfilePageContext, options: ScanOptions): Promise<void> {
   const startedAt = Date.now();
   let idleRounds = 0;
   let lastCount = 0;
   let oldestPublishedAt: number | undefined;
 
-  try {
-    injectPageHook();
-    await sendState({
-      status: 'scanning',
-      username: context.username,
-      profileUrl: context.profileUrl,
-      videosFound: 0,
-      startedAt,
-      message: 'Сканирование профиля…',
-    });
+  await sendState({
+    status: 'scanning',
+    mode: 'profile',
+    username: context.username,
+    profileUrl: context.profileUrl,
+    videosFound: 0,
+    startedAt,
+    message: 'Сканирование профиля…',
+  });
 
-    await Promise.all([
-      collectEmbeddedJson(context.username, context.profileUrl),
-      collectProfileDom(context.username),
-    ]);
+  await Promise.all([collectProfileEmbedded(context), collectProfileDom(context)]);
 
-    while (!stopRequested) {
-      if (detectChallenge()) {
-        await sendState({
-          status: 'blocked',
-          username: context.username,
-          profileUrl: context.profileUrl,
-          videosFound: lastCount,
-          startedAt,
-          oldestPublishedAt,
-          message: 'TikTok запросил проверку. Пройдите её вручную и запустите сканирование снова.',
-        });
-        return;
-      }
-
-      const domVideos = extractVideosFromDom(context.username);
-      await Promise.all([
-        sendBatch(context.username, context.profileUrl, domVideos),
-        collectProfileDom(context.username),
-      ]);
-      const dates = domVideos.map((video) => video.publishedAt).filter((value): value is number => Boolean(value));
-      if (dates.length) oldestPublishedAt = Math.min(oldestPublishedAt ?? Infinity, ...dates);
-
-      const currentCount = new Set(domVideos.map((video) => video.id)).size;
-      idleRounds = currentCount <= lastCount ? idleRounds + 1 : 0;
-      lastCount = Math.max(lastCount, currentCount);
-
+  while (!stopRequested) {
+    if (detectChallenge()) {
       await sendState({
-        status: 'scanning',
+        status: 'blocked',
+        mode: 'profile',
         username: context.username,
         profileUrl: context.profileUrl,
         videosFound: lastCount,
         startedAt,
         oldestPublishedAt,
-        message: `Найдено на странице: ${lastCount}. Загружаю дальше…`,
+        message: 'TikTok запросил проверку. Пройдите её вручную и запустите сканирование снова.',
       });
-
-      if (lastCount >= options.maxVideos || idleRounds >= options.maxIdleRounds) {
-        await sendState({
-          status: 'complete',
-          username: context.username,
-          profileUrl: context.profileUrl,
-          videosFound: lastCount,
-          startedAt,
-          oldestPublishedAt,
-          message: idleRounds >= options.maxIdleRounds ? 'Новые ролики перестали загружаться.' : 'Достигнут заданный лимит.',
-        });
-        return;
-      }
-
-      window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' });
-      await new Promise((resolve) => setTimeout(resolve, options.scrollDelayMs));
+      return;
     }
 
+    const domVideos = extractVideosFromDom(context.username);
+    await Promise.all([sendProfileBatch(context, domVideos), collectProfileDom(context)]);
+    const dates = domVideos.map((video) => video.publishedAt).filter((value): value is number => Boolean(value));
+    if (dates.length) oldestPublishedAt = Math.min(oldestPublishedAt ?? Infinity, ...dates);
+
+    const currentCount = new Set(domVideos.map((video) => video.id)).size;
+    idleRounds = currentCount <= lastCount ? idleRounds + 1 : 0;
+    lastCount = Math.max(lastCount, currentCount);
+
     await sendState({
-      status: 'stopped',
+      status: 'scanning',
+      mode: 'profile',
       username: context.username,
       profileUrl: context.profileUrl,
       videosFound: lastCount,
       startedAt,
       oldestPublishedAt,
-      message: 'Сканирование остановлено пользователем.',
+      message: `Найдено на странице: ${lastCount}. Загружаю дальше…`,
     });
-  } catch (cause) {
-    const details = cause instanceof Error ? cause.message : String(cause);
+
+    if (lastCount >= options.maxVideos || idleRounds >= options.maxIdleRounds) {
+      await sendState({
+        status: 'complete',
+        mode: 'profile',
+        username: context.username,
+        profileUrl: context.profileUrl,
+        videosFound: lastCount,
+        startedAt,
+        oldestPublishedAt,
+        message: idleRounds >= options.maxIdleRounds ? 'Новые ролики перестали загружаться.' : 'Достигнут заданный лимит.',
+      });
+      return;
+    }
+
+    window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' });
+    await new Promise((resolve) => setTimeout(resolve, options.scrollDelayMs));
+  }
+
+  await sendState({
+    status: 'stopped',
+    mode: 'profile',
+    username: context.username,
+    profileUrl: context.profileUrl,
+    videosFound: lastCount,
+    startedAt,
+    oldestPublishedAt,
+    message: 'Сканирование остановлено пользователем.',
+  });
+}
+
+async function startTagScan(context: TagPageContext, options: ScanOptions): Promise<void> {
+  const startedAt = Date.now();
+  let idleRounds = 0;
+  let lastCount = 0;
+  currentTagVideos = new Map();
+
+  await browser.runtime.sendMessage({
+    type: 'TAG_SCAN_BEGIN',
+    tag: context.tag,
+    tagUrl: context.tagUrl,
+    options,
+  } satisfies RuntimeMessage);
+
+  await sendState({
+    status: 'scanning',
+    mode: 'tag',
+    tag: context.tag,
+    tagUrl: context.tagUrl,
+    videosFound: 0,
+    accountsFound: 0,
+    startedAt,
+    message: `Сканирование #${context.tag}…`,
+  });
+
+  await collectTagEmbedded(context);
+
+  while (!stopRequested) {
+    if (detectChallenge()) {
+      const accountsFound = new Set([...(currentTagVideos?.values() ?? [])].map((video) => video.author.toLowerCase())).size;
+      await sendState({
+        status: 'blocked',
+        mode: 'tag',
+        tag: context.tag,
+        tagUrl: context.tagUrl,
+        videosFound: currentTagVideos?.size ?? lastCount,
+        accountsFound,
+        startedAt,
+        message: 'TikTok запросил проверку. Пройдите её вручную и запустите сканирование снова.',
+      });
+      return;
+    }
+
+    await sendTagBatch(context, extractVideosFromDiscoveryDom());
+    const currentCount = currentTagVideos?.size ?? 0;
+    const accountsFound = new Set([...(currentTagVideos?.values() ?? [])].map((video) => video.author.toLowerCase())).size;
+    idleRounds = currentCount <= lastCount ? idleRounds + 1 : 0;
+    lastCount = Math.max(lastCount, currentCount);
+
+    await sendState({
+      status: 'scanning',
+      mode: 'tag',
+      tag: context.tag,
+      tagUrl: context.tagUrl,
+      videosFound: currentCount,
+      accountsFound,
+      startedAt,
+      message: `Найдено ${currentCount} роликов из ${accountsFound} аккаунтов. Загружаю дальше…`,
+    });
+
+    if (currentCount >= options.maxVideos || idleRounds >= options.maxIdleRounds) {
+      await sendState({
+        status: 'complete',
+        mode: 'tag',
+        tag: context.tag,
+        tagUrl: context.tagUrl,
+        videosFound: currentCount,
+        accountsFound,
+        startedAt,
+        message: idleRounds >= options.maxIdleRounds
+          ? `Сканирование #${context.tag} завершено: новые ролики перестали загружаться.`
+          : `Сканирование #${context.tag} завершено по лимиту.`,
+      });
+      return;
+    }
+
+    window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' });
+    await new Promise((resolve) => setTimeout(resolve, options.scrollDelayMs));
+  }
+
+  const accountsFound = new Set([...(currentTagVideos?.values() ?? [])].map((video) => video.author.toLowerCase())).size;
+  await sendState({
+    status: 'stopped',
+    mode: 'tag',
+    tag: context.tag,
+    tagUrl: context.tagUrl,
+    videosFound: currentTagVideos?.size ?? lastCount,
+    accountsFound,
+    startedAt,
+    message: 'Сканирование хэштега остановлено пользователем.',
+  });
+}
+
+async function startScan(options: ScanOptions): Promise<void> {
+  if (scanning) return;
+  const context = getPageContext();
+  if (!context) {
     await sendState({
       status: 'error',
-      username: context.username,
-      profileUrl: context.profileUrl,
-      videosFound: lastCount,
-      startedAt,
-      oldestPublishedAt,
+      videosFound: 0,
+      message: 'Откройте публичный профиль TikTok или страницу хэштега TikTok.',
+    });
+    return;
+  }
+
+  scanning = true;
+  stopRequested = false;
+  currentContext = context;
+
+  try {
+    injectPageHook();
+    if (context.kind === 'profile') await startProfileScan(context, options);
+    else await startTagScan(context, options);
+  } catch (cause) {
+    const details = cause instanceof Error ? cause.message : String(cause);
+    const tagValues = [...(currentTagVideos?.values() ?? [])];
+    await sendState({
+      status: 'error',
+      mode: context.kind,
+      username: context.kind === 'profile' ? context.username : undefined,
+      profileUrl: context.kind === 'profile' ? context.profileUrl : undefined,
+      tag: context.kind === 'tag' ? context.tag : undefined,
+      tagUrl: context.kind === 'tag' ? context.tagUrl : undefined,
+      videosFound: context.kind === 'tag' ? tagValues.length : 0,
+      accountsFound: context.kind === 'tag' ? new Set(tagValues.map((video) => video.author.toLowerCase())).size : undefined,
       message: `Сканирование прервано: ${details}`,
     }).catch(() => undefined);
   } finally {
     scanning = false;
     stopRequested = false;
-    currentUsername = '';
+    currentContext = undefined;
+    currentTagVideos = undefined;
   }
 }
 
 export default defineContentScript({
-  matches: ['https://www.tiktok.com/@*', 'https://tiktok.com/@*'],
+  matches: [
+    'https://www.tiktok.com/@*',
+    'https://tiktok.com/@*',
+    'https://www.tiktok.com/tag/*',
+    'https://tiktok.com/tag/*',
+  ],
   runAt: 'document_start',
   main(ctx) {
     const runtimeMarker = '__TIKTOK_RESEARCH_SORTER_CONTENT_READY__';
@@ -206,21 +373,29 @@ export default defineContentScript({
     injectPageHook();
 
     ctx.addEventListener(window, 'message', (event: MessageEvent) => {
-      if (!scanning || event.source !== window) return;
+      if (!scanning || event.source !== window || !currentContext) return;
       const data = event.data as { source?: string; type?: string; payload?: unknown };
       if (data.source !== 'tiktok-research-sorter-page-hook' || data.type !== 'TIKTOK_API_PAYLOAD') return;
-      const context = getProfileContext();
-      if (!context || context.username !== currentUsername) return;
-      const videos = extractVideosFromPayload(data.payload, context.username, 'api');
-      const profile = extractProfileFromPayload(data.payload, context.username, 'api');
-      void Promise.all([
-        sendBatch(context.username, context.profileUrl, videos),
-        sendProfile(profile),
-      ]).catch(() => undefined);
+
+      if (currentContext.kind === 'profile') {
+        const pageContext = getPageContext();
+        if (pageContext?.kind !== 'profile' || pageContext.username !== currentContext.username) return;
+        const videos = extractVideosFromPayload(data.payload, currentContext.username, 'api');
+        const profile = extractProfileFromPayload(data.payload, currentContext.username, 'api');
+        void Promise.all([
+          sendProfileBatch(currentContext, videos),
+          sendProfile(profile),
+        ]).catch(() => undefined);
+        return;
+      }
+
+      const pageContext = getPageContext();
+      if (pageContext?.kind !== 'tag' || pageContext.tag.toLowerCase() !== currentContext.tag.toLowerCase()) return;
+      void sendTagBatch(currentContext, extractVideosFromPayload(data.payload, '', 'api')).catch(() => undefined);
     });
 
     browser.runtime.onMessage.addListener((message: RuntimeMessage) => {
-      if (message.type === 'PING') return Promise.resolve({ ok: true, context: getProfileContext() });
+      if (message.type === 'PING') return Promise.resolve({ ok: true, context: getPageContext() });
       if (message.type === 'START_SCAN') {
         void startScan(message.options);
         return Promise.resolve({ ok: true });

--- a/projects/tiktok-research-sorter/entrypoints/page-hook.ts
+++ b/projects/tiktok-research-sorter/entrypoints/page-hook.ts
@@ -5,9 +5,11 @@ export default defineUnlistedScript(() => {
   globalObject[marker] = true;
 
   const shouldInspect = (url: string) =>
-    url.includes('/api/post/item_list/') ||
-    url.includes('/api/user/detail/') ||
-    url.includes('/api/item/detail/');
+    url.includes('/api/post/item_list/')
+    || url.includes('/api/user/detail/')
+    || url.includes('/api/item/detail/')
+    || url.includes('/api/challenge/item_list/')
+    || url.includes('/api/search/item/full/');
 
   const emit = (url: string, payload: unknown) => {
     window.postMessage({

--- a/projects/tiktok-research-sorter/entrypoints/sidepanel/App.tsx
+++ b/projects/tiktok-research-sorter/entrypoints/sidepanel/App.tsx
@@ -1,19 +1,25 @@
 import { useEffect, useMemo, useState } from 'react';
 import { browser } from 'wxt/browser';
-import {
-  enrichVideos,
-  publicationFrequencyPerWeek,
-  strongestHashtags,
-  summarize,
-} from '../../lib/analytics';
+import { enrichVideos, publicationFrequencyPerWeek, strongestHashtags, summarize } from '../../lib/analytics';
 import { videosToCsv } from '../../lib/csv';
 import { formatCompactNumber } from '../../lib/numbers';
-import type { DashboardData, EnrichedVideo, ProfileSnapshot, RuntimeMessage, ScanOptions } from '../../lib/types';
+import { groupTopVideosPerAccount } from '../../lib/tag-research';
+import { APP_VERSION } from '../../lib/types';
+import type {
+  DashboardData,
+  EnrichedVideo,
+  ProfileSnapshot,
+  RuntimeMessage,
+  ScanOptions,
+  TikTokPageContext,
+} from '../../lib/types';
 
 type SortKey = 'views' | 'likes' | 'comments' | 'shares' | 'publishedAt' | 'viewsPerDay' | 'outlierScore' | 'engagementRate';
+type ViewMode = 'profile' | 'tag';
 
 const emptyDashboard: DashboardData = {
   profiles: {},
+  tagResearch: {},
   activeScan: { status: 'idle', videosFound: 0, updatedAt: Date.now() },
 };
 
@@ -21,11 +27,28 @@ const defaultOptions: ScanOptions = {
   maxVideos: 300,
   maxIdleRounds: 5,
   scrollDelayMs: 1200,
+  topVideosPerAccount: 1,
+  minViews: 0,
 };
 
 async function activeTabId(): Promise<number | undefined> {
   const tabs = await browser.tabs.query({ active: true, currentWindow: true });
   return tabs[0]?.id;
+}
+
+async function connectToActiveTikTokTab(): Promise<{ tabId: number; context?: TikTokPageContext }> {
+  const tabId = await activeTabId();
+  if (!tabId) throw new Error('Активная вкладка не найдена.');
+
+  try {
+    const response = await browser.tabs.sendMessage(tabId, { type: 'PING' } satisfies RuntimeMessage) as { context?: TikTokPageContext };
+    return { tabId, context: response?.context };
+  } catch {
+    await browser.scripting.executeScript({ target: { tabId }, files: ['/content-scripts/content.js'] });
+    await new Promise((resolve) => setTimeout(resolve, 180));
+    const response = await browser.tabs.sendMessage(tabId, { type: 'PING' } satisfies RuntimeMessage) as { context?: TikTokPageContext };
+    return { tabId, context: response?.context };
+  }
 }
 
 function downloadText(filename: string, content: string, type: string): void {
@@ -45,11 +68,7 @@ function percent(value: number | undefined): string {
 function formatDate(timestamp: number | undefined): string {
   if (!timestamp) return '—';
   return new Intl.DateTimeFormat('ru-RU', {
-    day: '2-digit',
-    month: 'short',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
+    day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit',
   }).format(new Date(timestamp));
 }
 
@@ -60,34 +79,63 @@ function initials(profile: ProfileSnapshot): string {
 
 export default function App() {
   const [dashboard, setDashboard] = useState<DashboardData>(emptyDashboard);
+  const [viewMode, setViewMode] = useState<ViewMode>('profile');
+  const [pageContext, setPageContext] = useState<TikTokPageContext>();
   const [selectedProfile, setSelectedProfile] = useState('');
+  const [selectedTag, setSelectedTag] = useState('');
   const [sortKey, setSortKey] = useState<SortKey>('outlierScore');
   const [query, setQuery] = useState('');
   const [minOutlier, setMinOutlier] = useState(0);
   const [maxVideos, setMaxVideos] = useState(defaultOptions.maxVideos);
+  const [topVideosPerAccount, setTopVideosPerAccount] = useState(defaultOptions.topVideosPerAccount);
+  const [minViews, setMinViews] = useState(defaultOptions.minViews);
   const [error, setError] = useState('');
 
   const refresh = async () => {
     const data = await browser.runtime.sendMessage({ type: 'GET_DASHBOARD' } satisfies RuntimeMessage) as DashboardData;
-    setDashboard(data ?? emptyDashboard);
+    setDashboard({ ...emptyDashboard, ...data, tagResearch: data?.tagResearch ?? {} });
+  };
+
+  const detectPageContext = async () => {
+    try {
+      const connection = await connectToActiveTikTokTab();
+      setPageContext(connection.context);
+      if (connection.context?.kind === 'tag') setViewMode('tag');
+      if (connection.context?.kind === 'profile') setViewMode('profile');
+    } catch {
+      setPageContext(undefined);
+    }
   };
 
   useEffect(() => {
     void refresh();
+    void detectPageContext();
     const listener = (message: { type?: string; dashboard?: DashboardData }) => {
-      if (message.type === 'DASHBOARD_UPDATED' && message.dashboard) setDashboard(message.dashboard);
+      if (message.type === 'DASHBOARD_UPDATED' && message.dashboard) {
+        setDashboard({ ...emptyDashboard, ...message.dashboard, tagResearch: message.dashboard.tagResearch ?? {} });
+      }
     };
     browser.runtime.onMessage.addListener(listener);
     return () => browser.runtime.onMessage.removeListener(listener);
   }, []);
 
   const usernames = Object.keys(dashboard.profiles).sort();
+  const tags = Object.keys(dashboard.tagResearch).sort();
+
   useEffect(() => {
     if (!selectedProfile && usernames[0]) setSelectedProfile(usernames[0]);
     if (dashboard.activeScan.username && dashboard.profiles[dashboard.activeScan.username]) {
       setSelectedProfile(dashboard.activeScan.username);
     }
   }, [dashboard.activeScan.username, usernames.join('|')]);
+
+  useEffect(() => {
+    if (!selectedTag && tags[0]) setSelectedTag(tags[0]);
+    if (dashboard.activeScan.tag && dashboard.tagResearch[dashboard.activeScan.tag.toLowerCase()]) {
+      setSelectedTag(dashboard.activeScan.tag.toLowerCase());
+      setViewMode('tag');
+    }
+  }, [dashboard.activeScan.tag, tags.join('|')]);
 
   const profile = selectedProfile ? dashboard.profiles[selectedProfile] : undefined;
   const enriched = useMemo(() => enrichVideos(profile?.videos ?? []), [profile?.videos]);
@@ -102,28 +150,36 @@ export default function App() {
   const frequency = useMemo(() => publicationFrequencyPerWeek(profile?.videos ?? []), [profile?.videos]);
   const topHashtags = useMemo(() => strongestHashtags(enriched), [enriched]);
 
+  const tagSnapshot = selectedTag ? dashboard.tagResearch[selectedTag] : undefined;
+  useEffect(() => {
+    if (!tagSnapshot) return;
+    setTopVideosPerAccount(tagSnapshot.topVideosPerAccount);
+    setMinViews(tagSnapshot.minViews);
+  }, [selectedTag]);
+
+  const tagGroups = useMemo(
+    () => groupTopVideosPerAccount(tagSnapshot?.videos ?? [], topVideosPerAccount, minViews),
+    [tagSnapshot?.videos, topVideosPerAccount, minViews],
+  );
+  const selectedTagVideos = useMemo(() => tagGroups.flatMap((group) => group.videos), [tagGroups]);
+  const enrichedTagVideos = useMemo(() => new Map(
+    enrichVideos(selectedTagVideos).map((video) => [`${video.author.toLowerCase()}:${video.id}`, video]),
+  ), [selectedTagVideos]);
+
   const start = async () => {
     setError('');
-    const tabId = await activeTabId();
-    if (!tabId) return setError('Активная вкладка не найдена.');
     try {
-      try {
-        await browser.tabs.sendMessage(tabId, { type: 'PING' } satisfies RuntimeMessage);
-      } catch {
-        await browser.scripting.executeScript({
-          target: { tabId },
-          files: ['/content-scripts/content.js'],
-        });
-        await new Promise((resolve) => setTimeout(resolve, 150));
-      }
-
+      const { tabId, context } = await connectToActiveTikTokTab();
+      setPageContext(context);
+      if (!context) throw new Error('Откройте публичный профиль TikTok или страницу хэштега TikTok.');
+      setViewMode(context.kind);
       await browser.tabs.sendMessage(tabId, {
         type: 'START_SCAN',
-        options: { ...defaultOptions, maxVideos },
+        options: { ...defaultOptions, maxVideos, topVideosPerAccount, minViews },
       } satisfies RuntimeMessage);
     } catch (cause) {
       const details = cause instanceof Error ? cause.message : String(cause);
-      setError(`Не удалось подключиться к вкладке TikTok. Перезагрузите страницу. ${details}`);
+      setError(`Не удалось подключиться к вкладке TikTok. ${details}`);
     }
   };
 
@@ -132,58 +188,204 @@ export default function App() {
     if (tabId) await browser.tabs.sendMessage(tabId, { type: 'STOP_SCAN' } satisfies RuntimeMessage).catch(() => undefined);
   };
 
-  const clear = async () => {
+  const clearProfileData = async () => {
     if (!selectedProfile) return;
     const data = await browser.runtime.sendMessage({ type: 'CLEAR_PROFILE', username: selectedProfile } satisfies RuntimeMessage) as DashboardData;
     setDashboard(data);
     setSelectedProfile('');
   };
 
-  const exportCsv = () => {
-    if (!profile) return;
-    downloadText(`${profile.username}-tiktok-analysis.csv`, `\uFEFF${videosToCsv(visible)}`, 'text/csv;charset=utf-8');
+  const clearTagData = async () => {
+    if (!selectedTag) return;
+    const data = await browser.runtime.sendMessage({ type: 'CLEAR_TAG_RESEARCH', tag: selectedTag } satisfies RuntimeMessage) as DashboardData;
+    setDashboard(data);
+    setSelectedTag('');
   };
 
-  const exportJson = () => {
+  const exportProfileCsv = () => {
     if (!profile) return;
-    downloadText(`${profile.username}-tiktok-analysis.json`, JSON.stringify({ profile, videos: visible }, null, 2), 'application/json');
+    downloadText(`${profile.username}-tiktok-analysis-v${APP_VERSION}.csv`, `\uFEFF${videosToCsv(visible)}`, 'text/csv;charset=utf-8');
   };
+
+  const exportProfileJson = () => {
+    if (!profile) return;
+    downloadText(
+      `${profile.username}-tiktok-analysis-v${APP_VERSION}.json`,
+      JSON.stringify({ version: APP_VERSION, profile, videos: visible }, null, 2),
+      'application/json',
+    );
+  };
+
+  const exportTagCsv = () => {
+    if (!tagSnapshot) return;
+    const enrichedVideos = selectedTagVideos.map((video) =>
+      enrichedTagVideos.get(`${video.author.toLowerCase()}:${video.id}`) ?? video as EnrichedVideo
+    );
+    downloadText(`${tagSnapshot.tag}-top-videos-v${APP_VERSION}.csv`, `\uFEFF${videosToCsv(enrichedVideos)}`, 'text/csv;charset=utf-8');
+  };
+
+  const exportTagJson = () => {
+    if (!tagSnapshot) return;
+    downloadText(
+      `${tagSnapshot.tag}-top-videos-v${APP_VERSION}.json`,
+      JSON.stringify({
+        version: APP_VERSION,
+        tag: tagSnapshot.tag,
+        tagUrl: tagSnapshot.tagUrl,
+        topVideosPerAccount,
+        minViews,
+        scannedVideos: tagSnapshot.scannedVideos,
+        accountsFound: tagSnapshot.accountsFound,
+        accounts: tagGroups,
+      }, null, 2),
+      'application/json',
+    );
+  };
+
+  const scanning = dashboard.activeScan.status === 'scanning';
+  const detectedLabel = pageContext?.kind === 'tag'
+    ? `Страница хэштега #${pageContext.tag}`
+    : pageContext?.kind === 'profile'
+      ? `Профиль @${pageContext.username}`
+      : 'Откройте профиль или страницу хэштега TikTok';
 
   return (
     <main className="app-shell">
       <header className="hero">
         <div>
-          <p className="eyebrow">LOCAL-FIRST RESEARCH TOOL</p>
+          <p className="eyebrow">LOCAL-FIRST RESEARCH TOOL · v{APP_VERSION}</p>
           <h1>TikTok Research Sorter</h1>
-          <p className="subtitle">Находит сильнейшие ролики профиля и считает вирусные выбросы.</p>
+          <p className="subtitle">Сканирует профили и страницы хэштегов, затем находит самые просматриваемые ролики каждого аккаунта.</p>
         </div>
         <span className={`status status-${dashboard.activeScan.status}`}>{dashboard.activeScan.status}</span>
       </header>
 
+      <section className="panel context-panel">
+        <span>Текущая вкладка</span>
+        <strong>{detectedLabel}</strong>
+        <button onClick={() => void detectPageContext()}>Обновить</button>
+      </section>
+
+      <section className="mode-tabs">
+        <button className={viewMode === 'profile' ? 'active' : ''} onClick={() => setViewMode('profile')}>Профили</button>
+        <button className={viewMode === 'tag' ? 'active' : ''} onClick={() => setViewMode('tag')}>Хэштеги</button>
+      </section>
+
       <section className="panel scan-panel">
         <div className="control-row">
           <label>
-            Лимит роликов
+            Сканировать роликов
             <select value={maxVideos} onChange={(event) => setMaxVideos(Number(event.target.value))}>
               {[50, 100, 300, 500, 1000].map((value) => <option key={value} value={value}>{value}</option>)}
             </select>
           </label>
-          <button className="primary" onClick={start} disabled={dashboard.activeScan.status === 'scanning'}>Сканировать профиль</button>
-          <button className="secondary" onClick={stop} disabled={dashboard.activeScan.status !== 'scanning'}>Стоп</button>
+          {viewMode === 'tag' && (
+            <>
+              <label>
+                Лучших с аккаунта
+                <select value={topVideosPerAccount} onChange={(event) => setTopVideosPerAccount(Number(event.target.value))}>
+                  {[1, 2, 3, 5, 10].map((value) => <option key={value} value={value}>{value}</option>)}
+                </select>
+              </label>
+              <label>
+                Минимум просмотров
+                <input type="number" min="0" step="1000" value={minViews} onChange={(event) => setMinViews(Math.max(0, Number(event.target.value)))} />
+              </label>
+            </>
+          )}
+          <button className="primary" onClick={start} disabled={scanning}>
+            {viewMode === 'tag' ? 'Сканировать хэштег' : 'Сканировать профиль'}
+          </button>
+          <button className="secondary" onClick={stop} disabled={!scanning}>Стоп</button>
         </div>
         <div className="progress-track"><div className="progress-fill" style={{ width: `${Math.min(100, (dashboard.activeScan.videosFound / maxVideos) * 100)}%` }} /></div>
-        <p className="scan-message">{dashboard.activeScan.message ?? 'Откройте профиль TikTok и нажмите «Сканировать профиль».'}</p>
+        <p className="scan-message">{dashboard.activeScan.message ?? 'Откройте нужную страницу TikTok и запустите сканирование.'}</p>
+        {viewMode === 'tag' && <p className="hint">Выбираются лучшие ролики каждого аккаунта среди роликов, найденных на открытой странице хэштега.</p>}
         {error && <p className="error">{error}</p>}
       </section>
 
-      {profile && (
-        <ProfileCard
+      {viewMode === 'profile' ? (
+        <ProfileResults
           profile={profile}
           summary={summary}
           frequency={frequency}
           topHashtags={topHashtags}
+          usernames={usernames}
+          selectedProfile={selectedProfile}
+          setSelectedProfile={setSelectedProfile}
+          sortKey={sortKey}
+          setSortKey={setSortKey}
+          query={query}
+          setQuery={setQuery}
+          minOutlier={minOutlier}
+          setMinOutlier={setMinOutlier}
+          visible={visible}
+          enrichedCount={enriched.length}
+          exportCsv={exportProfileCsv}
+          exportJson={exportProfileJson}
+          clear={clearProfileData}
+        />
+      ) : (
+        <TagResults
+          tags={tags}
+          selectedTag={selectedTag}
+          setSelectedTag={setSelectedTag}
+          snapshot={tagSnapshot}
+          groups={tagGroups}
+          enrichedVideos={enrichedTagVideos}
+          selectedCount={selectedTagVideos.length}
+          minViews={minViews}
+          exportCsv={exportTagCsv}
+          exportJson={exportTagJson}
+          clear={clearTagData}
         />
       )}
+    </main>
+  );
+}
+
+function ProfileResults({
+  profile,
+  summary,
+  frequency,
+  topHashtags,
+  usernames,
+  selectedProfile,
+  setSelectedProfile,
+  sortKey,
+  setSortKey,
+  query,
+  setQuery,
+  minOutlier,
+  setMinOutlier,
+  visible,
+  enrichedCount,
+  exportCsv,
+  exportJson,
+  clear,
+}: {
+  profile?: ProfileSnapshot;
+  summary: ReturnType<typeof summarize>;
+  frequency: number | undefined;
+  topHashtags: string[];
+  usernames: string[];
+  selectedProfile: string;
+  setSelectedProfile: (value: string) => void;
+  sortKey: SortKey;
+  setSortKey: (value: SortKey) => void;
+  query: string;
+  setQuery: (value: string) => void;
+  minOutlier: number;
+  setMinOutlier: (value: number) => void;
+  visible: EnrichedVideo[];
+  enrichedCount: number;
+  exportCsv: () => void;
+  exportJson: () => void;
+  clear: () => void;
+}) {
+  return (
+    <>
+      {profile && <ProfileCard profile={profile} summary={summary} frequency={frequency} topHashtags={topHashtags} />}
 
       <section className="panel toolbar">
         <label>
@@ -227,14 +429,91 @@ export default function App() {
         <button onClick={exportCsv} disabled={!visible.length}>CSV</button>
         <button onClick={exportJson} disabled={!visible.length}>JSON</button>
         <button className="danger" onClick={clear} disabled={!profile}>Удалить профиль</button>
-        <span>{visible.length} из {enriched.length}</span>
+        <span>{visible.length} из {enrichedCount}</span>
       </section>
 
       <section className="video-list">
-        {visible.map((video, index) => <VideoCard key={video.id} video={video} rank={index + 1} />)}
+        {visible.map((video, index) => <VideoCard key={video.id} video={video} rank={index + 1} showOutlier />)}
         {!visible.length && <div className="empty">Пока нет собранных роликов.</div>}
       </section>
-    </main>
+    </>
+  );
+}
+
+function TagResults({
+  tags,
+  selectedTag,
+  setSelectedTag,
+  snapshot,
+  groups,
+  enrichedVideos,
+  selectedCount,
+  minViews,
+  exportCsv,
+  exportJson,
+  clear,
+}: {
+  tags: string[];
+  selectedTag: string;
+  setSelectedTag: (value: string) => void;
+  snapshot: DashboardData['tagResearch'][string] | undefined;
+  groups: ReturnType<typeof groupTopVideosPerAccount>;
+  enrichedVideos: Map<string, EnrichedVideo>;
+  selectedCount: number;
+  minViews: number;
+  exportCsv: () => void;
+  exportJson: () => void;
+  clear: () => void;
+}) {
+  return (
+    <>
+      <section className="panel toolbar">
+        <label>
+          Хэштег
+          <select value={selectedTag} onChange={(event) => setSelectedTag(event.target.value)}>
+            <option value="">Нет данных</option>
+            {tags.map((tag) => <option key={tag} value={tag}>#{tag}</option>)}
+          </select>
+        </label>
+        {snapshot && <a className="source-link" href={snapshot.tagUrl} target="_blank" rel="noreferrer">Открыть #{snapshot.tag}</a>}
+      </section>
+
+      <section className="stats-grid">
+        <article><span>Просканировано</span><strong>{snapshot?.scannedVideos ?? 0}</strong></article>
+        <article><span>Аккаунтов</span><strong>{snapshot?.accountsFound ?? 0}</strong></article>
+        <article><span>Выбрано роликов</span><strong>{selectedCount}</strong></article>
+        <article><span>Минимум просмотров</span><strong>{formatCompactNumber(minViews)}</strong></article>
+      </section>
+
+      <section className="panel actions">
+        <button onClick={exportCsv} disabled={!selectedCount}>CSV</button>
+        <button onClick={exportJson} disabled={!selectedCount}>JSON</button>
+        <button className="danger" onClick={clear} disabled={!snapshot}>Удалить хэштег</button>
+        <span>{groups.length} аккаунтов</span>
+      </section>
+
+      <section className="account-groups">
+        {groups.map((group) => (
+          <section className="account-group" key={group.author}>
+            <header>
+              <a href={group.profileUrl} target="_blank" rel="noreferrer">@{group.author}</a>
+              <span>{group.videos.length} лучших · максимум {formatCompactNumber(group.topViews)}</span>
+            </header>
+            <div className="video-list">
+              {group.videos.map((video, index) => (
+                <VideoCard
+                  key={`${group.author}:${video.id}`}
+                  video={enrichedVideos.get(`${group.author.toLowerCase()}:${video.id}`) ?? video as EnrichedVideo}
+                  rank={index + 1}
+                  showAuthor={false}
+                />
+              ))}
+            </div>
+          </section>
+        ))}
+        {!groups.length && <div className="empty">Нет роликов, подходящих под выбранный минимум просмотров.</div>}
+      </section>
+    </>
   );
 }
 
@@ -295,7 +574,17 @@ function ProfileCard({
   );
 }
 
-function VideoCard({ video, rank }: { video: EnrichedVideo; rank: number }) {
+function VideoCard({
+  video,
+  rank,
+  showOutlier = false,
+  showAuthor = true,
+}: {
+  video: EnrichedVideo;
+  rank: number;
+  showOutlier?: boolean;
+  showAuthor?: boolean;
+}) {
   return (
     <article className="video-card">
       <a className="cover" href={video.videoUrl} target="_blank" rel="noreferrer">
@@ -303,10 +592,11 @@ function VideoCard({ video, rank }: { video: EnrichedVideo; rank: number }) {
         <span className="rank">#{rank}</span>
       </a>
       <div className="video-copy">
+        {showAuthor && <a className="video-author" href={video.profileUrl} target="_blank" rel="noreferrer">@{video.author}</a>}
         <div className="metrics">
           <strong>{formatCompactNumber(video.views)} views</strong>
-          <span>{video.outlierScore?.toFixed(1) ?? '—'}× outlier</span>
-          <span>{formatCompactNumber(video.viewsPerDay ?? 0)}/day</span>
+          {showOutlier && <span>{video.outlierScore?.toFixed(1) ?? '—'}× outlier</span>}
+          {video.viewsPerDay !== undefined && <span>{formatCompactNumber(video.viewsPerDay)}/day</span>}
         </div>
         <p>{video.description || 'Без описания'}</p>
         <div className="micro-metrics">

--- a/projects/tiktok-research-sorter/entrypoints/sidepanel/style.css
+++ b/projects/tiktok-research-sorter/entrypoints/sidepanel/style.css
@@ -4,9 +4,10 @@ body { margin: 0; min-width: 330px; background: radial-gradient(circle at top ri
 button, input, select { font: inherit; }
 button { border: 0; cursor: pointer; }
 button:disabled { cursor: not-allowed; opacity: .45; }
+a { color: inherit; }
 .app-shell { padding: 18px; display: grid; gap: 14px; }
 .hero { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
-.eyebrow { color: #8d90a8; letter-spacing: .14em; font-size: 10px; margin: 0 0 6px; }
+.eyebrow { color: #8d90a8; letter-spacing: .12em; font-size: 9px; margin: 0 0 6px; }
 h1 { font-size: 22px; margin: 0; line-height: 1.05; }
 h2 { margin: 0; font-size: 18px; line-height: 1.15; }
 .subtitle { color: #aeb2c6; font-size: 13px; line-height: 1.45; margin: 8px 0 0; }
@@ -15,6 +16,13 @@ h2 { margin: 0; font-size: 18px; line-height: 1.15; }
 .status-complete { background: #123424; color: #79e5aa; }
 .status-error, .status-blocked { background: #471c25; color: #ff95a8; }
 .panel { background: rgba(24, 28, 40, .88); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 13px; box-shadow: 0 12px 30px rgba(0,0,0,.22); }
+.context-panel { display: grid; grid-template-columns: minmax(0,1fr) auto; gap: 4px 10px; align-items: center; }
+.context-panel > span { color: #8f95aa; font-size: 9px; text-transform: uppercase; letter-spacing: .06em; }
+.context-panel > strong { font-size: 12px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.context-panel > button { grid-column: 2; grid-row: 1 / span 2; padding: 7px 9px; }
+.mode-tabs { display: grid; grid-template-columns: 1fr 1fr; gap: 7px; padding: 4px; background: #111621; border: 1px solid rgba(255,255,255,.07); border-radius: 12px; }
+.mode-tabs button { background: transparent; color: #969bae; }
+.mode-tabs button.active { color: #fff; background: linear-gradient(135deg, rgba(122,92,255,.85), rgba(208,79,255,.72)); font-weight: 700; }
 .control-row, .toolbar, .actions { display: flex; gap: 9px; align-items: end; flex-wrap: wrap; }
 label { display: grid; gap: 5px; color: #aeb2c6; font-size: 11px; flex: 1; min-width: 110px; }
 select, input { width: 100%; color: #f6f7fb; background: #0f131e; border: 1px solid #303648; border-radius: 9px; padding: 8px 9px; outline: none; }
@@ -26,6 +34,7 @@ button { color: #f7f7fb; background: #303648; border-radius: 9px; padding: 9px 1
 .progress-track { height: 6px; background: #0d1018; border-radius: 999px; overflow: hidden; margin-top: 12px; }
 .progress-fill { height: 100%; background: linear-gradient(90deg, #24e7ca, #d04fff); transition: width .25s ease; }
 .scan-message { color: #aeb2c6; font-size: 12px; margin: 9px 0 0; }
+.hint { color: #777f95; font-size: 10px; line-height: 1.4; margin: 6px 0 0; }
 .error { color: #ff91a4; font-size: 12px; margin: 8px 0 0; }
 .profile-card { display: grid; gap: 13px; overflow: hidden; position: relative; }
 .profile-card::before { content: ""; position: absolute; inset: 0 0 auto; height: 3px; background: linear-gradient(90deg, #24e7ca, #7a5cff, #d04fff); }
@@ -50,6 +59,7 @@ button { color: #f7f7fb; background: #303648; border-radius: 9px; padding: 9px 1
 .profile-topics > div { display: flex; flex-wrap: wrap; gap: 5px; }
 .profile-topics div > span { padding: 5px 7px; border-radius: 9px; color: #6ee6d2; background: rgba(36,231,202,.09); border: 1px solid rgba(36,231,202,.16); font-size: 9px; }
 .profile-topics em { color: #81879a; font-size: 10px; font-style: normal; }
+.source-link { color: #8fded3; text-decoration: none; font-size: 11px; padding: 8px 0; }
 .stats-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 9px; }
 .stats-grid article { background: #171b27; border: 1px solid rgba(255,255,255,.07); border-radius: 12px; padding: 11px; }
 .stats-grid span { display: block; color: #9297aa; font-size: 10px; }
@@ -62,6 +72,7 @@ button { color: #f7f7fb; background: #303648; border-radius: 9px; padding: 9px 1
 .cover-placeholder { height: 100%; display: grid; place-items: center; color: #6f7487; font-weight: 800; }
 .rank { position: absolute; top: 5px; left: 5px; color: #fff; background: rgba(0,0,0,.68); border-radius: 6px; padding: 3px 5px; font-size: 10px; }
 .video-copy { min-width: 0; }
+.video-author { display: inline-block; color: #8fded3; text-decoration: none; font-size: 10px; margin-bottom: 5px; }
 .metrics { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
 .metrics strong { color: #fff; font-size: 12px; }
 .metrics span { color: #d2c8ff; background: #2b2446; border-radius: 999px; padding: 3px 6px; font-size: 9px; }
@@ -69,6 +80,11 @@ button { color: #f7f7fb; background: #303648; border-radius: 9px; padding: 9px 1
 .micro-metrics { display: flex; gap: 8px; flex-wrap: wrap; color: #9fa4b6; font-size: 10px; }
 .hashtags { display: flex; gap: 4px; flex-wrap: wrap; margin-top: 8px; }
 .hashtags span { color: #6ee6d2; font-size: 9px; }
+.account-groups { display: grid; gap: 12px; }
+.account-group { display: grid; gap: 9px; padding: 12px; border: 1px solid rgba(255,255,255,.08); background: rgba(16,20,30,.75); border-radius: 14px; }
+.account-group > header { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.account-group > header a { color: #8fded3; text-decoration: none; font-weight: 800; font-size: 13px; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+.account-group > header span { color: #8f95aa; font-size: 9px; text-align: right; }
 .empty { color: #8e93a5; text-align: center; padding: 40px 10px; border: 1px dashed #343a4c; border-radius: 14px; }
 @media (min-width: 520px) {
   .stats-grid { grid-template-columns: repeat(4, 1fr); }

--- a/projects/tiktok-research-sorter/lib/store.ts
+++ b/projects/tiktok-research-sorter/lib/store.ts
@@ -1,13 +1,23 @@
 import { browser } from 'wxt/browser';
 import { median } from './analytics';
+import { mergeDiscoveredVideos } from './tag-research';
 import { mergeVideoRecords } from './tiktok-parser';
-import type { DashboardData, ProfileRecord, ProfileSnapshot, ScanState, VideoRecord } from './types';
+import type {
+  DashboardData,
+  ProfileRecord,
+  ProfileSnapshot,
+  ScanOptions,
+  ScanState,
+  TagResearchSnapshot,
+  VideoRecord,
+} from './types';
 
 const STORAGE_KEY = 'tiktokResearchSorter.dashboard.v1';
 const STALE_SCAN_MS = 2 * 60 * 1000;
 
 const initialState: DashboardData = {
   profiles: {},
+  tagResearch: {},
   activeScan: {
     status: 'idle',
     videosFound: 0,
@@ -21,10 +31,22 @@ const sourcePriority: Record<ProfileRecord['source'], number> = {
   api: 3,
 };
 
+function normalizeTagKey(tag: string): string {
+  return tag.trim().replace(/^#/, '').toLowerCase();
+}
+
+function normalizeDashboard(value: DashboardData | undefined): DashboardData {
+  if (!value) return structuredClone(initialState);
+  return {
+    profiles: value.profiles ?? {},
+    tagResearch: value.tagResearch ?? {},
+    activeScan: value.activeScan ?? structuredClone(initialState.activeScan),
+  };
+}
+
 export async function loadDashboard(): Promise<DashboardData> {
   const stored = await browser.storage.local.get(STORAGE_KEY);
-  const value = stored[STORAGE_KEY] as DashboardData | undefined;
-  const dashboard = value ?? structuredClone(initialState);
+  const dashboard = normalizeDashboard(stored[STORAGE_KEY] as DashboardData | undefined);
 
   if (
     dashboard.activeScan.status === 'scanning'
@@ -115,9 +137,68 @@ export async function mergeVideoBatch(username: string, profileUrl: string, vide
   return dashboard;
 }
 
+export async function beginTagResearch(
+  tag: string,
+  tagUrl: string,
+  options: ScanOptions,
+): Promise<DashboardData> {
+  const dashboard = await loadDashboard();
+  const key = normalizeTagKey(tag);
+  dashboard.tagResearch[key] = {
+    tag: key,
+    tagUrl,
+    videos: [],
+    topVideosPerAccount: Math.max(1, Math.floor(options.topVideosPerAccount)),
+    minViews: Math.max(0, Math.floor(options.minViews)),
+    scannedVideos: 0,
+    accountsFound: 0,
+    lastScannedAt: Date.now(),
+  };
+  await saveDashboard(dashboard);
+  return dashboard;
+}
+
+export async function mergeTagVideoBatch(
+  tag: string,
+  tagUrl: string,
+  videos: VideoRecord[],
+): Promise<DashboardData> {
+  const dashboard = await loadDashboard();
+  const key = normalizeTagKey(tag);
+  const existing: TagResearchSnapshot = dashboard.tagResearch[key] ?? {
+    tag: key,
+    tagUrl,
+    videos: [],
+    topVideosPerAccount: 1,
+    minViews: 0,
+    scannedVideos: 0,
+    accountsFound: 0,
+    lastScannedAt: Date.now(),
+  };
+
+  existing.videos = mergeDiscoveredVideos([...existing.videos, ...videos]);
+  existing.scannedVideos = existing.videos.length;
+  existing.accountsFound = new Set(existing.videos.map((video) => video.author.toLowerCase())).size;
+  existing.lastScannedAt = Date.now();
+  existing.tagUrl = tagUrl;
+  dashboard.tagResearch[key] = existing;
+  dashboard.activeScan.videosFound = existing.scannedVideos;
+  dashboard.activeScan.accountsFound = existing.accountsFound;
+  dashboard.activeScan.updatedAt = Date.now();
+  await saveDashboard(dashboard);
+  return dashboard;
+}
+
 export async function clearProfile(username: string): Promise<DashboardData> {
   const dashboard = await loadDashboard();
   delete dashboard.profiles[username];
+  await saveDashboard(dashboard);
+  return dashboard;
+}
+
+export async function clearTagResearch(tag: string): Promise<DashboardData> {
+  const dashboard = await loadDashboard();
+  delete dashboard.tagResearch[normalizeTagKey(tag)];
   await saveDashboard(dashboard);
   return dashboard;
 }

--- a/projects/tiktok-research-sorter/lib/tag-research.ts
+++ b/projects/tiktok-research-sorter/lib/tag-research.ts
@@ -1,0 +1,73 @@
+import { mergeVideoRecords } from './tiktok-parser';
+import type { VideoRecord } from './types';
+
+export interface AccountVideoGroup {
+  author: string;
+  profileUrl: string;
+  videos: VideoRecord[];
+  topViews: number;
+}
+
+function normalizeLimit(value: number): number {
+  if (!Number.isFinite(value)) return 1;
+  return Math.min(20, Math.max(1, Math.floor(value)));
+}
+
+function normalizeMinViews(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value));
+}
+
+export function mergeDiscoveredVideos(videos: VideoRecord[]): VideoRecord[] {
+  const merged = new Map<string, VideoRecord>();
+
+  for (const video of videos) {
+    const author = video.author.trim().replace(/^@/, '').toLowerCase();
+    if (!author || !video.id) continue;
+    const key = `${author}:${video.id}`;
+    const existing = merged.get(key);
+    merged.set(key, existing ? mergeVideoRecords(existing, video) : { ...video, author });
+  }
+
+  return [...merged.values()];
+}
+
+export function groupTopVideosPerAccount(
+  videos: VideoRecord[],
+  topVideosPerAccount: number,
+  minViews: number,
+): AccountVideoGroup[] {
+  const limit = normalizeLimit(topVideosPerAccount);
+  const threshold = normalizeMinViews(minViews);
+  const byAuthor = new Map<string, VideoRecord[]>();
+
+  for (const video of mergeDiscoveredVideos(videos)) {
+    if (video.views < threshold) continue;
+    const list = byAuthor.get(video.author) ?? [];
+    list.push(video);
+    byAuthor.set(video.author, list);
+  }
+
+  return [...byAuthor.entries()]
+    .map(([author, accountVideos]) => {
+      const selected = [...accountVideos]
+        .sort((a, b) => b.views - a.views || (b.publishedAt ?? 0) - (a.publishedAt ?? 0) || a.id.localeCompare(b.id))
+        .slice(0, limit);
+      return {
+        author,
+        profileUrl: selected[0]?.profileUrl ?? `https://www.tiktok.com/@${author}`,
+        videos: selected,
+        topViews: selected[0]?.views ?? 0,
+      };
+    })
+    .filter((group) => group.videos.length > 0)
+    .sort((a, b) => b.topViews - a.topViews || a.author.localeCompare(b.author));
+}
+
+export function selectTopVideosPerAccount(
+  videos: VideoRecord[],
+  topVideosPerAccount: number,
+  minViews: number,
+): VideoRecord[] {
+  return groupTopVideosPerAccount(videos, topVideosPerAccount, minViews).flatMap((group) => group.videos);
+}

--- a/projects/tiktok-research-sorter/lib/tiktok-parser.ts
+++ b/projects/tiktok-research-sorter/lib/tiktok-parser.ts
@@ -152,7 +152,7 @@ export function extractVideosFromPayload(
 
     if (looksLikeVideoItem(value)) {
       const normalized = normalizeTikTokItem(value, fallbackAuthor, source);
-      if (normalized) found.set(normalized.id, normalized);
+      if (normalized) found.set(`${normalized.author.toLowerCase()}:${normalized.id}`, normalized);
     }
 
     if (Array.isArray(value)) {
@@ -298,41 +298,71 @@ export function extractProfileFromDom(username: string): ProfileRecord {
   };
 }
 
-export function extractVideosFromDom(username: string): VideoRecord[] {
+export function parseTikTokVideoUrl(value: string, baseUrl = 'https://www.tiktok.com'): { author: string; id: string; videoUrl: string } | undefined {
+  try {
+    const url = new URL(value, baseUrl);
+    const match = url.pathname.match(/^\/@([^/]+)\/video\/(\d+)/i);
+    if (!match?.[1] || !match[2]) return undefined;
+    const author = decodeURIComponent(match[1]).replace(/^@/, '');
+    if (!author) return undefined;
+    return {
+      author,
+      id: match[2],
+      videoUrl: `${url.origin}/@${author}/video/${match[2]}`,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function extractVideoFromLink(link: HTMLAnchorElement): VideoRecord | undefined {
+  const parsed = parseTikTokVideoUrl(link.href, location.origin);
+  if (!parsed) return undefined;
+
+  const card = link.closest<HTMLElement>(
+    '[data-e2e="user-post-item"], [data-e2e="challenge-item"], [data-e2e="search-card-video-container"], article, li, div'
+  );
+  const viewsNode = card?.querySelector<HTMLElement>(
+    '[data-e2e="video-views"], [data-e2e="search-card-video-views"], [class*="video-count"], strong'
+  );
+  const image = link.querySelector<HTMLImageElement>('img') ?? card?.querySelector<HTMLImageElement>('img');
+  const description = image?.alt ?? link.getAttribute('aria-label') ?? '';
+  const cardText = card?.textContent?.toLowerCase() ?? '';
+
+  return {
+    id: parsed.id,
+    author: parsed.author,
+    profileUrl: `https://www.tiktok.com/@${parsed.author}`,
+    videoUrl: parsed.videoUrl,
+    description,
+    views: parseCompactNumber(viewsNode?.textContent),
+    likes: 0,
+    comments: 0,
+    shares: 0,
+    coverUrl: sanitizeHttpUrl(image?.currentSrc || image?.src || undefined),
+    hashtags: Array.from(description.matchAll(/#([\p{L}\p{N}_]+)/gu), (entry) => entry[1] ?? '').filter(Boolean),
+    isPinned: ['pinned', 'закреплено', 'fixé', 'angeheftet'].some((label) => cardText.includes(label)),
+    collectedAt: Date.now(),
+    source: 'dom',
+  };
+}
+
+export function extractVideosFromDiscoveryDom(): VideoRecord[] {
   const found = new Map<string, VideoRecord>();
-  const links = document.querySelectorAll<HTMLAnchorElement>(`a[href*="/@${CSS.escape(username)}/video/"]`);
+  const links = document.querySelectorAll<HTMLAnchorElement>('a[href*="/video/"]');
 
   for (const link of links) {
-    const url = new URL(link.href, location.origin);
-    const match = url.pathname.match(/\/video\/(\d+)/);
-    const id = match?.[1];
-    if (!id || found.has(id)) continue;
-
-    const card = link.closest<HTMLElement>('[data-e2e="user-post-item"], [data-e2e="user-post-item-list"] > div, div');
-    const viewsNode = card?.querySelector<HTMLElement>('[data-e2e="video-views"], strong');
-    const image = link.querySelector<HTMLImageElement>('img') ?? card?.querySelector<HTMLImageElement>('img');
-    const description = image?.alt ?? link.getAttribute('aria-label') ?? '';
-    const cardText = card?.textContent?.toLowerCase() ?? '';
-
-    found.set(id, {
-      id,
-      author: username,
-      profileUrl: `https://www.tiktok.com/@${username}`,
-      videoUrl: url.toString().split('?')[0] ?? url.toString(),
-      description,
-      views: parseCompactNumber(viewsNode?.textContent),
-      likes: 0,
-      comments: 0,
-      shares: 0,
-      coverUrl: sanitizeHttpUrl(image?.currentSrc || image?.src || undefined),
-      hashtags: Array.from(description.matchAll(/#([\p{L}\p{N}_]+)/gu), (entry) => entry[1] ?? '').filter(Boolean),
-      isPinned: ['pinned', 'закреплено', 'fixé', 'angeheftet'].some((label) => cardText.includes(label)),
-      collectedAt: Date.now(),
-      source: 'dom',
-    });
+    const video = extractVideoFromLink(link);
+    if (!video) continue;
+    found.set(`${video.author.toLowerCase()}:${video.id}`, video);
   }
 
   return [...found.values()];
+}
+
+export function extractVideosFromDom(username: string): VideoRecord[] {
+  const normalized = username.toLowerCase();
+  return extractVideosFromDiscoveryDom().filter((video) => video.author.toLowerCase() === normalized);
 }
 
 export function mergeVideoRecords(current: VideoRecord, incoming: VideoRecord): VideoRecord {

--- a/projects/tiktok-research-sorter/lib/types.ts
+++ b/projects/tiktok-research-sorter/lib/types.ts
@@ -1,4 +1,21 @@
+export const APP_VERSION = '0.3.0';
+
 export type ScanStatus = 'idle' | 'scanning' | 'paused' | 'complete' | 'stopped' | 'blocked' | 'error';
+export type ScanMode = 'profile' | 'tag';
+
+export interface ProfilePageContext {
+  kind: 'profile';
+  username: string;
+  profileUrl: string;
+}
+
+export interface TagPageContext {
+  kind: 'tag';
+  tag: string;
+  tagUrl: string;
+}
+
+export type TikTokPageContext = ProfilePageContext | TagPageContext;
 
 export interface VideoRecord {
   id: string;
@@ -55,21 +72,38 @@ export interface ProfileSnapshot extends Omit<ProfileRecord, 'collectedAt' | 'so
   profileDataSource?: ProfileRecord['source'];
 }
 
-export interface ScanState {
-  status: ScanStatus;
-  username?: string;
-  profileUrl?: string;
-  videosFound: number;
-  startedAt?: number;
-  updatedAt: number;
-  oldestPublishedAt?: number;
-  message?: string;
-}
-
 export interface ScanOptions {
   maxVideos: number;
   maxIdleRounds: number;
   scrollDelayMs: number;
+  topVideosPerAccount: number;
+  minViews: number;
+}
+
+export interface TagResearchSnapshot {
+  tag: string;
+  tagUrl: string;
+  videos: VideoRecord[];
+  topVideosPerAccount: number;
+  minViews: number;
+  scannedVideos: number;
+  accountsFound: number;
+  lastScannedAt: number;
+}
+
+export interface ScanState {
+  status: ScanStatus;
+  mode?: ScanMode;
+  username?: string;
+  profileUrl?: string;
+  tag?: string;
+  tagUrl?: string;
+  videosFound: number;
+  accountsFound?: number;
+  startedAt?: number;
+  updatedAt: number;
+  oldestPublishedAt?: number;
+  message?: string;
 }
 
 export type RuntimeMessage =
@@ -78,12 +112,16 @@ export type RuntimeMessage =
   | { type: 'STOP_SCAN' }
   | { type: 'GET_DASHBOARD' }
   | { type: 'CLEAR_PROFILE'; username: string }
+  | { type: 'CLEAR_TAG_RESEARCH'; tag: string }
   | { type: 'PROFILE_DATA'; profile: ProfileRecord }
   | { type: 'VIDEO_BATCH'; username: string; profileUrl: string; videos: VideoRecord[] }
+  | { type: 'TAG_SCAN_BEGIN'; tag: string; tagUrl: string; options: ScanOptions }
+  | { type: 'TAG_VIDEO_BATCH'; tag: string; tagUrl: string; videos: VideoRecord[] }
   | { type: 'SCAN_STATE'; state: ScanState }
   | { type: 'DASHBOARD_UPDATED'; dashboard: DashboardData };
 
 export interface DashboardData {
   profiles: Record<string, ProfileSnapshot>;
+  tagResearch: Record<string, TagResearchSnapshot>;
   activeScan: ScanState;
 }

--- a/projects/tiktok-research-sorter/logs/latest.md
+++ b/projects/tiktok-research-sorter/logs/latest.md
@@ -1,47 +1,58 @@
 # Latest Log — TikTok Research Sorter
 
-Date: 2026-07-12
-Version: `0.2.0`
-Status: integrated into `main`; automatic updater follows `main`
+Date: 2026-07-13
+Version: `0.3.0`
+Issue: `#82`
+Branch: `agent/tiktok-research-sorter-tag-scan-v0.3.0`
+Status: implementation complete locally; final GitHub validation pending
 
-## Completed
+## Added
 
-- Full TikTok profile and video research interface.
-- Serialized background persistence and stale-scan recovery.
-- API → embedded JSON → DOM source precedence.
-- Corrected analytics, localized count parsing, duration normalization, and CSV formula safety.
-- Atomic Windows updater with candidate build, validation, rollback, dedicated Chrome profile, and non-interactive CI mode.
-- 40 unit and regression tests.
-- Linux and Windows GitHub Actions validation.
-- Automatic unpacked extension, extension ZIP, updater ZIP, and source ZIP artifacts.
-- Project Execution OS structure and context-manifest integrity validation.
-- PR #71 merged into `main`.
-- Updater default branch changed from the development branch to `main`.
+- Automatic recognition of TikTok hashtag pages such as `/tag/weddingphotography`.
+- Selected observation of TikTok challenge/search item-list responses.
+- DOM fallback for video links from multiple authors on discovery pages.
+- Hashtag snapshot persistence in `chrome.storage.local`.
+- Per-account grouping and highest-viewed top-N selection.
+- User controls for top 1, 2, 3, 5, or 10 videos per account.
+- User control for minimum view count.
+- Separate profile and hashtag result modes in the side panel.
+- Versioned hashtag/profile CSV and JSON export.
+- Version bump and versioned installation artifacts to `v0.3.0`.
 
-## Final automated verification
+## Automated coverage added
 
-- Project Execution OS structure validation: passed.
-- System-context manifest validation: passed.
-- Linux reproducible install: passed.
-- TypeScript strict check: passed.
-- 40 tests: passed.
-- Chrome MV3 production build: passed.
-- Packaging and artifact upload: passed.
-- Windows zero-side-effect dry run: passed.
-- Windows full updater validation: passed.
-- Generated manifest version check: passed.
+- sanitized `weddingphotography` hashtag payload fixture;
+- extraction of multiple authors from one discovery payload;
+- top-one selection per account;
+- top-two/top-three behavior;
+- minimum-view filtering;
+- duplicate video metric merging;
+- TikTok discovery-link parsing.
 
-## Distribution behavior
+## Local verification performed
 
-The desktop shortcut now downloads `main`, validates the candidate build, preserves the active build on failure, retains one previous version, and launches the dedicated persistent Chrome profile only after success.
+```text
+npm ci --no-audit --no-fund
+npm run check
+npm test
+npm run build
+```
 
-## Remaining boundaries
+Local result for the reconstructed project package:
 
-- No Chrome Web Store submission is authorized.
-- No public GitHub Release is authorized.
-- TikTok can change its public APIs and DOM.
-- IndexedDB remains a future scaling option for very large datasets.
+- TypeScript: passed;
+- new hashtag tests: passed;
+- production Chrome MV3 build: passed;
+- generated manifest version: `0.3.0`.
+
+## Pending final evidence
+
+- GitHub Linux CI;
+- GitHub Windows updater CI;
+- Project Execution OS integrity CI;
+- downloadable v0.3.0 artifacts;
+- pull-request merge into `main`.
 
 ## Owner action
 
-None for installation updates, code validation, packaging, or repository integration.
+None during implementation and automated validation.

--- a/projects/tiktok-research-sorter/package.json
+++ b/projects/tiktok-research-sorter/package.json
@@ -1,9 +1,9 @@
 {
   "name": "tiktok-research-sorter",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
-  "description": "Local-first Chrome extension for scanning and ranking public TikTok profile videos.",
+  "description": "Local-first Chrome extension for scanning public TikTok profiles and hashtag pages, then ranking videos per account.",
   "scripts": {
     "dev": "wxt",
     "build": "wxt build",

--- a/projects/tiktok-research-sorter/tests/fixtures/tag-weddingphotography.json
+++ b/projects/tiktok-research-sorter/tests/fixtures/tag-weddingphotography.json
@@ -1,0 +1,44 @@
+{
+  "itemList": [
+    {
+      "id": "tag001",
+      "desc": "Wedding photo idea #weddingphotography",
+      "createTime": 1700000000,
+      "author": { "uniqueId": "alicephoto" },
+      "video": { "duration": 15000, "cover": "https://example.com/a1.jpg" },
+      "stats": { "playCount": 120000, "diggCount": 9000, "commentCount": 120, "shareCount": 80 }
+    },
+    {
+      "id": "tag002",
+      "desc": "Behind the scenes #weddingphotography",
+      "createTime": 1700100000,
+      "author": { "uniqueId": "alicephoto" },
+      "video": { "duration": 22000, "cover": "https://example.com/a2.jpg" },
+      "stats": { "playCount": 45000, "diggCount": 3000, "commentCount": 50, "shareCount": 20 }
+    },
+    {
+      "id": "tag003",
+      "desc": "Golden hour wedding #weddingphotography",
+      "createTime": 1700200000,
+      "author": { "uniqueId": "bobweddings" },
+      "video": { "duration": 18000, "cover": "https://example.com/b1.jpg" },
+      "stats": { "playCount": 250000, "diggCount": 18000, "commentCount": 200, "shareCount": 150 }
+    },
+    {
+      "id": "tag004",
+      "desc": "Wedding posing tip #weddingphotography",
+      "createTime": 1700300000,
+      "author": { "uniqueId": "bobweddings" },
+      "video": { "duration": 19000, "cover": "https://example.com/b2.jpg" },
+      "stats": { "playCount": 70000, "diggCount": 5000, "commentCount": 70, "shareCount": 40 }
+    },
+    {
+      "id": "tag005",
+      "desc": "Small wedding story #weddingphotography",
+      "createTime": 1700400000,
+      "author": { "uniqueId": "carolstudio" },
+      "video": { "duration": 25000, "cover": "https://example.com/c1.jpg" },
+      "stats": { "playCount": 8000, "diggCount": 500, "commentCount": 10, "shareCount": 5 }
+    }
+  ]
+}

--- a/projects/tiktok-research-sorter/tests/tag-research.test.ts
+++ b/projects/tiktok-research-sorter/tests/tag-research.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { groupTopVideosPerAccount, mergeDiscoveredVideos, selectTopVideosPerAccount } from '../lib/tag-research';
+import { extractVideosFromPayload, parseTikTokVideoUrl } from '../lib/tiktok-parser';
+import type { VideoRecord } from '../lib/types';
+import tagFixture from './fixtures/tag-weddingphotography.json';
+
+const fixtureVideos = () => extractVideosFromPayload(tagFixture, '', 'api');
+
+describe('TikTok hashtag research', () => {
+  it('extracts multiple authors from a hashtag payload', () => {
+    const videos = fixtureVideos();
+    expect(videos).toHaveLength(5);
+    expect(new Set(videos.map((video) => video.author))).toEqual(new Set(['alicephoto', 'bobweddings', 'carolstudio']));
+  });
+
+  it('keeps the single highest-viewed video from every account', () => {
+    const selected = selectTopVideosPerAccount(fixtureVideos(), 1, 0);
+    expect(selected.map((video) => video.id)).toEqual(['tag003', 'tag001', 'tag005']);
+  });
+
+  it('supports two or three top videos per account', () => {
+    const groups = groupTopVideosPerAccount(fixtureVideos(), 2, 0);
+    expect(groups.find((group) => group.author === 'alicephoto')?.videos.map((video) => video.id)).toEqual(['tag001', 'tag002']);
+    expect(groups.find((group) => group.author === 'bobweddings')?.videos.map((video) => video.id)).toEqual(['tag003', 'tag004']);
+  });
+
+  it('applies the minimum view threshold before grouping', () => {
+    const groups = groupTopVideosPerAccount(fixtureVideos(), 3, 50_000);
+    expect(groups.map((group) => group.author)).toEqual(['bobweddings', 'alicephoto']);
+    expect(groups.flatMap((group) => group.videos).map((video) => video.id)).toEqual(['tag003', 'tag004', 'tag001']);
+  });
+
+  it('deduplicates the same account and video while preserving higher metrics', () => {
+    const videos = fixtureVideos();
+    const original = videos[0];
+    expect(original).toBeDefined();
+    const duplicate: VideoRecord = { ...original!, views: 999_999, source: 'api' };
+    const merged = mergeDiscoveredVideos([...videos, duplicate]);
+    expect(merged).toHaveLength(5);
+    expect(merged.find((video) => video.id === original!.id)?.views).toBe(999_999);
+  });
+
+  it('parses author and video id from TikTok discovery links', () => {
+    expect(parseTikTokVideoUrl('https://www.tiktok.com/@alicephoto/video/123456789')).toEqual({
+      author: 'alicephoto',
+      id: '123456789',
+      videoUrl: 'https://www.tiktok.com/@alicephoto/video/123456789',
+    });
+    expect(parseTikTokVideoUrl('https://www.tiktok.com/tag/weddingphotography')).toBeUndefined();
+  });
+});

--- a/projects/tiktok-research-sorter/wxt.config.ts
+++ b/projects/tiktok-research-sorter/wxt.config.ts
@@ -4,8 +4,8 @@ export default defineConfig({
   srcDir: '.',
   manifest: {
     name: 'TikTok Research Sorter',
-    description: 'Scan, sort, compare, and export public TikTok profile video metrics locally.',
-    version: '0.2.0',
+    description: 'Scan public TikTok profiles and hashtag pages, rank videos per account, and export research locally.',
+    version: '0.3.0',
     permissions: ['storage', 'sidePanel', 'activeTab', 'scripting'],
     host_permissions: ['https://www.tiktok.com/*', 'https://tiktok.com/*'],
     action: {


### PR DESCRIPTION
## Summary

Adds TikTok Research Sorter v0.3.0 hashtag-page research while preserving the existing public-profile workflow.

## Hashtag workflow

- detects public `/tag/<hashtag>` pages automatically;
- scans videos loaded by TikTok through selected JSON payloads and DOM fallback;
- groups discovered videos by account;
- lets the user keep the top 1, 2, 3, 5, or 10 highest-viewed videos from each account;
- supports a minimum-view threshold;
- stores the complete locally discovered hashtag snapshot so filters can be changed after scanning;
- exports versioned CSV and JSON results.

## Reliability and scope

- no additional host permissions beyond TikTok;
- no login, CAPTCHA, private-profile, paywall, rate-limit, or access-control bypass;
- hashtag results represent videos actually loaded on the open hashtag page;
- the extension does not silently visit every creator profile;
- existing profile scanning remains available.

## Validation

- sanitized hashtag fixture and six new regression tests;
- strict TypeScript and production build passed in the local reconstructed package;
- final Linux CI, Windows updater CI, Project Execution OS integrity validation, and v0.3.0 artifacts are required before merge.

Closes #82 after merge and final evidence.