### PR TITLE
Add favorites and selected HTML export v0.4.0

### DIFF
--- a/.github/workflows/tiktok-research-sorter-ci.yml
+++ b/.github/workflows/tiktok-research-sorter-ci.yml
@@ -66,16 +66,16 @@ jobs:
         run: |
           set -euo pipefail
           cd .output/chrome-mv3
-          zip -qr ../../tiktok-research-sorter-extension-v0.3.0.zip .
+          zip -qr ../../tiktok-research-sorter-extension-v0.4.0.zip .
           cd ../..
-          zip -qr tiktok-sorter-auto-updater-setup-v0.3.0.zip automation/windows
-          zip -qr tiktok-research-sorter-source-v0.3.0.zip . \
+          zip -qr tiktok-sorter-auto-updater-setup-v0.4.0.zip automation/windows
+          zip -qr tiktok-research-sorter-source-v0.4.0.zip . \
             -x 'node_modules/*' '.output/*' '.wxt/*' '*.zip'
 
       - name: Upload unpacked extension
         uses: actions/upload-artifact@v4
         with:
-          name: tiktok-research-sorter-chrome-mv3-v0.3.0-${{ github.sha }}
+          name: tiktok-research-sorter-chrome-mv3-v0.4.0-${{ github.sha }}
           path: projects/tiktok-research-sorter/.output/chrome-mv3/
           retention-days: 14
           if-no-files-found: error
@@ -83,11 +83,11 @@ jobs:
       - name: Upload packaged files
         uses: actions/upload-artifact@v4
         with:
-          name: tiktok-research-sorter-packages-v0.3.0-${{ github.sha }}
+          name: tiktok-research-sorter-packages-v0.4.0-${{ github.sha }}
           path: |
-            projects/tiktok-research-sorter/tiktok-research-sorter-extension-v0.3.0.zip
-            projects/tiktok-research-sorter/tiktok-sorter-auto-updater-setup-v0.3.0.zip
-            projects/tiktok-research-sorter/tiktok-research-sorter-source-v0.3.0.zip
+            projects/tiktok-research-sorter/tiktok-research-sorter-extension-v0.4.0.zip
+            projects/tiktok-research-sorter/tiktok-sorter-auto-updater-setup-v0.4.0.zip
+            projects/tiktok-research-sorter/tiktok-research-sorter-source-v0.4.0.zip
           retention-days: 30
           if-no-files-found: error
 
@@ -128,4 +128,4 @@ jobs:
           $manifest = Join-Path $env:LOCALAPPDATA 'TikTokResearchSorterDev\source\.output\chrome-mv3\manifest.json'
           if (-not (Test-Path $manifest)) { throw "Manifest not found: $manifest" }
           $json = Get-Content $manifest -Raw | ConvertFrom-Json
-          if ($json.version -ne '0.3.0') { throw "Unexpected manifest version: $($json.version)" }
+          if ($json.version -ne '0.4.0') { throw "Unexpected manifest version: $($json.version)" }

--- a/projects/tiktok-research-sorter/README.md
+++ b/projects/tiktok-research-sorter/README.md
@@ -1,8 +1,8 @@
 # TikTok Research Sorter
 
-Local-first Manifest V3 extension for scanning public TikTok profile pages and public TikTok hashtag pages, ranking videos, and exporting research data.
+Local-first Manifest V3 extension for scanning public TikTok profile and hashtag pages, ranking videos, saving favorites, and exporting selected research.
 
-## Version 0.3.0
+## Version 0.4.0
 
 ### Profile research
 
@@ -29,14 +29,43 @@ The extension groups discovered videos by account and keeps the requested top vi
 
 Important: hashtag mode ranks videos found on the open hashtag page. It does not silently visit every creator profile or claim to inspect videos that TikTok did not load.
 
+### Favorites and HTML shortlist
+
+Every video card has a star:
+
+- `☆` adds the video to Favorites;
+- `★` removes it from Favorites.
+
+Favorites are stored separately from profile and hashtag results, so clearing a scanned profile or hashtag does not remove saved videos.
+
+Open the `★ Избранное` tab to:
+
+1. select videos with checkboxes;
+2. select all or clear the current selection;
+3. remove selected favorites;
+4. download `tiktok-favorites-selected-v0.4.0.html`.
+
+The generated HTML page is standalone and suitable for sending as a file. It contains:
+
+- clickable TikTok video and profile links;
+- preview images when TikTok provides them;
+- descriptions and hashtags;
+- publication dates and audio titles;
+- views, likes, comments, shares, saves, and engagement rate;
+- a print-friendly responsive layout.
+
+Only checked favorites are included. User-controlled text is HTML-escaped, and non-HTTP(S) links or previews are rejected.
+
 ### Reliability and safety
 
 - Side Panel interface opened from the extension toolbar.
 - User-initiated automatic scrolling with explicit stop, challenge detection, and error recovery.
 - Hybrid collection from embedded JSON, selected TikTok page requests, and loaded DOM cards.
 - Serialized local persistence to prevent lost updates.
+- Backward-compatible dashboard migration adds Favorites to existing installations.
 - Strict data-source precedence: API → embedded JSON → DOM fallback.
 - CSV export with spreadsheet-formula protection.
+- HTML export with markup escaping and URL protocol validation.
 - No login, CAPTCHA, private-profile, rate-limit, paywall, or access-control bypass.
 - Host permissions remain limited to TikTok.
 
@@ -76,9 +105,9 @@ Load `.output/chrome-mv3` through `chrome://extensions` with Developer mode enab
 Each successful branch or pull-request run uploads versioned files:
 
 - unpacked Chrome MV3 extension;
-- `tiktok-research-sorter-extension-v0.3.0.zip`;
-- `tiktok-sorter-auto-updater-setup-v0.3.0.zip`;
-- `tiktok-research-sorter-source-v0.3.0.zip`.
+- `tiktok-research-sorter-extension-v0.4.0.zip`;
+- `tiktok-sorter-auto-updater-setup-v0.4.0.zip`;
+- `tiktok-research-sorter-source-v0.4.0.zip`.
 
 ## Product boundary
 

--- a/projects/tiktok-research-sorter/entrypoints/background.ts
+++ b/projects/tiktok-research-sorter/entrypoints/background.ts
@@ -7,6 +7,8 @@ import {
   mergeProfileData,
   mergeTagVideoBatch,
   mergeVideoBatch,
+  removeFavorites,
+  toggleFavorite,
   updateScanState,
 } from '../lib/store';
 import type { DashboardData, RuntimeMessage } from '../lib/types';
@@ -39,6 +41,10 @@ export default defineBackground(() => {
         return publish(() => beginTagResearch(message.tag, message.tagUrl, message.options));
       case 'TAG_VIDEO_BATCH':
         return publish(() => mergeTagVideoBatch(message.tag, message.tagUrl, message.videos));
+      case 'TOGGLE_FAVORITE':
+        return publish(() => toggleFavorite(message.video));
+      case 'REMOVE_FAVORITES':
+        return publish(() => removeFavorites(message.keys));
       case 'SCAN_STATE':
         return publish(() => updateScanState(message.state));
       case 'CLEAR_PROFILE':

--- a/projects/tiktok-research-sorter/entrypoints/sidepanel/App.tsx
+++ b/projects/tiktok-research-sorter/entrypoints/sidepanel/App.tsx
@@ -2,24 +2,29 @@ import { useEffect, useMemo, useState } from 'react';
 import { browser } from 'wxt/browser';
 import { enrichVideos, publicationFrequencyPerWeek, strongestHashtags, summarize } from '../../lib/analytics';
 import { videosToCsv } from '../../lib/csv';
+import { favoriteKey, orderedFavoriteEntries, selectFavoriteEntries } from '../../lib/favorites';
+import { generateFavoritesHtml } from '../../lib/html-export';
 import { formatCompactNumber } from '../../lib/numbers';
 import { groupTopVideosPerAccount } from '../../lib/tag-research';
 import { APP_VERSION } from '../../lib/types';
 import type {
   DashboardData,
   EnrichedVideo,
+  FavoriteEntry,
   ProfileSnapshot,
   RuntimeMessage,
   ScanOptions,
   TikTokPageContext,
+  VideoRecord,
 } from '../../lib/types';
 
 type SortKey = 'views' | 'likes' | 'comments' | 'shares' | 'publishedAt' | 'viewsPerDay' | 'outlierScore' | 'engagementRate';
-type ViewMode = 'profile' | 'tag';
+type ViewMode = 'profile' | 'tag' | 'favorites';
 
 const emptyDashboard: DashboardData = {
   profiles: {},
   tagResearch: {},
+  favorites: {},
   activeScan: { status: 'idle', videosFound: 0, updatedAt: Date.now() },
 };
 
@@ -30,6 +35,15 @@ const defaultOptions: ScanOptions = {
   topVideosPerAccount: 1,
   minViews: 0,
 };
+
+function normalizeDashboard(value: Partial<DashboardData> | undefined): DashboardData {
+  return {
+    profiles: value?.profiles ?? {},
+    tagResearch: value?.tagResearch ?? {},
+    favorites: value?.favorites ?? {},
+    activeScan: value?.activeScan ?? emptyDashboard.activeScan,
+  };
+}
 
 async function activeTabId(): Promise<number | undefined> {
   const tabs = await browser.tabs.query({ active: true, currentWindow: true });
@@ -89,11 +103,14 @@ export default function App() {
   const [maxVideos, setMaxVideos] = useState(defaultOptions.maxVideos);
   const [topVideosPerAccount, setTopVideosPerAccount] = useState(defaultOptions.topVideosPerAccount);
   const [minViews, setMinViews] = useState(defaultOptions.minViews);
+  const [selectedFavoriteKeys, setSelectedFavoriteKeys] = useState<Set<string>>(new Set());
   const [error, setError] = useState('');
+
+  const applyDashboard = (value: Partial<DashboardData> | undefined) => setDashboard(normalizeDashboard(value));
 
   const refresh = async () => {
     const data = await browser.runtime.sendMessage({ type: 'GET_DASHBOARD' } satisfies RuntimeMessage) as DashboardData;
-    setDashboard({ ...emptyDashboard, ...data, tagResearch: data?.tagResearch ?? {} });
+    applyDashboard(data);
   };
 
   const detectPageContext = async () => {
@@ -111,9 +128,7 @@ export default function App() {
     void refresh();
     void detectPageContext();
     const listener = (message: { type?: string; dashboard?: DashboardData }) => {
-      if (message.type === 'DASHBOARD_UPDATED' && message.dashboard) {
-        setDashboard({ ...emptyDashboard, ...message.dashboard, tagResearch: message.dashboard.tagResearch ?? {} });
-      }
+      if (message.type === 'DASHBOARD_UPDATED' && message.dashboard) applyDashboard(message.dashboard);
     };
     browser.runtime.onMessage.addListener(listener);
     return () => browser.runtime.onMessage.removeListener(listener);
@@ -121,6 +136,8 @@ export default function App() {
 
   const usernames = Object.keys(dashboard.profiles).sort();
   const tags = Object.keys(dashboard.tagResearch).sort();
+  const favoriteEntries = useMemo(() => orderedFavoriteEntries(dashboard.favorites), [dashboard.favorites]);
+  const favoriteKeysSignature = favoriteEntries.map((entry) => entry.key).join('|');
 
   useEffect(() => {
     if (!selectedProfile && usernames[0]) setSelectedProfile(usernames[0]);
@@ -136,6 +153,11 @@ export default function App() {
       setViewMode('tag');
     }
   }, [dashboard.activeScan.tag, tags.join('|')]);
+
+  useEffect(() => {
+    const available = new Set(favoriteEntries.map((entry) => entry.key));
+    setSelectedFavoriteKeys((current) => new Set([...current].filter((key) => available.has(key))));
+  }, [favoriteKeysSignature]);
 
   const profile = selectedProfile ? dashboard.profiles[selectedProfile] : undefined;
   const enriched = useMemo(() => enrichVideos(profile?.videos ?? []), [profile?.videos]);
@@ -163,8 +185,11 @@ export default function App() {
   );
   const selectedTagVideos = useMemo(() => tagGroups.flatMap((group) => group.videos), [tagGroups]);
   const enrichedTagVideos = useMemo(() => new Map(
-    enrichVideos(selectedTagVideos).map((video) => [`${video.author.toLowerCase()}:${video.id}`, video]),
+    enrichVideos(selectedTagVideos).map((video) => [favoriteKey(video), video]),
   ), [selectedTagVideos]);
+  const enrichedFavoriteVideos = useMemo(() => new Map(
+    enrichVideos(favoriteEntries.map((entry) => entry.video)).map((video) => [favoriteKey(video), video]),
+  ), [favoriteEntries]);
 
   const start = async () => {
     setError('');
@@ -188,18 +213,31 @@ export default function App() {
     if (tabId) await browser.tabs.sendMessage(tabId, { type: 'STOP_SCAN' } satisfies RuntimeMessage).catch(() => undefined);
   };
 
+  const toggleFavorite = async (video: VideoRecord) => {
+    const data = await browser.runtime.sendMessage({ type: 'TOGGLE_FAVORITE', video } satisfies RuntimeMessage) as DashboardData;
+    applyDashboard(data);
+  };
+
   const clearProfileData = async () => {
     if (!selectedProfile) return;
     const data = await browser.runtime.sendMessage({ type: 'CLEAR_PROFILE', username: selectedProfile } satisfies RuntimeMessage) as DashboardData;
-    setDashboard(data);
+    applyDashboard(data);
     setSelectedProfile('');
   };
 
   const clearTagData = async () => {
     if (!selectedTag) return;
     const data = await browser.runtime.sendMessage({ type: 'CLEAR_TAG_RESEARCH', tag: selectedTag } satisfies RuntimeMessage) as DashboardData;
-    setDashboard(data);
+    applyDashboard(data);
     setSelectedTag('');
+  };
+
+  const removeSelectedFavorites = async () => {
+    const keys = [...selectedFavoriteKeys];
+    if (!keys.length) return;
+    const data = await browser.runtime.sendMessage({ type: 'REMOVE_FAVORITES', keys } satisfies RuntimeMessage) as DashboardData;
+    applyDashboard(data);
+    setSelectedFavoriteKeys(new Set());
   };
 
   const exportProfileCsv = () => {
@@ -219,7 +257,7 @@ export default function App() {
   const exportTagCsv = () => {
     if (!tagSnapshot) return;
     const enrichedVideos = selectedTagVideos.map((video) =>
-      enrichedTagVideos.get(`${video.author.toLowerCase()}:${video.id}`) ?? video as EnrichedVideo
+      enrichedTagVideos.get(favoriteKey(video)) ?? video as EnrichedVideo
     );
     downloadText(`${tagSnapshot.tag}-top-videos-v${APP_VERSION}.csv`, `\uFEFF${videosToCsv(enrichedVideos)}`, 'text/csv;charset=utf-8');
   };
@@ -242,6 +280,16 @@ export default function App() {
     );
   };
 
+  const exportSelectedFavoritesHtml = () => {
+    const selected = selectFavoriteEntries(dashboard.favorites, selectedFavoriteKeys);
+    if (!selected.length) return;
+    downloadText(
+      `tiktok-favorites-selected-v${APP_VERSION}.html`,
+      generateFavoritesHtml(selected, { title: 'Отобранные TikTok-ролики' }),
+      'text/html;charset=utf-8',
+    );
+  };
+
   const scanning = dashboard.activeScan.status === 'scanning';
   const detectedLabel = pageContext?.kind === 'tag'
     ? `Страница хэштега #${pageContext.tag}`
@@ -249,13 +297,15 @@ export default function App() {
       ? `Профиль @${pageContext.username}`
       : 'Откройте профиль или страницу хэштега TikTok';
 
+  const isFavorite = (video: Pick<VideoRecord, 'author' | 'id'>) => Boolean(dashboard.favorites[favoriteKey(video)]);
+
   return (
     <main className="app-shell">
       <header className="hero">
         <div>
           <p className="eyebrow">LOCAL-FIRST RESEARCH TOOL · v{APP_VERSION}</p>
           <h1>TikTok Research Sorter</h1>
-          <p className="subtitle">Сканирует профили и страницы хэштегов, затем находит самые просматриваемые ролики каждого аккаунта.</p>
+          <p className="subtitle">Сканирует TikTok, сохраняет понравившиеся ролики и создаёт готовые HTML-подборки.</p>
         </div>
         <span className={`status status-${dashboard.activeScan.status}`}>{dashboard.activeScan.status}</span>
       </header>
@@ -266,45 +316,50 @@ export default function App() {
         <button onClick={() => void detectPageContext()}>Обновить</button>
       </section>
 
-      <section className="mode-tabs">
+      <section className="mode-tabs mode-tabs-three">
         <button className={viewMode === 'profile' ? 'active' : ''} onClick={() => setViewMode('profile')}>Профили</button>
         <button className={viewMode === 'tag' ? 'active' : ''} onClick={() => setViewMode('tag')}>Хэштеги</button>
+        <button className={viewMode === 'favorites' ? 'active' : ''} onClick={() => setViewMode('favorites')}>
+          ★ Избранное <span className="tab-count">{favoriteEntries.length}</span>
+        </button>
       </section>
 
-      <section className="panel scan-panel">
-        <div className="control-row">
-          <label>
-            Сканировать роликов
-            <select value={maxVideos} onChange={(event) => setMaxVideos(Number(event.target.value))}>
-              {[50, 100, 300, 500, 1000].map((value) => <option key={value} value={value}>{value}</option>)}
-            </select>
-          </label>
-          {viewMode === 'tag' && (
-            <>
-              <label>
-                Лучших с аккаунта
-                <select value={topVideosPerAccount} onChange={(event) => setTopVideosPerAccount(Number(event.target.value))}>
-                  {[1, 2, 3, 5, 10].map((value) => <option key={value} value={value}>{value}</option>)}
-                </select>
-              </label>
-              <label>
-                Минимум просмотров
-                <input type="number" min="0" step="1000" value={minViews} onChange={(event) => setMinViews(Math.max(0, Number(event.target.value)))} />
-              </label>
-            </>
-          )}
-          <button className="primary" onClick={start} disabled={scanning}>
-            {viewMode === 'tag' ? 'Сканировать хэштег' : 'Сканировать профиль'}
-          </button>
-          <button className="secondary" onClick={stop} disabled={!scanning}>Стоп</button>
-        </div>
-        <div className="progress-track"><div className="progress-fill" style={{ width: `${Math.min(100, (dashboard.activeScan.videosFound / maxVideos) * 100)}%` }} /></div>
-        <p className="scan-message">{dashboard.activeScan.message ?? 'Откройте нужную страницу TikTok и запустите сканирование.'}</p>
-        {viewMode === 'tag' && <p className="hint">Выбираются лучшие ролики каждого аккаунта среди роликов, найденных на открытой странице хэштега.</p>}
-        {error && <p className="error">{error}</p>}
-      </section>
+      {viewMode !== 'favorites' && (
+        <section className="panel scan-panel">
+          <div className="control-row">
+            <label>
+              Сканировать роликов
+              <select value={maxVideos} onChange={(event) => setMaxVideos(Number(event.target.value))}>
+                {[50, 100, 300, 500, 1000].map((value) => <option key={value} value={value}>{value}</option>)}
+              </select>
+            </label>
+            {viewMode === 'tag' && (
+              <>
+                <label>
+                  Лучших с аккаунта
+                  <select value={topVideosPerAccount} onChange={(event) => setTopVideosPerAccount(Number(event.target.value))}>
+                    {[1, 2, 3, 5, 10].map((value) => <option key={value} value={value}>{value}</option>)}
+                  </select>
+                </label>
+                <label>
+                  Минимум просмотров
+                  <input type="number" min="0" step="1000" value={minViews} onChange={(event) => setMinViews(Math.max(0, Number(event.target.value)))} />
+                </label>
+              </>
+            )}
+            <button className="primary" onClick={start} disabled={scanning}>
+              {viewMode === 'tag' ? 'Сканировать хэштег' : 'Сканировать профиль'}
+            </button>
+            <button className="secondary" onClick={stop} disabled={!scanning}>Стоп</button>
+          </div>
+          <div className="progress-track"><div className="progress-fill" style={{ width: `${Math.min(100, (dashboard.activeScan.videosFound / maxVideos) * 100)}%` }} /></div>
+          <p className="scan-message">{dashboard.activeScan.message ?? 'Откройте нужную страницу TikTok и запустите сканирование.'}</p>
+          {viewMode === 'tag' && <p className="hint">Выбираются лучшие ролики каждого аккаунта среди роликов, найденных на открытой странице хэштега.</p>}
+          {error && <p className="error">{error}</p>}
+        </section>
+      )}
 
-      {viewMode === 'profile' ? (
+      {viewMode === 'profile' && (
         <ProfileResults
           profile={profile}
           summary={summary}
@@ -324,8 +379,12 @@ export default function App() {
           exportCsv={exportProfileCsv}
           exportJson={exportProfileJson}
           clear={clearProfileData}
+          isFavorite={isFavorite}
+          toggleFavorite={toggleFavorite}
         />
-      ) : (
+      )}
+
+      {viewMode === 'tag' && (
         <TagResults
           tags={tags}
           selectedTag={selectedTag}
@@ -338,6 +397,20 @@ export default function App() {
           exportCsv={exportTagCsv}
           exportJson={exportTagJson}
           clear={clearTagData}
+          isFavorite={isFavorite}
+          toggleFavorite={toggleFavorite}
+        />
+      )}
+
+      {viewMode === 'favorites' && (
+        <FavoritesResults
+          entries={favoriteEntries}
+          enrichedVideos={enrichedFavoriteVideos}
+          selectedKeys={selectedFavoriteKeys}
+          setSelectedKeys={setSelectedFavoriteKeys}
+          toggleFavorite={toggleFavorite}
+          removeSelected={removeSelectedFavorites}
+          exportHtml={exportSelectedFavoritesHtml}
         />
       )}
     </main>
@@ -363,6 +436,8 @@ function ProfileResults({
   exportCsv,
   exportJson,
   clear,
+  isFavorite,
+  toggleFavorite,
 }: {
   profile?: ProfileSnapshot;
   summary: ReturnType<typeof summarize>;
@@ -382,6 +457,8 @@ function ProfileResults({
   exportCsv: () => void;
   exportJson: () => void;
   clear: () => void;
+  isFavorite: (video: Pick<VideoRecord, 'author' | 'id'>) => boolean;
+  toggleFavorite: (video: VideoRecord) => Promise<void>;
 }) {
   return (
     <>
@@ -433,7 +510,16 @@ function ProfileResults({
       </section>
 
       <section className="video-list">
-        {visible.map((video, index) => <VideoCard key={video.id} video={video} rank={index + 1} showOutlier />)}
+        {visible.map((video, index) => (
+          <VideoCard
+            key={favoriteKey(video)}
+            video={video}
+            rank={index + 1}
+            showOutlier
+            favorite={isFavorite(video)}
+            onToggleFavorite={() => void toggleFavorite(video)}
+          />
+        ))}
         {!visible.length && <div className="empty">Пока нет собранных роликов.</div>}
       </section>
     </>
@@ -452,6 +538,8 @@ function TagResults({
   exportCsv,
   exportJson,
   clear,
+  isFavorite,
+  toggleFavorite,
 }: {
   tags: string[];
   selectedTag: string;
@@ -464,6 +552,8 @@ function TagResults({
   exportCsv: () => void;
   exportJson: () => void;
   clear: () => void;
+  isFavorite: (video: Pick<VideoRecord, 'author' | 'id'>) => boolean;
+  toggleFavorite: (video: VideoRecord) => Promise<void>;
 }) {
   return (
     <>
@@ -500,18 +590,90 @@ function TagResults({
               <span>{group.videos.length} лучших · максимум {formatCompactNumber(group.topViews)}</span>
             </header>
             <div className="video-list">
-              {group.videos.map((video, index) => (
-                <VideoCard
-                  key={`${group.author}:${video.id}`}
-                  video={enrichedVideos.get(`${group.author.toLowerCase()}:${video.id}`) ?? video as EnrichedVideo}
-                  rank={index + 1}
-                  showAuthor={false}
-                />
-              ))}
+              {group.videos.map((video, index) => {
+                const displayVideo = enrichedVideos.get(favoriteKey(video)) ?? video as EnrichedVideo;
+                return (
+                  <VideoCard
+                    key={favoriteKey(video)}
+                    video={displayVideo}
+                    rank={index + 1}
+                    showAuthor={false}
+                    favorite={isFavorite(video)}
+                    onToggleFavorite={() => void toggleFavorite(video)}
+                  />
+                );
+              })}
             </div>
           </section>
         ))}
         {!groups.length && <div className="empty">Нет роликов, подходящих под выбранный минимум просмотров.</div>}
+      </section>
+    </>
+  );
+}
+
+function FavoritesResults({
+  entries,
+  enrichedVideos,
+  selectedKeys,
+  setSelectedKeys,
+  toggleFavorite,
+  removeSelected,
+  exportHtml,
+}: {
+  entries: FavoriteEntry[];
+  enrichedVideos: Map<string, EnrichedVideo>;
+  selectedKeys: Set<string>;
+  setSelectedKeys: (value: Set<string>) => void;
+  toggleFavorite: (video: VideoRecord) => Promise<void>;
+  removeSelected: () => Promise<void>;
+  exportHtml: () => void;
+}) {
+  const allSelected = entries.length > 0 && selectedKeys.size === entries.length;
+
+  const toggleSelection = (key: string, checked: boolean) => {
+    const next = new Set(selectedKeys);
+    if (checked) next.add(key);
+    else next.delete(key);
+    setSelectedKeys(next);
+  };
+
+  return (
+    <>
+      <section className="panel favorites-intro">
+        <div>
+          <p className="eyebrow">ИЗБРАННОЕ</p>
+          <h2>Отбор роликов для отправки</h2>
+          <p>Отметьте нужные ролики чекбоксами. HTML-файл сохранит ссылки, описания, показатели и превью.</p>
+        </div>
+        <strong>{entries.length}</strong>
+      </section>
+
+      <section className="panel actions favorites-actions">
+        <button onClick={() => setSelectedKeys(new Set(entries.map((entry) => entry.key)))} disabled={!entries.length || allSelected}>Выбрать все</button>
+        <button onClick={() => setSelectedKeys(new Set())} disabled={!selectedKeys.size}>Снять выбор</button>
+        <button className="primary" onClick={exportHtml} disabled={!selectedKeys.size}>Скачать HTML выбранного</button>
+        <button className="danger" onClick={() => void removeSelected()} disabled={!selectedKeys.size}>Удалить выбранное</button>
+        <span>Выбрано: {selectedKeys.size}</span>
+      </section>
+
+      <section className="video-list favorites-list">
+        {entries.map((entry, index) => {
+          const video = enrichedVideos.get(entry.key) ?? entry.video as EnrichedVideo;
+          return (
+            <VideoCard
+              key={entry.key}
+              video={video}
+              rank={index + 1}
+              favorite
+              selected={selectedKeys.has(entry.key)}
+              onSelectedChange={(checked) => toggleSelection(entry.key, checked)}
+              onToggleFavorite={() => void toggleFavorite(entry.video)}
+              favoritedAt={entry.favoritedAt}
+            />
+          );
+        })}
+        {!entries.length && <div className="empty">Избранных роликов пока нет. Нажмите звёздочку на любой карточке.</div>}
       </section>
     </>
   );
@@ -579,14 +741,42 @@ function VideoCard({
   rank,
   showOutlier = false,
   showAuthor = true,
+  favorite = false,
+  selected,
+  onSelectedChange,
+  onToggleFavorite,
+  favoritedAt,
 }: {
   video: EnrichedVideo;
   rank: number;
   showOutlier?: boolean;
   showAuthor?: boolean;
+  favorite?: boolean;
+  selected?: boolean;
+  onSelectedChange?: (checked: boolean) => void;
+  onToggleFavorite?: () => void;
+  favoritedAt?: number;
 }) {
   return (
-    <article className="video-card">
+    <article className={`video-card${selected ? ' selected' : ''}`}>
+      <div className="card-controls">
+        {onSelectedChange && (
+          <label className="select-control" title="Выбрать для HTML">
+            <input type="checkbox" checked={Boolean(selected)} onChange={(event) => onSelectedChange(event.target.checked)} />
+            <span>Выбрать</span>
+          </label>
+        )}
+        {onToggleFavorite && (
+          <button
+            className={`favorite-star${favorite ? ' active' : ''}`}
+            onClick={onToggleFavorite}
+            title={favorite ? 'Удалить из избранного' : 'Добавить в избранное'}
+            aria-label={favorite ? 'Удалить из избранного' : 'Добавить в избранное'}
+          >
+            {favorite ? '★' : '☆'}
+          </button>
+        )}
+      </div>
       <a className="cover" href={video.videoUrl} target="_blank" rel="noreferrer">
         {video.coverUrl ? <img src={video.coverUrl} alt="" /> : <div className="cover-placeholder">#{rank}</div>}
         <span className="rank">#{rank}</span>
@@ -606,6 +796,7 @@ function VideoCard({
           <span>ER {percent(video.engagementRate)}</span>
         </div>
         <div className="hashtags">{video.hashtags.slice(0, 6).map((tag) => <span key={tag}>#{tag}</span>)}</div>
+        {favoritedAt && <div className="favorite-date">Добавлено: {formatDate(favoritedAt)}</div>}
       </div>
     </article>
   );

--- a/projects/tiktok-research-sorter/entrypoints/sidepanel/style.css
+++ b/projects/tiktok-research-sorter/entrypoints/sidepanel/style.css
@@ -21,8 +21,10 @@ h2 { margin: 0; font-size: 18px; line-height: 1.15; }
 .context-panel > strong { font-size: 12px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .context-panel > button { grid-column: 2; grid-row: 1 / span 2; padding: 7px 9px; }
 .mode-tabs { display: grid; grid-template-columns: 1fr 1fr; gap: 7px; padding: 4px; background: #111621; border: 1px solid rgba(255,255,255,.07); border-radius: 12px; }
-.mode-tabs button { background: transparent; color: #969bae; }
+.mode-tabs-three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.mode-tabs button { background: transparent; color: #969bae; padding-inline: 8px; }
 .mode-tabs button.active { color: #fff; background: linear-gradient(135deg, rgba(122,92,255,.85), rgba(208,79,255,.72)); font-weight: 700; }
+.tab-count { display: inline-grid; place-items: center; min-width: 18px; height: 18px; margin-left: 4px; border-radius: 999px; background: rgba(255,255,255,.14); font-size: 9px; }
 .control-row, .toolbar, .actions { display: flex; gap: 9px; align-items: end; flex-wrap: wrap; }
 label { display: grid; gap: 5px; color: #aeb2c6; font-size: 11px; flex: 1; min-width: 110px; }
 select, input { width: 100%; color: #f6f7fb; background: #0f131e; border: 1px solid #303648; border-radius: 9px; padding: 8px 9px; outline: none; }
@@ -66,26 +68,44 @@ button { color: #f7f7fb; background: #303648; border-radius: 9px; padding: 9px 1
 .stats-grid strong { display: block; font-size: 18px; margin-top: 4px; }
 .actions span { margin-left: auto; color: #9297aa; font-size: 11px; }
 .video-list { display: grid; gap: 10px; }
-.video-card { display: grid; grid-template-columns: 92px minmax(0,1fr); gap: 11px; background: rgba(22,26,38,.94); border: 1px solid rgba(255,255,255,.07); border-radius: 13px; padding: 9px; }
+.video-card { position: relative; display: grid; grid-template-columns: 92px minmax(0,1fr); gap: 11px; background: rgba(22,26,38,.94); border: 1px solid rgba(255,255,255,.07); border-radius: 13px; padding: 9px; transition: border-color .18s ease, box-shadow .18s ease; }
+.video-card.selected { border-color: rgba(122,92,255,.85); box-shadow: 0 0 0 3px rgba(122,92,255,.14); }
+.card-controls { position: absolute; top: 7px; right: 7px; z-index: 4; display: flex; align-items: center; gap: 6px; }
+.favorite-star { width: 34px; height: 34px; padding: 0; display: grid; place-items: center; border-radius: 50%; color: #d9dce8; background: rgba(8,10,16,.82); border: 1px solid rgba(255,255,255,.16); font-size: 21px; line-height: 1; box-shadow: 0 5px 14px rgba(0,0,0,.32); }
+.favorite-star.active { color: #ffd666; background: rgba(76,54,8,.94); border-color: rgba(255,214,102,.48); }
+.select-control { min-width: 0; display: flex; align-items: center; gap: 5px; padding: 7px 8px; color: #e5e7ef; background: rgba(8,10,16,.84); border: 1px solid rgba(255,255,255,.15); border-radius: 9px; cursor: pointer; box-shadow: 0 5px 14px rgba(0,0,0,.26); }
+.select-control input { width: 16px; height: 16px; margin: 0; padding: 0; accent-color: #8a69ff; }
+.select-control span { font-size: 9px; }
 .cover { position: relative; min-height: 124px; border-radius: 9px; overflow: hidden; background: #0a0d13; display: block; }
 .cover img { width: 100%; height: 100%; object-fit: cover; position: absolute; inset: 0; }
 .cover-placeholder { height: 100%; display: grid; place-items: center; color: #6f7487; font-weight: 800; }
 .rank { position: absolute; top: 5px; left: 5px; color: #fff; background: rgba(0,0,0,.68); border-radius: 6px; padding: 3px 5px; font-size: 10px; }
-.video-copy { min-width: 0; }
-.video-author { display: inline-block; color: #8fded3; text-decoration: none; font-size: 10px; margin-bottom: 5px; }
-.metrics { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
+.video-copy { min-width: 0; padding-top: 3px; }
+.video-author { display: inline-block; color: #8fded3; text-decoration: none; font-size: 10px; margin-bottom: 5px; padding-right: 40px; }
+.metrics { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; padding-right: 38px; }
 .metrics strong { color: #fff; font-size: 12px; }
 .metrics span { color: #d2c8ff; background: #2b2446; border-radius: 999px; padding: 3px 6px; font-size: 9px; }
 .video-copy p { color: #d9dbe5; font-size: 11px; line-height: 1.4; margin: 8px 0; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
 .micro-metrics { display: flex; gap: 8px; flex-wrap: wrap; color: #9fa4b6; font-size: 10px; }
 .hashtags { display: flex; gap: 4px; flex-wrap: wrap; margin-top: 8px; }
 .hashtags span { color: #6ee6d2; font-size: 9px; }
+.favorite-date { margin-top: 8px; color: #7f8599; font-size: 9px; }
 .account-groups { display: grid; gap: 12px; }
 .account-group { display: grid; gap: 9px; padding: 12px; border: 1px solid rgba(255,255,255,.08); background: rgba(16,20,30,.75); border-radius: 14px; }
 .account-group > header { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
 .account-group > header a { color: #8fded3; text-decoration: none; font-weight: 800; font-size: 13px; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
 .account-group > header span { color: #8f95aa; font-size: 9px; text-align: right; }
+.favorites-intro { display: flex; justify-content: space-between; gap: 16px; align-items: center; background: linear-gradient(135deg, rgba(37,32,55,.96), rgba(24,28,40,.92)); }
+.favorites-intro p:last-child { color: #aeb2c6; font-size: 11px; line-height: 1.5; margin: 8px 0 0; }
+.favorites-intro > strong { width: 58px; height: 58px; flex: 0 0 58px; display: grid; place-items: center; border-radius: 50%; color: #ffd666; background: rgba(255,214,102,.1); border: 1px solid rgba(255,214,102,.26); font-size: 22px; }
+.favorites-actions { align-items: center; }
+.favorites-list .video-card { background: rgba(26,29,42,.97); }
 .empty { color: #8e93a5; text-align: center; padding: 40px 10px; border: 1px dashed #343a4c; border-radius: 14px; }
+@media (max-width: 430px) {
+  .mode-tabs button { font-size: 10px; padding-inline: 4px; }
+  .select-control span { display: none; }
+  .metrics { padding-right: 30px; }
+}
 @media (min-width: 520px) {
   .stats-grid { grid-template-columns: repeat(4, 1fr); }
   .profile-stats { grid-template-columns: repeat(4, minmax(0, 1fr)); }

--- a/projects/tiktok-research-sorter/lib/favorites.ts
+++ b/projects/tiktok-research-sorter/lib/favorites.ts
@@ -1,0 +1,22 @@
+import type { FavoriteEntry, VideoRecord } from './types';
+
+export function favoriteKey(video: Pick<VideoRecord, 'author' | 'id'>): string {
+  const author = video.author.trim().replace(/^@/, '').toLowerCase();
+  return `${author}:${video.id.trim()}`;
+}
+
+export function orderedFavoriteEntries(favorites: Record<string, FavoriteEntry>): FavoriteEntry[] {
+  return Object.values(favorites).sort((a, b) =>
+    b.favoritedAt - a.favoritedAt
+    || b.video.views - a.video.views
+    || a.key.localeCompare(b.key)
+  );
+}
+
+export function selectFavoriteEntries(
+  favorites: Record<string, FavoriteEntry>,
+  selectedKeys: Iterable<string>,
+): FavoriteEntry[] {
+  const selected = new Set(selectedKeys);
+  return orderedFavoriteEntries(favorites).filter((entry) => selected.has(entry.key));
+}

--- a/projects/tiktok-research-sorter/lib/html-export.ts
+++ b/projects/tiktok-research-sorter/lib/html-export.ts
@@ -1,0 +1,174 @@
+import { enrichVideos } from './analytics';
+import { APP_VERSION } from './types';
+import type { FavoriteEntry } from './types';
+
+export interface FavoritesHtmlOptions {
+  title?: string;
+  generatedAt?: number;
+}
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/gu, '&amp;')
+    .replace(/</gu, '&lt;')
+    .replace(/>/gu, '&gt;')
+    .replace(/"/gu, '&quot;')
+    .replace(/'/gu, '&#39;');
+}
+
+function safeHttpUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function formatNumber(value: number | undefined): string {
+  return new Intl.NumberFormat('ru-RU').format(value ?? 0);
+}
+
+function formatDate(timestampSeconds: number | undefined): string {
+  if (!timestampSeconds) return 'Дата не указана';
+  return new Intl.DateTimeFormat('ru-RU', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  }).format(new Date(timestampSeconds * 1000));
+}
+
+function renderPreview(coverUrl: string | undefined, author: string): string {
+  const safeCover = safeHttpUrl(coverUrl);
+  if (!safeCover) return '<div class="preview placeholder">Превью недоступно</div>';
+  return `<img class="preview" src="${escapeHtml(safeCover)}" alt="Превью ролика @${escapeHtml(author)}" loading="lazy">`;
+}
+
+export function generateFavoritesHtml(
+  entries: FavoriteEntry[],
+  options: FavoritesHtmlOptions = {},
+): string {
+  const title = options.title?.trim() || 'Отобранные TikTok-ролики';
+  const generatedAt = options.generatedAt ?? Date.now();
+  const enriched = enrichVideos(entries.map((entry) => entry.video));
+  const enrichedByKey = new Map(entries.map((entry, index) => [entry.key, enriched[index]]));
+
+  const cards = entries.map((entry, index) => {
+    const video = enrichedByKey.get(entry.key) ?? entry.video;
+    const videoUrl = safeHttpUrl(video.videoUrl);
+    const profileUrl = safeHttpUrl(video.profileUrl);
+    const hashtags = video.hashtags
+      .map((tag) => `<span>#${escapeHtml(tag.replace(/^#/, ''))}</span>`)
+      .join('');
+    const description = video.description?.trim() || 'Без описания';
+    const engagement = 'engagementRate' in video && typeof video.engagementRate === 'number'
+      ? `${video.engagementRate.toFixed(2)}%`
+      : '—';
+
+    return `
+      <article class="card" data-video-key="${escapeHtml(entry.key)}">
+        <div class="rank">${index + 1}</div>
+        <a class="preview-link" href="${escapeHtml(videoUrl ?? '#')}" target="_blank" rel="noopener noreferrer">
+          ${renderPreview(video.coverUrl, video.author)}
+        </a>
+        <div class="content">
+          <div class="card-head">
+            <div>
+              <a class="author" href="${escapeHtml(profileUrl ?? '#')}" target="_blank" rel="noopener noreferrer">@${escapeHtml(video.author)}</a>
+              <div class="date">${escapeHtml(formatDate(video.publishedAt))}</div>
+            </div>
+            <a class="open" href="${escapeHtml(videoUrl ?? '#')}" target="_blank" rel="noopener noreferrer">Открыть ролик ↗</a>
+          </div>
+          <p class="description">${escapeHtml(description)}</p>
+          <div class="metrics">
+            <div><span>Просмотры</span><strong>${escapeHtml(formatNumber(video.views))}</strong></div>
+            <div><span>Лайки</span><strong>${escapeHtml(formatNumber(video.likes))}</strong></div>
+            <div><span>Комментарии</span><strong>${escapeHtml(formatNumber(video.comments))}</strong></div>
+            <div><span>Репосты</span><strong>${escapeHtml(formatNumber(video.shares))}</strong></div>
+            <div><span>Сохранения</span><strong>${escapeHtml(formatNumber(video.saves))}</strong></div>
+            <div><span>ER</span><strong>${escapeHtml(engagement)}</strong></div>
+          </div>
+          ${video.audioTitle ? `<div class="audio">Аудио: ${escapeHtml(video.audioTitle)}</div>` : ''}
+          <div class="hashtags">${hashtags}</div>
+        </div>
+      </article>`;
+  }).join('\n');
+
+  const generatedLabel = new Intl.DateTimeFormat('ru-RU', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(generatedAt));
+
+  return `<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="generator" content="TikTok Research Sorter v${APP_VERSION}">
+  <title>${escapeHtml(title)}</title>
+  <style>
+    :root { color-scheme: light; font-family: Inter, Arial, sans-serif; color: #1d2230; background: #f3f5f9; }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: #f3f5f9; }
+    .page { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 36px 0 60px; }
+    .header { background: linear-gradient(135deg, #171b2c, #34235d); color: #fff; border-radius: 24px; padding: 28px; margin-bottom: 22px; }
+    .header h1 { margin: 0; font-size: clamp(26px, 5vw, 44px); line-height: 1.05; }
+    .header p { margin: 12px 0 0; color: #d4d3e8; line-height: 1.5; }
+    .summary { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 18px; }
+    .summary span { background: rgba(255,255,255,.12); border: 1px solid rgba(255,255,255,.16); border-radius: 999px; padding: 8px 12px; font-size: 13px; }
+    .grid { display: grid; gap: 18px; }
+    .card { position: relative; display: grid; grid-template-columns: 220px minmax(0,1fr); gap: 20px; background: #fff; border: 1px solid #e2e6ef; border-radius: 20px; padding: 16px; box-shadow: 0 14px 35px rgba(30,36,52,.08); }
+    .rank { position: absolute; top: 24px; left: 24px; z-index: 2; background: rgba(0,0,0,.76); color: #fff; border-radius: 10px; padding: 6px 9px; font-weight: 800; }
+    .preview-link { display: block; min-height: 300px; border-radius: 14px; overflow: hidden; background: #111522; text-decoration: none; }
+    .preview { width: 100%; height: 100%; min-height: 300px; object-fit: cover; display: block; }
+    .placeholder { display: grid; place-items: center; color: #aeb5c7; padding: 20px; text-align: center; }
+    .content { min-width: 0; padding: 4px 4px 4px 0; }
+    .card-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; }
+    .author { color: #6840d8; font-size: 18px; font-weight: 800; text-decoration: none; }
+    .date { margin-top: 5px; color: #7d8496; font-size: 13px; }
+    .open { color: #fff; background: #6840d8; border-radius: 10px; padding: 9px 12px; font-weight: 700; text-decoration: none; white-space: nowrap; }
+    .description { margin: 20px 0; color: #303747; font-size: 16px; line-height: 1.55; white-space: pre-wrap; }
+    .metrics { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 10px; }
+    .metrics div { background: #f5f6fa; border: 1px solid #e7e9f0; border-radius: 12px; padding: 10px; }
+    .metrics span { display: block; color: #81889a; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; }
+    .metrics strong { display: block; margin-top: 5px; font-size: 17px; }
+    .audio { margin-top: 15px; color: #5d6475; font-size: 13px; }
+    .hashtags { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 14px; }
+    .hashtags span { color: #087f73; background: #e9faf7; border: 1px solid #c9eee8; border-radius: 999px; padding: 5px 8px; font-size: 12px; }
+    .empty { background: #fff; border: 1px dashed #cbd1df; border-radius: 18px; padding: 50px 20px; text-align: center; color: #6e7586; }
+    .footer { margin-top: 26px; color: #7d8494; font-size: 12px; text-align: center; }
+    @media (max-width: 760px) {
+      .card { grid-template-columns: 1fr; }
+      .preview-link, .preview { min-height: 420px; max-height: 620px; }
+      .metrics { grid-template-columns: repeat(2, minmax(0,1fr)); }
+    }
+    @media print {
+      body { background: #fff; }
+      .page { width: 100%; padding: 0; }
+      .header, .card { box-shadow: none; break-inside: avoid; }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <header class="header">
+      <h1>${escapeHtml(title)}</h1>
+      <p>Отобранные ролики с кликабельными ссылками, описаниями, метриками и превью.</p>
+      <div class="summary">
+        <span>Роликов: ${entries.length}</span>
+        <span>Создано: ${escapeHtml(generatedLabel)}</span>
+        <span>TikTok Research Sorter v${APP_VERSION}</span>
+      </div>
+    </header>
+    <section class="grid">
+      ${cards || '<div class="empty">В подборке нет выбранных роликов.</div>'}
+    </section>
+    <footer class="footer">Страница создана локально. Ссылки и изображения открываются с публичных страниц TikTok.</footer>
+  </main>
+</body>
+</html>`;
+}

--- a/projects/tiktok-research-sorter/lib/store.ts
+++ b/projects/tiktok-research-sorter/lib/store.ts
@@ -1,5 +1,6 @@
 import { browser } from 'wxt/browser';
 import { median } from './analytics';
+import { favoriteKey } from './favorites';
 import { mergeDiscoveredVideos } from './tag-research';
 import { mergeVideoRecords } from './tiktok-parser';
 import type {
@@ -18,6 +19,7 @@ const STALE_SCAN_MS = 2 * 60 * 1000;
 const initialState: DashboardData = {
   profiles: {},
   tagResearch: {},
+  favorites: {},
   activeScan: {
     status: 'idle',
     videosFound: 0,
@@ -35,18 +37,19 @@ function normalizeTagKey(tag: string): string {
   return tag.trim().replace(/^#/, '').toLowerCase();
 }
 
-function normalizeDashboard(value: DashboardData | undefined): DashboardData {
+function normalizeDashboard(value: Partial<DashboardData> | undefined): DashboardData {
   if (!value) return structuredClone(initialState);
   return {
     profiles: value.profiles ?? {},
     tagResearch: value.tagResearch ?? {},
+    favorites: value.favorites ?? {},
     activeScan: value.activeScan ?? structuredClone(initialState.activeScan),
   };
 }
 
 export async function loadDashboard(): Promise<DashboardData> {
   const stored = await browser.storage.local.get(STORAGE_KEY);
-  const dashboard = normalizeDashboard(stored[STORAGE_KEY] as DashboardData | undefined);
+  const dashboard = normalizeDashboard(stored[STORAGE_KEY] as Partial<DashboardData> | undefined);
 
   if (
     dashboard.activeScan.status === 'scanning'
@@ -185,6 +188,31 @@ export async function mergeTagVideoBatch(
   dashboard.activeScan.videosFound = existing.scannedVideos;
   dashboard.activeScan.accountsFound = existing.accountsFound;
   dashboard.activeScan.updatedAt = Date.now();
+  await saveDashboard(dashboard);
+  return dashboard;
+}
+
+export async function toggleFavorite(video: VideoRecord): Promise<DashboardData> {
+  const dashboard = await loadDashboard();
+  const key = favoriteKey(video);
+
+  if (dashboard.favorites[key]) {
+    delete dashboard.favorites[key];
+  } else {
+    dashboard.favorites[key] = {
+      key,
+      video: structuredClone(video),
+      favoritedAt: Date.now(),
+    };
+  }
+
+  await saveDashboard(dashboard);
+  return dashboard;
+}
+
+export async function removeFavorites(keys: string[]): Promise<DashboardData> {
+  const dashboard = await loadDashboard();
+  for (const key of new Set(keys)) delete dashboard.favorites[key];
   await saveDashboard(dashboard);
   return dashboard;
 }

--- a/projects/tiktok-research-sorter/lib/types.ts
+++ b/projects/tiktok-research-sorter/lib/types.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '0.3.0';
+export const APP_VERSION = '0.4.0';
 
 export type ScanStatus = 'idle' | 'scanning' | 'paused' | 'complete' | 'stopped' | 'blocked' | 'error';
 export type ScanMode = 'profile' | 'tag';
@@ -46,6 +46,12 @@ export interface EnrichedVideo extends VideoRecord {
   commentRate?: number;
   shareRate?: number;
   outlierScore?: number;
+}
+
+export interface FavoriteEntry {
+  key: string;
+  video: VideoRecord;
+  favoritedAt: number;
 }
 
 export interface ProfileRecord {
@@ -113,6 +119,8 @@ export type RuntimeMessage =
   | { type: 'GET_DASHBOARD' }
   | { type: 'CLEAR_PROFILE'; username: string }
   | { type: 'CLEAR_TAG_RESEARCH'; tag: string }
+  | { type: 'TOGGLE_FAVORITE'; video: VideoRecord }
+  | { type: 'REMOVE_FAVORITES'; keys: string[] }
   | { type: 'PROFILE_DATA'; profile: ProfileRecord }
   | { type: 'VIDEO_BATCH'; username: string; profileUrl: string; videos: VideoRecord[] }
   | { type: 'TAG_SCAN_BEGIN'; tag: string; tagUrl: string; options: ScanOptions }
@@ -123,5 +131,6 @@ export type RuntimeMessage =
 export interface DashboardData {
   profiles: Record<string, ProfileSnapshot>;
   tagResearch: Record<string, TagResearchSnapshot>;
+  favorites: Record<string, FavoriteEntry>;
   activeScan: ScanState;
 }

--- a/projects/tiktok-research-sorter/package.json
+++ b/projects/tiktok-research-sorter/package.json
@@ -1,9 +1,9 @@
 {
   "name": "tiktok-research-sorter",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
-  "description": "Local-first Chrome extension for scanning public TikTok profiles and hashtag pages, then ranking videos per account.",
+  "description": "Local-first Chrome extension for TikTok profile and hashtag research with favorites and selected HTML export.",
   "scripts": {
     "dev": "wxt",
     "build": "wxt build",

--- a/projects/tiktok-research-sorter/tests/favorites-html.test.ts
+++ b/projects/tiktok-research-sorter/tests/favorites-html.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { favoriteKey, orderedFavoriteEntries, selectFavoriteEntries } from '../lib/favorites';
+import { generateFavoritesHtml } from '../lib/html-export';
+import type { FavoriteEntry, VideoRecord } from '../lib/types';
+
+function video(id: string, author: string, views: number, overrides: Partial<VideoRecord> = {}): VideoRecord {
+  return {
+    id,
+    author,
+    profileUrl: `https://www.tiktok.com/@${author}`,
+    videoUrl: `https://www.tiktok.com/@${author}/video/${id}`,
+    description: `Video ${id}`,
+    publishedAt: 1_700_000_000,
+    durationSeconds: 20,
+    views,
+    likes: 100,
+    comments: 10,
+    shares: 5,
+    saves: 3,
+    coverUrl: `https://example.com/${id}.jpg`,
+    hashtags: ['wedding', 'photography'],
+    audioTitle: 'Test audio',
+    isPinned: false,
+    collectedAt: 1_700_000_000_000,
+    source: 'api',
+    ...overrides,
+  };
+}
+
+function favorite(entryVideo: VideoRecord, favoritedAt: number): FavoriteEntry {
+  return {
+    key: favoriteKey(entryVideo),
+    video: entryVideo,
+    favoritedAt,
+  };
+}
+
+describe('favorites', () => {
+  it('creates a stable case-insensitive key from author and video id', () => {
+    expect(favoriteKey({ author: '@OlgaPhoto', id: '123' })).toBe('olgaphoto:123');
+    expect(favoriteKey({ author: 'olgaphoto', id: '123' })).toBe('olgaphoto:123');
+  });
+
+  it('orders newest favorites first and exports only checked entries', () => {
+    const first = favorite(video('1', 'alice', 100), 1000);
+    const second = favorite(video('2', 'bob', 200), 2000);
+    const favorites = { [first.key]: first, [second.key]: second };
+
+    expect(orderedFavoriteEntries(favorites).map((entry) => entry.key)).toEqual([second.key, first.key]);
+    expect(selectFavoriteEntries(favorites, [first.key]).map((entry) => entry.key)).toEqual([first.key]);
+  });
+
+  it('generates a standalone HTML page with links, preview, description, and metrics', () => {
+    const entry = favorite(video('777', 'creator', 123_456), 2000);
+    const html = generateFavoritesHtml([entry], { title: 'Client shortlist', generatedAt: 1_700_000_000_000 });
+
+    expect(html).toContain('<!doctype html>');
+    expect(html).toContain('<meta charset="utf-8">');
+    expect(html).toContain('Client shortlist');
+    expect(html).toContain('https://www.tiktok.com/@creator/video/777');
+    expect(html).toContain('https://example.com/777.jpg');
+    expect(html).toContain('Video 777');
+    expect(html).toContain('data-video-key="creator:777"');
+    expect(html).toContain('TikTok Research Sorter v0.4.0');
+  });
+
+  it('escapes user-controlled text and rejects non-http links and previews', () => {
+    const unsafe = favorite(video('9', 'bad', 1, {
+      description: '<script>alert("x")</script>',
+      profileUrl: 'javascript:alert(1)',
+      videoUrl: 'javascript:alert(2)',
+      coverUrl: 'data:text/html,<script>alert(3)</script>',
+      hashtags: ['<img src=x onerror=alert(4)>'],
+    }), 3000);
+
+    const html = generateFavoritesHtml([unsafe], { generatedAt: 1_700_000_000_000 });
+
+    expect(html).not.toContain('<script>alert');
+    expect(html).not.toContain('javascript:');
+    expect(html).not.toContain('data:text/html');
+    expect(html).toContain('&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;');
+    expect(html).toContain('Превью недоступно');
+  });
+
+  it('keeps unselected favorites out of the generated selection', () => {
+    const selected = favorite(video('11', 'one', 10), 2000);
+    const omitted = favorite(video('22', 'two', 20), 1000);
+    const favorites = { [selected.key]: selected, [omitted.key]: omitted };
+    const chosen = selectFavoriteEntries(favorites, [selected.key]);
+    const html = generateFavoritesHtml(chosen, { generatedAt: 1_700_000_000_000 });
+
+    expect(html).toContain('/video/11');
+    expect(html).not.toContain('/video/22');
+  });
+});

--- a/projects/tiktok-research-sorter/wxt.config.ts
+++ b/projects/tiktok-research-sorter/wxt.config.ts
@@ -4,8 +4,8 @@ export default defineConfig({
   srcDir: '.',
   manifest: {
     name: 'TikTok Research Sorter',
-    description: 'Scan public TikTok profiles and hashtag pages, rank videos per account, and export research locally.',
-    version: '0.3.0',
+    description: 'Scan TikTok profiles and hashtag pages, save favorites, and export selected research as HTML.',
+    version: '0.4.0',
     permissions: ['storage', 'sidePanel', 'activeTab', 'scripting'],
     host_permissions: ['https://www.tiktok.com/*', 'https://tiktok.com/*'],
     action: {


### PR DESCRIPTION
## Summary

Adds a durable favorites workflow to TikTok Research Sorter v0.4.0.

## Delivered behavior

- star control on every profile and hashtag video card;
- favorites persist independently in local Chrome storage;
- dedicated Favorites tab with count;
- checkbox selection, select all, clear selection, individual removal, and bulk removal;
- standalone HTML export containing only checked favorites;
- HTML includes clickable video/profile links, descriptions, previews, hashtags, dates, audio, and available metrics;
- exported HTML is escaped and rejects non-HTTP(S) links/previews;
- versioned extension and artifact names use v0.4.0;
- existing profile and hashtag workflows remain intact.

## Validation gate

- strict TypeScript;
- all unit/regression tests, including favorites and HTML safety;
- Linux build and packaging;
- Windows updater validation;
- Project Execution OS integrity;
- installable ZIP with root-level manifest version 0.4.0.

Closes #84 after green validation and merge.