### PR TITLE
Add complete channel information to Favorites and HTML v0.5.0

### DIFF
--- a/.github/workflows/tiktok-research-sorter-ci.yml
+++ b/.github/workflows/tiktok-research-sorter-ci.yml
@@ -66,16 +66,16 @@ jobs:
         run: |
           set -euo pipefail
           cd .output/chrome-mv3
-          zip -qr ../../tiktok-research-sorter-extension-v0.4.0.zip .
+          zip -qr ../../tiktok-research-sorter-extension-v0.5.0.zip .
           cd ../..
-          zip -qr tiktok-sorter-auto-updater-setup-v0.4.0.zip automation/windows
-          zip -qr tiktok-research-sorter-source-v0.4.0.zip . \
+          zip -qr tiktok-sorter-auto-updater-setup-v0.5.0.zip automation/windows
+          zip -qr tiktok-research-sorter-source-v0.5.0.zip . \
             -x 'node_modules/*' '.output/*' '.wxt/*' '*.zip'
 
       - name: Upload unpacked extension
         uses: actions/upload-artifact@v4
         with:
-          name: tiktok-research-sorter-chrome-mv3-v0.4.0-${{ github.sha }}
+          name: tiktok-research-sorter-chrome-mv3-v0.5.0-${{ github.sha }}
           path: projects/tiktok-research-sorter/.output/chrome-mv3/
           retention-days: 14
           if-no-files-found: error
@@ -83,11 +83,11 @@ jobs:
       - name: Upload packaged files
         uses: actions/upload-artifact@v4
         with:
-          name: tiktok-research-sorter-packages-v0.4.0-${{ github.sha }}
+          name: tiktok-research-sorter-packages-v0.5.0-${{ github.sha }}
           path: |
-            projects/tiktok-research-sorter/tiktok-research-sorter-extension-v0.4.0.zip
-            projects/tiktok-research-sorter/tiktok-sorter-auto-updater-setup-v0.4.0.zip
-            projects/tiktok-research-sorter/tiktok-research-sorter-source-v0.4.0.zip
+            projects/tiktok-research-sorter/tiktok-research-sorter-extension-v0.5.0.zip
+            projects/tiktok-research-sorter/tiktok-sorter-auto-updater-setup-v0.5.0.zip
+            projects/tiktok-research-sorter/tiktok-research-sorter-source-v0.5.0.zip
           retention-days: 30
           if-no-files-found: error
 
@@ -128,4 +128,4 @@ jobs:
           $manifest = Join-Path $env:LOCALAPPDATA 'TikTokResearchSorterDev\source\.output\chrome-mv3\manifest.json'
           if (-not (Test-Path $manifest)) { throw "Manifest not found: $manifest" }
           $json = Get-Content $manifest -Raw | ConvertFrom-Json
-          if ($json.version -ne '0.4.0') { throw "Unexpected manifest version: $($json.version)" }
+          if ($json.version -ne '0.5.0') { throw "Unexpected manifest version: $($json.version)" }

--- a/projects/tiktok-research-sorter/PROJECT.md
+++ b/projects/tiktok-research-sorter/PROJECT.md
@@ -4,17 +4,18 @@
 
 - Project name: `TikTok Research Sorter`
 - Project type: `Chrome Extension / local social-content research tool`
-- Current version: `0.4.0`
-- Short description: a Manifest V3 browser extension that scans public TikTok profile and hashtag pages, stores research locally, ranks videos, saves favorites, and exports selected shortlists as standalone HTML.
+- Current version: `0.5.0`
+- Short description: a Manifest V3 browser extension that scans public TikTok profile and hashtag pages, stores research locally, ranks videos, saves favorites with durable channel snapshots, and exports selected channel-and-video shortlists as standalone HTML.
 
 ## 2. Purpose
 
 Supported workflows:
 
 ```text
-public profile -> scan loaded profile videos -> calculate metrics -> filter/sort -> favorite/export
-public hashtag -> scan loaded hashtag videos -> group by account -> top N + minimum views -> favorite/export
-favorites -> checkbox selection -> standalone HTML shortlist -> send as a file
+public profile -> scan loaded profile videos + public channel data -> metrics -> filter/sort -> favorite/export
+public hashtag -> scan loaded hashtag videos -> group by account -> top N + minimum views -> favorite
+favorite -> preserve video + channel snapshot -> enrich/refresh channel data
+favorites -> checkbox selection -> channel-grouped standalone HTML -> send as a file
 ```
 
 Primary users:
@@ -28,26 +29,28 @@ Primary users:
 
 - Durable source: `projects/tiktok-research-sorter/` inside `oleg3479881328-code/Project-Execution-OS`.
 - Stable implementation and distribution branch: `main`.
-- Version 0.4.0 delivery issue: `#84`.
-- Version 0.4.0 pull request: `#85`.
+- Active feature branch: `agent/tiktok-research-sorter-channel-export-v0.5.0` until PR #87 is merged.
+- Version 0.5.0 delivery issue: `#86`.
+- Version 0.5.0 pull request: `#87`.
 
 ## 4. Architecture
 
 ```text
 TikTok public page
 → selected fetch/XHR payload observer + embedded JSON + DOM fallback
+→ optional same-origin public profile enrichment
 → isolated content script
 → serialized background persistence
-→ chrome.storage.local profiles + hashtag snapshots + favorites
-→ React side panel
-→ CSV / JSON / standalone HTML export
+→ chrome.storage.local profiles + hashtag snapshots + favorite video/channel snapshots
+→ React side panel grouped by channel
+→ CSV / JSON / channel-grouped standalone HTML export
 ```
 
 ## 5. Current status
 
-- Mode: `stable / integrated`
-- Phase: `v0.4.0 favorites and HTML shortlist delivered`
-- Status: profile, hashtag, favorites, and selected HTML-export workflows are integrated into `main`; Linux, Windows, integrity, and packaging validation are green.
+- Mode: `implementation / automated validation`
+- Phase: `v0.5.0 complete public channel information`
+- Status: implementation and tests are committed on PR #87; final Linux, Windows, integrity, artifact, and merge evidence are pending.
 
 ## 6. Key decisions and constraints
 
@@ -56,24 +59,31 @@ TikTok public page
 - Host access remains limited to TikTok.
 - Do not bypass login, private accounts, CAPTCHA, rate limits, paywalls, or access controls.
 - Prefer structured JSON payloads; DOM selectors are fallback only.
+- Store only fields TikTok actually returns; display missing values as unavailable.
 - Favorites are durable local snapshots independent of profile and hashtag deletion.
-- HTML exports include only checked favorites.
+- Existing favorite channel snapshots are refreshed only when richer public data becomes available.
+- Same-origin profile enrichment must not navigate the visible page.
+- HTML exports include only checked favorites and group them by channel.
 - HTML text is escaped and external URLs are restricted to HTTP(S).
-- Exported previews remain dependent on the external TikTok image URL remaining available.
+- Exported avatars and previews remain dependent on external URLs remaining available.
 - Preserve only sanitized fixtures. Never commit cookies, tokens, authorization headers, browser profiles, signatures, or raw identifying traffic.
 - Keep generated deliverables and exports versioned.
 
-## 7. Current validation baseline
+## 7. Current validation gate
 
-- Project Execution OS integrity validation passes.
-- Linux reproducible install, strict TypeScript check, all tests, production build, and versioned packaging pass.
-- Windows updater dry-run, full local-source validation, and manifest check pass.
-- Installable extension archive contains root-level `manifest.json` with version `0.4.0`.
+Before v0.5.0 is integrated:
+
+- Project Execution OS integrity validation passes;
+- Linux reproducible install, strict TypeScript check, all tests, production build, and versioned packaging pass;
+- Windows updater dry-run, full local-source validation, and manifest check pass;
+- installable extension archive contains root-level `manifest.json` with version `0.5.0`;
+- PR #87 is mergeable and merged into `main`.
 
 ## 8. Read next
 
 1. `PROJECT_STATE.md`
 2. `logs/latest.md`
 3. `README.md`
-4. `docs/RESEARCH_AND_DECISIONS.md`
-5. `docs/IMPLEMENTATION_HANDOFF.md`
+4. `coordination/CHANNEL_PROFILE_EXPORT_V0.5.0.md`
+5. `docs/RESEARCH_AND_DECISIONS.md`
+6. `docs/IMPLEMENTATION_HANDOFF.md`

--- a/projects/tiktok-research-sorter/PROJECT_STATE.md
+++ b/projects/tiktok-research-sorter/PROJECT_STATE.md
@@ -1,58 +1,70 @@
 ---
 project_mode: internal
-status: stable
-version: 0.4.0
-branch: main
-active_issue: 84
-pull_request: 85
+status: active
+version: 0.5.0
+branch: agent/tiktok-research-sorter-channel-export-v0.5.0
+active_issue: 86
+pull_request: 87
 ---
 
 # TikTok Research Sorter — Project State
 
 ## Current phase
 
-Version 0.4.0 is integrated into `main`. It adds durable favorites, checkbox-based curation, and safe standalone HTML export while preserving the existing public-profile and hashtag research workflows. The Windows updater follows `main`.
+Version 0.5.0 adds complete public channel snapshots to Favorites and selected HTML exports while preserving the profile, hashtag, favorites, and checkbox-selection workflows. PR #87 is under final automated validation before integration into `main`.
 
 ## Working implementation
 
 - WXT Manifest V3 extension with a React side panel.
-- Public profile scanning with profile analytics, filters, and versioned CSV/JSON export.
+- Public profile scanning with expanded channel identity, counters, identifiers, flags, locale, timestamps, and analytics.
 - Public hashtag scanning with per-account top-N selection and a minimum-view threshold.
 - A star control on every video card.
-- Favorites stored independently from profile and hashtag snapshots.
-- Dedicated Favorites view with favorite count.
-- Checkbox selection, select all, clear selection, individual removal, and bulk removal.
-- Standalone HTML export containing only checked favorites.
-- HTML cards include clickable video/profile links, descriptions, preview images, dates, audio, hashtags, and available metrics.
+- Durable favorite entries containing both the video snapshot and a channel snapshot.
+- Backward-compatible migration of v0.4.0 favorites to partial channel snapshots.
+- Automatic channel-snapshot refresh when richer profile information is collected.
+- Same-origin public channel enrichment after adding a favorite, without navigating the visible TikTok page.
+- Manual `Обновить канал` action as a fallback.
+- Favorites grouped by channel with complete channel cards.
+- Selected-only standalone HTML grouped by channel.
+- Channel HTML includes identity, public IDs, counters, flags, locale, dates, website, source, channel analytics, links, and selected videos.
 - HTML escaping and HTTP(S)-only URL validation.
-- Backward-compatible migration for dashboards created before Favorites existed.
-- Atomic Windows one-click updater following `main`.
+- Atomic Windows one-click updater following `main` after merge.
+
+## Supported public channel fields
+
+- username, profile URL, display name, avatar, biography, verification, and website;
+- public user ID and `secUid`;
+- followers, following, friends, total profile likes, and public video count;
+- region, language, private-account flag, commerce-account flag, and account creation date;
+- locally collected video count, median views, average engagement, and strongest hashtags;
+- collection/update timestamps and data source.
+
+Missing fields remain unavailable and are never inferred.
 
 ## Boundaries
 
 - Data remains local unless the user explicitly exports it.
-- Exported HTML references public TikTok links and externally hosted preview images; previews can stop loading if TikTok later expires those URLs.
+- TikTok can omit public fields, request verification, change payloads, or expire external preview/avatar URLs.
+- Public channel enrichment uses the existing TikTok host permission and does not navigate the visible page.
 - No login, CAPTCHA, private-profile, paywall, rate-limit, or access-control bypass.
 - No additional host permissions beyond TikTok.
 - No backend, cloud sync, Chrome Web Store submission, or public GitHub Release.
 
-## Final validation
+## Validation status
 
-For PR #85 head `eb3328251cb256164237baefb66b25b449d222cb`:
+Implementation and regression coverage are committed on PR #87. Final evidence still required:
 
-- Project Execution OS integrity run `29333836074`: passed.
-- TikTok Research Sorter CI run `29333836128`: passed.
-- Linux reproducible install, strict TypeScript, all tests, production build, packaging, and artifact upload: passed.
-- Windows updater dry-run, full local-source validation, and manifest version check: passed.
-- PR #85 merged into `main` as `92f66e3fea0b96f30dfad8dc0de7aff5e1a5c696`.
+- Project Execution OS integrity validation;
+- Linux reproducible install, TypeScript, all tests, production build, packaging, and artifact upload;
+- Windows updater dry-run, full local-source validation, and manifest version check;
+- installable extension ZIP inspection;
+- PR merge into `main`.
 
-## Distribution
+## Distribution target
 
-Successful v0.4.0 CI produced:
+Successful v0.5.0 CI must produce:
 
 - unpacked Chrome MV3 extension;
-- `tiktok-research-sorter-extension-v0.4.0.zip`;
-- `tiktok-sorter-auto-updater-setup-v0.4.0.zip`;
-- `tiktok-research-sorter-source-v0.4.0.zip`.
-
-The installable extension ZIP was independently inspected: `manifest.json` is at the archive root and declares version `0.4.0`.
+- `tiktok-research-sorter-extension-v0.5.0.zip`;
+- `tiktok-sorter-auto-updater-setup-v0.5.0.zip`;
+- `tiktok-research-sorter-source-v0.5.0.zip`.

--- a/projects/tiktok-research-sorter/README.md
+++ b/projects/tiktok-research-sorter/README.md
@@ -1,13 +1,13 @@
 # TikTok Research Sorter
 
-Local-first Manifest V3 extension for scanning public TikTok profile and hashtag pages, ranking videos, saving favorites, and exporting selected research.
+Local-first Manifest V3 extension for scanning public TikTok profile and hashtag pages, ranking videos, saving favorites with channel snapshots, and exporting selected research.
 
-## Version 0.4.0
+## Version 0.5.0
 
 ### Profile research
 
-- Full profile card with avatar, display name, biography, verification status, followers, following, profile likes, and public video count.
-- Scan metadata: last scan, collected coverage, estimated posting frequency, median views, and strongest hashtags.
+- Full profile card with avatar, display name, biography, verification, website, public IDs, region, language, account flags, followers, following, friends, profile likes, and public video count.
+- Scan metadata: last scan, profile update time, collected coverage, estimated posting frequency, median views, average engagement, and strongest hashtags.
 - Video cards with cover, rank, views, views/day, outlier score, engagement, and hashtags.
 - Sorting, search, outlier filtering, CSV export, and JSON export.
 
@@ -27,42 +27,56 @@ The side panel automatically detects hashtag mode. Choose:
 
 The extension groups discovered videos by account and keeps the requested top videos from each account. Results can be adjusted after scanning because the locally stored hashtag snapshot retains all videos collected during that scan.
 
-Important: hashtag mode ranks videos found on the open hashtag page. It does not silently visit every creator profile or claim to inspect videos that TikTok did not load.
+Important: hashtag mode ranks videos found on the open hashtag page. It does not silently claim to inspect videos TikTok did not load.
 
-### Favorites and HTML shortlist
+### Favorites with complete channel information
 
 Every video card has a star:
 
 - `☆` adds the video to Favorites;
 - `★` removes it from Favorites.
 
-Favorites are stored separately from profile and hashtag results, so clearing a scanned profile or hashtag does not remove saved videos.
+When a video is added, the extension stores a durable channel snapshot. It also requests public profile enrichment from the current TikTok tab without navigating away. Existing favorite snapshots are refreshed automatically whenever richer profile data is collected later.
+
+The channel snapshot can contain every supported public field TikTok actually exposes:
+
+- username, display name, avatar, biography, profile link, verification, and website;
+- public user ID and `secUid`;
+- followers, following, friends, total profile likes, and public video count;
+- region, language, private-account flag, commerce-account flag, and account creation date;
+- locally collected video count, median views, average engagement, and strongest hashtags;
+- collection timestamps and data source.
+
+Unavailable fields are displayed as `—`; values are never invented.
+
+### Selected HTML with channels
 
 Open the `★ Избранное` tab to:
 
-1. select videos with checkboxes;
-2. select all or clear the current selection;
-3. remove selected favorites;
-4. download `tiktok-favorites-selected-v0.4.0.html`.
+1. review favorites grouped by channel;
+2. refresh a channel profile when needed;
+3. select videos with checkboxes;
+4. select all or clear the current selection;
+5. remove selected favorites;
+6. download `tiktok-favorites-with-channels-v0.5.0.html`.
 
-The generated HTML page is standalone and suitable for sending as a file. It contains:
+The standalone HTML file is suitable for sending to another person. Each channel section contains the full stored channel card followed by only that channel's checked videos. It includes:
 
 - clickable TikTok video and profile links;
+- channel avatar, biography, identifiers, public statistics, flags, dates, website, source, and channel analytics;
 - preview images when TikTok provides them;
-- descriptions and hashtags;
-- publication dates and audio titles;
-- views, likes, comments, shares, saves, and engagement rate;
-- a print-friendly responsive layout.
+- video descriptions, hashtags, publication dates, audio titles, duration, pinned status, and metrics;
+- a responsive and print-friendly layout.
 
-Only checked favorites are included. User-controlled text is HTML-escaped, and non-HTTP(S) links or previews are rejected.
+User-controlled text is HTML-escaped, and non-HTTP(S) links or previews are rejected.
 
 ### Reliability and safety
 
 - Side Panel interface opened from the extension toolbar.
 - User-initiated automatic scrolling with explicit stop, challenge detection, and error recovery.
-- Hybrid collection from embedded JSON, selected TikTok page requests, and loaded DOM cards.
+- Hybrid collection from embedded JSON, selected TikTok page requests, loaded DOM cards, and same-origin public profile enrichment.
 - Serialized local persistence to prevent lost updates.
-- Backward-compatible dashboard migration adds Favorites to existing installations.
+- Backward-compatible migration adds channel snapshots to existing favorites.
 - Strict data-source precedence: API → embedded JSON → DOM fallback.
 - CSV export with spreadsheet-formula protection.
 - HTML export with markup escaping and URL protocol validation.
@@ -105,10 +119,10 @@ Load `.output/chrome-mv3` through `chrome://extensions` with Developer mode enab
 Each successful branch or pull-request run uploads versioned files:
 
 - unpacked Chrome MV3 extension;
-- `tiktok-research-sorter-extension-v0.4.0.zip`;
-- `tiktok-sorter-auto-updater-setup-v0.4.0.zip`;
-- `tiktok-research-sorter-source-v0.4.0.zip`.
+- `tiktok-research-sorter-extension-v0.5.0.zip`;
+- `tiktok-sorter-auto-updater-setup-v0.5.0.zip`;
+- `tiktok-research-sorter-source-v0.5.0.zip`.
 
 ## Product boundary
 
-This project analyzes data already visible to the user on public TikTok pages. Data remains local in the browser unless the user explicitly exports it. TikTok can change public payloads and page structure, so platform parsing remains isolated and regression-tested.
+The project stores only public data TikTok makes available to the current browser session. TikTok can omit fields, request verification, change payloads, or expire external preview URLs. Missing fields remain unavailable rather than being inferred.

--- a/projects/tiktok-research-sorter/entrypoints/content.ts
+++ b/projects/tiktok-research-sorter/entrypoints/content.ts
@@ -1,5 +1,6 @@
 import { browser } from 'wxt/browser';
 import {
+  extractProfileFromDocument,
   extractProfileFromDom,
   extractProfileFromPayload,
   extractVideosFromDiscoveryDom,
@@ -105,10 +106,10 @@ function detectChallenge(): boolean {
   );
 }
 
-function embeddedPayloads(): unknown[] {
+function embeddedPayloadsFromRoot(root: ParentNode): unknown[] {
   const candidates = [
-    document.querySelector<HTMLScriptElement>('#__UNIVERSAL_DATA_FOR_REHYDRATION__'),
-    document.querySelector<HTMLScriptElement>('#SIGI_STATE'),
+    root.querySelector<HTMLScriptElement>('#__UNIVERSAL_DATA_FOR_REHYDRATION__'),
+    root.querySelector<HTMLScriptElement>('#SIGI_STATE'),
   ].filter(Boolean) as HTMLScriptElement[];
 
   return candidates.flatMap((script) => {
@@ -118,6 +119,10 @@ function embeddedPayloads(): unknown[] {
       return [];
     }
   });
+}
+
+function embeddedPayloads(): unknown[] {
+  return embeddedPayloadsFromRoot(document);
 }
 
 async function collectProfileEmbedded(context: ProfilePageContext): Promise<void> {
@@ -137,6 +142,71 @@ async function collectTagEmbedded(context: TagPageContext): Promise<void> {
 
 async function collectProfileDom(context: ProfilePageContext): Promise<void> {
   await sendProfile(extractProfileFromDom(context.username));
+}
+
+async function enrichChannel(usernameInput: string): Promise<{ ok: boolean; videosFound: number; message?: string }> {
+  const username = usernameInput.trim().replace(/^@/, '');
+  if (!username) return { ok: false, videosFound: 0, message: 'Не указан канал.' };
+
+  const context: ProfilePageContext = {
+    kind: 'profile',
+    username,
+    profileUrl: `https://www.tiktok.com/@${encodeURIComponent(username)}`,
+  };
+
+  try {
+    const response = await fetch(context.profileUrl, {
+      credentials: 'include',
+      cache: 'no-store',
+      headers: { Accept: 'text/html,application/xhtml+xml' },
+    });
+    if (!response.ok) {
+      return { ok: false, videosFound: 0, message: `TikTok вернул HTTP ${response.status}.` };
+    }
+
+    const html = await response.text();
+    const lowered = html.toLowerCase();
+    if (lowered.includes('verify to continue') || lowered.includes('captcha')) {
+      return { ok: false, videosFound: 0, message: 'TikTok запросил проверку пользователя.' };
+    }
+
+    const parsedDocument = new DOMParser().parseFromString(html, 'text/html');
+    const mergedVideos = new Map<string, VideoRecord>();
+    let profileFound = false;
+
+    for (const payload of embeddedPayloadsFromRoot(parsedDocument)) {
+      const profile = extractProfileFromPayload(payload, username, 'embedded-json');
+      if (profile) {
+        profileFound = true;
+        await sendProfile(profile);
+      }
+      for (const video of extractVideosFromPayload(payload, username, 'embedded-json')) {
+        const existing = mergedVideos.get(video.id);
+        mergedVideos.set(video.id, existing ? mergeVideoRecords(existing, video) : video);
+      }
+    }
+
+    const domProfile = extractProfileFromDocument(parsedDocument, username, 'dom');
+    await sendProfile(domProfile);
+    profileFound = profileFound || Boolean(
+      domProfile.displayName || domProfile.bio || domProfile.avatarUrl
+      || domProfile.followers !== undefined || domProfile.videoCount !== undefined
+    );
+
+    const videos = [...mergedVideos.values()];
+    await sendProfileBatch(context, videos);
+    return {
+      ok: profileFound,
+      videosFound: videos.length,
+      message: profileFound ? undefined : 'TikTok не отдал расширенные публичные данные канала.',
+    };
+  } catch (cause) {
+    return {
+      ok: false,
+      videosFound: 0,
+      message: cause instanceof Error ? cause.message : String(cause),
+    };
+  }
 }
 
 async function startProfileScan(context: ProfilePageContext, options: ScanOptions): Promise<void> {
@@ -404,6 +474,7 @@ export default defineContentScript({
         stopRequested = true;
         return Promise.resolve({ ok: true });
       }
+      if (message.type === 'ENRICH_CHANNEL') return enrichChannel(message.username);
       return undefined;
     });
   },

--- a/projects/tiktok-research-sorter/entrypoints/sidepanel/App.tsx
+++ b/projects/tiktok-research-sorter/entrypoints/sidepanel/App.tsx
@@ -2,12 +2,18 @@ import { useEffect, useMemo, useState } from 'react';
 import { browser } from 'wxt/browser';
 import { enrichVideos, publicationFrequencyPerWeek, strongestHashtags, summarize } from '../../lib/analytics';
 import { videosToCsv } from '../../lib/csv';
-import { favoriteKey, orderedFavoriteEntries, selectFavoriteEntries } from '../../lib/favorites';
+import {
+  favoriteKey,
+  groupFavoriteEntriesByChannel,
+  orderedFavoriteEntries,
+  selectFavoriteEntries,
+} from '../../lib/favorites';
 import { generateFavoritesHtml } from '../../lib/html-export';
 import { formatCompactNumber } from '../../lib/numbers';
 import { groupTopVideosPerAccount } from '../../lib/tag-research';
 import { APP_VERSION } from '../../lib/types';
 import type {
+  ChannelSnapshot,
   DashboardData,
   EnrichedVideo,
   FavoriteEntry,
@@ -86,7 +92,22 @@ function formatDate(timestamp: number | undefined): string {
   }).format(new Date(timestamp));
 }
 
-function initials(profile: ProfileSnapshot): string {
+function formatUnixDate(timestampSeconds: number | undefined): string {
+  if (!timestampSeconds) return '—';
+  return new Intl.DateTimeFormat('ru-RU', {
+    day: '2-digit', month: 'short', year: 'numeric',
+  }).format(new Date(timestampSeconds * 1000));
+}
+
+function formatOptionalNumber(value: number | undefined): string {
+  return value === undefined ? '—' : formatCompactNumber(value);
+}
+
+function yesNo(value: boolean | undefined): string {
+  return value === undefined ? '—' : value ? 'Да' : 'Нет';
+}
+
+function initials(profile: { displayName?: string; username: string }): string {
   const source = profile.displayName || profile.username;
   return source.split(/\s+/).filter(Boolean).slice(0, 2).map((part) => part[0]?.toUpperCase()).join('') || 'TT';
 }
@@ -121,6 +142,23 @@ export default function App() {
       if (connection.context?.kind === 'profile') setViewMode('profile');
     } catch {
       setPageContext(undefined);
+    }
+  };
+
+  const requestChannelEnrichment = async (username: string, surfaceError = false) => {
+    try {
+      const { tabId } = await connectToActiveTikTokTab();
+      const result = await browser.tabs.sendMessage(tabId, {
+        type: 'ENRICH_CHANNEL',
+        username,
+      } satisfies RuntimeMessage) as { ok?: boolean; message?: string };
+      if (surfaceError && !result?.ok) setError(result?.message || `Не удалось получить данные канала @${username}.`);
+      if (result?.ok) setError('');
+    } catch (cause) {
+      if (surfaceError) {
+        const details = cause instanceof Error ? cause.message : String(cause);
+        setError(`Откройте любую страницу TikTok и повторите обновление канала. ${details}`);
+      }
     }
   };
 
@@ -214,8 +252,10 @@ export default function App() {
   };
 
   const toggleFavorite = async (video: VideoRecord) => {
+    const adding = !dashboard.favorites[favoriteKey(video)];
     const data = await browser.runtime.sendMessage({ type: 'TOGGLE_FAVORITE', video } satisfies RuntimeMessage) as DashboardData;
     applyDashboard(data);
+    if (adding) void requestChannelEnrichment(video.author, false);
   };
 
   const clearProfileData = async () => {
@@ -284,8 +324,8 @@ export default function App() {
     const selected = selectFavoriteEntries(dashboard.favorites, selectedFavoriteKeys);
     if (!selected.length) return;
     downloadText(
-      `tiktok-favorites-selected-v${APP_VERSION}.html`,
-      generateFavoritesHtml(selected, { title: 'Отобранные TikTok-ролики' }),
+      `tiktok-favorites-with-channels-v${APP_VERSION}.html`,
+      generateFavoritesHtml(selected, { title: 'Отобранные TikTok-ролики и каналы' }),
       'text/html;charset=utf-8',
     );
   };
@@ -305,7 +345,7 @@ export default function App() {
         <div>
           <p className="eyebrow">LOCAL-FIRST RESEARCH TOOL · v{APP_VERSION}</p>
           <h1>TikTok Research Sorter</h1>
-          <p className="subtitle">Сканирует TikTok, сохраняет понравившиеся ролики и создаёт готовые HTML-подборки.</p>
+          <p className="subtitle">Сохраняет ролики вместе с полной публичной информацией о каналах и создаёт готовые HTML-подборки.</p>
         </div>
         <span className={`status status-${dashboard.activeScan.status}`}>{dashboard.activeScan.status}</span>
       </header>
@@ -359,6 +399,8 @@ export default function App() {
         </section>
       )}
 
+      {viewMode === 'favorites' && error && <section className="panel error-panel">{error}</section>}
+
       {viewMode === 'profile' && (
         <ProfileResults
           profile={profile}
@@ -409,6 +451,7 @@ export default function App() {
           selectedKeys={selectedFavoriteKeys}
           setSelectedKeys={setSelectedFavoriteKeys}
           toggleFavorite={toggleFavorite}
+          refreshChannel={(username) => requestChannelEnrichment(username, true)}
           removeSelected={removeSelectedFavorites}
           exportHtml={exportSelectedFavoritesHtml}
         />
@@ -618,6 +661,7 @@ function FavoritesResults({
   selectedKeys,
   setSelectedKeys,
   toggleFavorite,
+  refreshChannel,
   removeSelected,
   exportHtml,
 }: {
@@ -626,9 +670,11 @@ function FavoritesResults({
   selectedKeys: Set<string>;
   setSelectedKeys: (value: Set<string>) => void;
   toggleFavorite: (video: VideoRecord) => Promise<void>;
+  refreshChannel: (username: string) => Promise<void>;
   removeSelected: () => Promise<void>;
   exportHtml: () => void;
 }) {
+  const groups = groupFavoriteEntriesByChannel(entries);
   const allSelected = entries.length > 0 && selectedKeys.size === entries.length;
 
   const toggleSelection = (key: string, checked: boolean) => {
@@ -643,8 +689,8 @@ function FavoritesResults({
       <section className="panel favorites-intro">
         <div>
           <p className="eyebrow">ИЗБРАННОЕ</p>
-          <h2>Отбор роликов для отправки</h2>
-          <p>Отметьте нужные ролики чекбоксами. HTML-файл сохранит ссылки, описания, показатели и превью.</p>
+          <h2>Отбор роликов и каналов для отправки</h2>
+          <p>HTML-файл включает выбранные ролики и все публичные данные каналов, которые удалось получить от TikTok.</p>
         </div>
         <strong>{entries.length}</strong>
       </section>
@@ -652,30 +698,94 @@ function FavoritesResults({
       <section className="panel actions favorites-actions">
         <button onClick={() => setSelectedKeys(new Set(entries.map((entry) => entry.key)))} disabled={!entries.length || allSelected}>Выбрать все</button>
         <button onClick={() => setSelectedKeys(new Set())} disabled={!selectedKeys.size}>Снять выбор</button>
-        <button className="primary" onClick={exportHtml} disabled={!selectedKeys.size}>Скачать HTML выбранного</button>
+        <button className="primary" onClick={exportHtml} disabled={!selectedKeys.size}>Скачать HTML с каналами</button>
         <button className="danger" onClick={() => void removeSelected()} disabled={!selectedKeys.size}>Удалить выбранное</button>
-        <span>Выбрано: {selectedKeys.size}</span>
+        <span>Выбрано: {selectedKeys.size} · Каналов: {groups.length}</span>
       </section>
 
-      <section className="video-list favorites-list">
-        {entries.map((entry, index) => {
-          const video = enrichedVideos.get(entry.key) ?? entry.video as EnrichedVideo;
-          return (
-            <VideoCard
-              key={entry.key}
-              video={video}
-              rank={index + 1}
-              favorite
-              selected={selectedKeys.has(entry.key)}
-              onSelectedChange={(checked) => toggleSelection(entry.key, checked)}
-              onToggleFavorite={() => void toggleFavorite(entry.video)}
-              favoritedAt={entry.favoritedAt}
-            />
-          );
-        })}
+      <section className="favorite-channel-groups">
+        {groups.map((group) => (
+          <section className="favorite-channel-group" key={group.key}>
+            <ChannelCard channel={group.channel} onRefresh={() => void refreshChannel(group.channel.username)} />
+            <div className="video-list favorites-list">
+              {group.entries.map((entry, index) => {
+                const video = enrichedVideos.get(entry.key) ?? entry.video as EnrichedVideo;
+                return (
+                  <VideoCard
+                    key={entry.key}
+                    video={video}
+                    rank={index + 1}
+                    favorite
+                    selected={selectedKeys.has(entry.key)}
+                    onSelectedChange={(checked) => toggleSelection(entry.key, checked)}
+                    onToggleFavorite={() => void toggleFavorite(entry.video)}
+                    favoritedAt={entry.favoritedAt}
+                  />
+                );
+              })}
+            </div>
+          </section>
+        ))}
         {!entries.length && <div className="empty">Избранных роликов пока нет. Нажмите звёздочку на любой карточке.</div>}
       </section>
     </>
+  );
+}
+
+function ChannelCard({ channel, onRefresh }: { channel: ChannelSnapshot; onRefresh: () => void }) {
+  return (
+    <section className="panel channel-card">
+      <div className="channel-head">
+        <a className="channel-avatar" href={channel.profileUrl} target="_blank" rel="noreferrer">
+          {channel.avatarUrl ? <img src={channel.avatarUrl} alt="" /> : <span>{initials(channel)}</span>}
+        </a>
+        <div className="channel-identity">
+          <div className="channel-title-row">
+            <h2>{channel.displayName || `@${channel.username}`}</h2>
+            {channel.verified && <span className="verified" title="Проверенный аккаунт">✓</span>}
+            <span className={`channel-completeness ${channel.completeness}`}>{channel.completeness === 'full' ? 'полные данные' : 'частичные данные'}</span>
+          </div>
+          <a href={channel.profileUrl} target="_blank" rel="noreferrer">@{channel.username}</a>
+          {channel.bio && <p>{channel.bio}</p>}
+          <div className="channel-links">
+            <a href={channel.profileUrl} target="_blank" rel="noreferrer">Профиль TikTok ↗</a>
+            {channel.website && <a href={channel.website} target="_blank" rel="noreferrer">Сайт ↗</a>}
+          </div>
+        </div>
+        <button className="secondary channel-refresh" onClick={onRefresh}>Обновить канал</button>
+      </div>
+
+      <div className="channel-stats">
+        <article><span>Подписчики</span><strong>{formatOptionalNumber(channel.followers)}</strong></article>
+        <article><span>Подписки</span><strong>{formatOptionalNumber(channel.following)}</strong></article>
+        <article><span>Друзья</span><strong>{formatOptionalNumber(channel.friends)}</strong></article>
+        <article><span>Лайки профиля</span><strong>{formatOptionalNumber(channel.totalLikes)}</strong></article>
+        <article><span>Видео в профиле</span><strong>{formatOptionalNumber(channel.videoCount)}</strong></article>
+        <article><span>Собрано видео</span><strong>{formatCompactNumber(channel.collectedVideoCount)}</strong></article>
+        <article><span>Медиана просмотров</span><strong>{formatCompactNumber(channel.medianViews)}</strong></article>
+        <article><span>Средний ER</span><strong>{percent(channel.averageEngagementRate)}</strong></article>
+      </div>
+
+      <div className="channel-details">
+        <div><span>User ID</span><strong>{channel.userId || '—'}</strong></div>
+        <div><span>secUid</span><strong>{channel.secUid || '—'}</strong></div>
+        <div><span>Регион</span><strong>{channel.region || '—'}</strong></div>
+        <div><span>Язык</span><strong>{channel.language || '—'}</strong></div>
+        <div><span>Создан</span><strong>{formatUnixDate(channel.accountCreatedAt)}</strong></div>
+        <div><span>Закрытый аккаунт</span><strong>{yesNo(channel.privateAccount)}</strong></div>
+        <div><span>Коммерческий</span><strong>{yesNo(channel.commerceAccount)}</strong></div>
+        <div><span>Источник</span><strong>{channel.profileDataSource || '—'}</strong></div>
+        <div><span>Обновлено</span><strong>{formatDate(channel.profileDataUpdatedAt || channel.capturedAt)}</strong></div>
+      </div>
+
+      <div className="profile-topics">
+        <span>Сильные темы канала</span>
+        <div>
+          {channel.strongestHashtags.map((tag) => <span key={tag}>#{tag}</span>)}
+          {!channel.strongestHashtags.length && <em>Появятся после сбора роликов канала.</em>}
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -711,18 +821,33 @@ function ProfileCard({
         </div>
       </div>
 
-      <div className="profile-stats">
-        <article><span>Подписчики</span><strong>{profile.followers === undefined ? '—' : formatCompactNumber(profile.followers)}</strong></article>
-        <article><span>Подписки</span><strong>{profile.following === undefined ? '—' : formatCompactNumber(profile.following)}</strong></article>
-        <article><span>Лайки профиля</span><strong>{profile.totalLikes === undefined ? '—' : formatCompactNumber(profile.totalLikes)}</strong></article>
-        <article><span>Видео в профиле</span><strong>{profile.videoCount === undefined ? '—' : formatCompactNumber(profile.videoCount)}</strong></article>
+      <div className="profile-stats profile-stats-wide">
+        <article><span>Подписчики</span><strong>{formatOptionalNumber(profile.followers)}</strong></article>
+        <article><span>Подписки</span><strong>{formatOptionalNumber(profile.following)}</strong></article>
+        <article><span>Друзья</span><strong>{formatOptionalNumber(profile.friends)}</strong></article>
+        <article><span>Лайки профиля</span><strong>{formatOptionalNumber(profile.totalLikes)}</strong></article>
+        <article><span>Видео в профиле</span><strong>{formatOptionalNumber(profile.videoCount)}</strong></article>
+        <article><span>Собрано видео</span><strong>{formatCompactNumber(profile.videos.length)}</strong></article>
+        <article><span>Медиана просмотров</span><strong>{formatCompactNumber(profile.medianViews)}</strong></article>
+        <article><span>Средний ER</span><strong>{summary.averageEngagementRate.toFixed(2)}%</strong></article>
+      </div>
+
+      <div className="profile-details">
+        <div><span>User ID</span><strong>{profile.userId || '—'}</strong></div>
+        <div><span>secUid</span><strong>{profile.secUid || '—'}</strong></div>
+        <div><span>Регион</span><strong>{profile.region || '—'}</strong></div>
+        <div><span>Язык</span><strong>{profile.language || '—'}</strong></div>
+        <div><span>Создан</span><strong>{formatUnixDate(profile.accountCreatedAt)}</strong></div>
+        <div><span>Закрытый аккаунт</span><strong>{yesNo(profile.privateAccount)}</strong></div>
+        <div><span>Коммерческий</span><strong>{yesNo(profile.commerceAccount)}</strong></div>
+        <div><span>Источник</span><strong>{profile.profileDataSource || '—'}</strong></div>
       </div>
 
       <div className="profile-insights">
         <div><span>Последнее сканирование</span><strong>{formatDate(profile.lastScannedAt)}</strong></div>
+        <div><span>Обновление профиля</span><strong>{formatDate(profile.profileDataUpdatedAt)}</strong></div>
         <div><span>Покрытие</span><strong>{coverage}</strong></div>
         <div><span>Частота публикаций</span><strong>{frequency === undefined ? '—' : `${frequency.toFixed(1)} в неделю`}</strong></div>
-        <div><span>Типичный ролик</span><strong>{formatCompactNumber(summary.medianViews)} просмотров</strong></div>
       </div>
 
       <div className="profile-topics">

--- a/projects/tiktok-research-sorter/entrypoints/sidepanel/style.css
+++ b/projects/tiktok-research-sorter/entrypoints/sidepanel/style.css
@@ -38,6 +38,7 @@ button { color: #f7f7fb; background: #303648; border-radius: 9px; padding: 9px 1
 .scan-message { color: #aeb2c6; font-size: 12px; margin: 9px 0 0; }
 .hint { color: #777f95; font-size: 10px; line-height: 1.4; margin: 6px 0 0; }
 .error { color: #ff91a4; font-size: 12px; margin: 8px 0 0; }
+.error-panel { color: #ff91a4; font-size: 12px; }
 .profile-card { display: grid; gap: 13px; overflow: hidden; position: relative; }
 .profile-card::before { content: ""; position: absolute; inset: 0 0 auto; height: 3px; background: linear-gradient(90deg, #24e7ca, #7a5cff, #d04fff); }
 .profile-head { display: grid; grid-template-columns: 72px minmax(0, 1fr); gap: 12px; align-items: start; }
@@ -50,10 +51,13 @@ button { color: #f7f7fb; background: #303648; border-radius: 9px; padding: 9px 1
 .profile-identity > a { color: #8fded3; text-decoration: none; font-size: 11px; }
 .profile-identity p { margin: 7px 0 5px; color: #d4d6e0; font-size: 11px; line-height: 1.45; white-space: pre-line; }
 .profile-site { display: inline-block; color: #d3c9ff !important; }
-.profile-stats { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
-.profile-stats article { padding: 9px; border-radius: 10px; background: #101520; border: 1px solid rgba(255,255,255,.06); }
-.profile-stats span, .profile-insights span, .profile-topics > span { color: #8f95aa; font-size: 9px; text-transform: uppercase; letter-spacing: .06em; }
-.profile-stats strong { display: block; margin-top: 4px; font-size: 15px; }
+.profile-stats, .channel-stats { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+.profile-stats article, .channel-stats article { padding: 9px; border-radius: 10px; background: #101520; border: 1px solid rgba(255,255,255,.06); }
+.profile-stats span, .channel-stats span, .profile-insights span, .profile-details span, .channel-details span, .profile-topics > span { color: #8f95aa; font-size: 9px; text-transform: uppercase; letter-spacing: .06em; }
+.profile-stats strong, .channel-stats strong { display: block; margin-top: 4px; font-size: 15px; }
+.profile-details, .channel-details { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px 12px; padding-top: 11px; border-top: 1px solid rgba(255,255,255,.07); }
+.profile-details div, .channel-details div { min-width: 0; }
+.profile-details strong, .channel-details strong { display: block; margin-top: 4px; color: #e7e8ef; font-size: 10px; line-height: 1.35; overflow-wrap: anywhere; }
 .profile-insights { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px 12px; padding-top: 11px; border-top: 1px solid rgba(255,255,255,.07); }
 .profile-insights div { min-width: 0; }
 .profile-insights strong { display: block; margin-top: 4px; color: #e7e8ef; font-size: 11px; line-height: 1.35; }
@@ -99,8 +103,31 @@ button { color: #f7f7fb; background: #303648; border-radius: 9px; padding: 9px 1
 .favorites-intro p:last-child { color: #aeb2c6; font-size: 11px; line-height: 1.5; margin: 8px 0 0; }
 .favorites-intro > strong { width: 58px; height: 58px; flex: 0 0 58px; display: grid; place-items: center; border-radius: 50%; color: #ffd666; background: rgba(255,214,102,.1); border: 1px solid rgba(255,214,102,.26); font-size: 22px; }
 .favorites-actions { align-items: center; }
+.favorite-channel-groups { display: grid; gap: 16px; }
+.favorite-channel-group { display: grid; gap: 10px; padding: 10px; border-radius: 16px; background: rgba(12,15,23,.48); border: 1px solid rgba(255,255,255,.05); }
+.channel-card { display: grid; gap: 13px; position: relative; overflow: hidden; }
+.channel-card::before { content: ""; position: absolute; inset: 0 0 auto; height: 3px; background: linear-gradient(90deg, #ffd666, #7a5cff, #24e7ca); }
+.channel-head { display: grid; grid-template-columns: 74px minmax(0, 1fr) auto; gap: 12px; align-items: start; }
+.channel-avatar { width: 74px; height: 74px; border-radius: 50%; overflow: hidden; display: grid; place-items: center; background: linear-gradient(135deg, #2d3346, #6840d8); color: #fff; font-weight: 900; font-size: 20px; border: 2px solid rgba(255,255,255,.14); }
+.channel-avatar img { width: 100%; height: 100%; object-fit: cover; }
+.channel-identity { min-width: 0; }
+.channel-title-row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.channel-title-row h2 { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.channel-identity > a, .channel-links a { color: #8fded3; text-decoration: none; font-size: 11px; }
+.channel-identity p { margin: 7px 0 5px; color: #d4d6e0; font-size: 11px; line-height: 1.45; white-space: pre-line; }
+.channel-links { display: flex; gap: 9px; flex-wrap: wrap; }
+.channel-completeness { padding: 4px 7px; border-radius: 999px; font-size: 8px; text-transform: uppercase; letter-spacing: .05em; }
+.channel-completeness.full { color: #79e5aa; background: rgba(18,52,36,.8); border: 1px solid rgba(121,229,170,.2); }
+.channel-completeness.partial { color: #ffd675; background: rgba(60,45,6,.8); border: 1px solid rgba(255,214,117,.2); }
+.channel-refresh { padding: 7px 9px; white-space: nowrap; font-size: 10px; }
 .favorites-list .video-card { background: rgba(26,29,42,.97); }
 .empty { color: #8e93a5; text-align: center; padding: 40px 10px; border: 1px dashed #343a4c; border-radius: 14px; }
+@media (max-width: 560px) {
+  .channel-head { grid-template-columns: 64px minmax(0,1fr); }
+  .channel-avatar { width: 64px; height: 64px; }
+  .channel-refresh { grid-column: 1 / -1; justify-self: start; }
+  .profile-details, .channel-details { grid-template-columns: 1fr; }
+}
 @media (max-width: 430px) {
   .mode-tabs button { font-size: 10px; padding-inline: 4px; }
   .select-control span { display: none; }
@@ -108,6 +135,6 @@ button { color: #f7f7fb; background: #303648; border-radius: 9px; padding: 9px 1
 }
 @media (min-width: 520px) {
   .stats-grid { grid-template-columns: repeat(4, 1fr); }
-  .profile-stats { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .profile-stats, .channel-stats { grid-template-columns: repeat(4, minmax(0, 1fr)); }
   .video-card { grid-template-columns: 112px minmax(0,1fr); }
 }

--- a/projects/tiktok-research-sorter/lib/favorites.ts
+++ b/projects/tiktok-research-sorter/lib/favorites.ts
@@ -1,16 +1,143 @@
-import type { FavoriteEntry, VideoRecord } from './types';
+import { enrichVideos, strongestHashtags, summarize } from './analytics';
+import type { ChannelSnapshot, FavoriteEntry, ProfileSnapshot, VideoRecord } from './types';
+
+export interface FavoriteChannelGroup {
+  key: string;
+  channel: ChannelSnapshot;
+  entries: FavoriteEntry[];
+  latestFavoritedAt: number;
+}
+
+export function profileKey(username: string): string {
+  return username.trim().replace(/^@/, '').toLowerCase();
+}
 
 export function favoriteKey(video: Pick<VideoRecord, 'author' | 'id'>): string {
-  const author = video.author.trim().replace(/^@/, '').toLowerCase();
-  return `${author}:${video.id.trim()}`;
+  return `${profileKey(video.author)}:${video.id.trim()}`;
+}
+
+export function minimalChannelSnapshot(video: Pick<VideoRecord, 'author' | 'profileUrl'>): ChannelSnapshot {
+  const username = video.author.trim().replace(/^@/, '');
+  const now = Date.now();
+  return {
+    username,
+    profileUrl: video.profileUrl || `https://www.tiktok.com/@${username}`,
+    medianViews: 0,
+    lastScannedAt: now,
+    collectedVideoCount: 0,
+    strongestHashtags: [],
+    capturedAt: now,
+    completeness: 'partial',
+  };
+}
+
+export function channelSnapshotFromProfile(profile: ProfileSnapshot): ChannelSnapshot {
+  const enriched = enrichVideos(profile.videos);
+  const summary = summarize(enriched);
+  const meaningfulFields = [
+    profile.displayName,
+    profile.bio,
+    profile.avatarUrl,
+    profile.followers,
+    profile.following,
+    profile.totalLikes,
+    profile.videoCount,
+    profile.userId,
+    profile.secUid,
+  ].filter((value) => value !== undefined && value !== '').length;
+
+  return {
+    username: profile.username,
+    profileUrl: profile.profileUrl,
+    userId: profile.userId,
+    secUid: profile.secUid,
+    displayName: profile.displayName,
+    bio: profile.bio,
+    avatarUrl: profile.avatarUrl,
+    followers: profile.followers,
+    following: profile.following,
+    friends: profile.friends,
+    totalLikes: profile.totalLikes,
+    videoCount: profile.videoCount,
+    verified: profile.verified,
+    privateAccount: profile.privateAccount,
+    commerceAccount: profile.commerceAccount,
+    website: profile.website,
+    region: profile.region,
+    language: profile.language,
+    accountCreatedAt: profile.accountCreatedAt,
+    medianViews: profile.medianViews,
+    lastScannedAt: profile.lastScannedAt,
+    profileDataUpdatedAt: profile.profileDataUpdatedAt,
+    profileDataSource: profile.profileDataSource,
+    collectedVideoCount: profile.videos.length,
+    averageEngagementRate: enriched.length ? summary.averageEngagementRate : undefined,
+    strongestHashtags: strongestHashtags(enriched, 12),
+    capturedAt: Date.now(),
+    completeness: meaningfulFields >= 3 ? 'full' : 'partial',
+  };
+}
+
+function channelScore(channel: ChannelSnapshot): number {
+  return [
+    channel.displayName,
+    channel.bio,
+    channel.avatarUrl,
+    channel.followers,
+    channel.following,
+    channel.friends,
+    channel.totalLikes,
+    channel.videoCount,
+    channel.userId,
+    channel.secUid,
+    channel.website,
+    channel.region,
+    channel.language,
+    channel.accountCreatedAt,
+  ].filter((value) => value !== undefined && value !== '').length
+    + channel.collectedVideoCount
+    + (channel.completeness === 'full' ? 20 : 0);
+}
+
+export function mergeChannelSnapshots(current: ChannelSnapshot, incoming: ChannelSnapshot): ChannelSnapshot {
+  const incomingIsRicher = channelScore(incoming) >= channelScore(current);
+  const primary = incomingIsRicher ? incoming : current;
+  const secondary = incomingIsRicher ? current : incoming;
+
+  return {
+    ...secondary,
+    ...primary,
+    username: primary.username || secondary.username,
+    profileUrl: primary.profileUrl || secondary.profileUrl,
+    medianViews: Math.max(current.medianViews, incoming.medianViews),
+    lastScannedAt: Math.max(current.lastScannedAt, incoming.lastScannedAt),
+    profileDataUpdatedAt: Math.max(current.profileDataUpdatedAt ?? 0, incoming.profileDataUpdatedAt ?? 0) || undefined,
+    collectedVideoCount: Math.max(current.collectedVideoCount, incoming.collectedVideoCount),
+    averageEngagementRate: primary.averageEngagementRate ?? secondary.averageEngagementRate,
+    strongestHashtags: Array.from(new Set([...current.strongestHashtags, ...incoming.strongestHashtags])).slice(0, 12),
+    capturedAt: Math.max(current.capturedAt, incoming.capturedAt),
+    completeness: current.completeness === 'full' || incoming.completeness === 'full' ? 'full' : 'partial',
+  };
+}
+
+export function normalizeFavoriteEntry(entry: Partial<FavoriteEntry> & { video: VideoRecord }): FavoriteEntry {
+  const key = entry.key || favoriteKey(entry.video);
+  return {
+    key,
+    video: entry.video,
+    channel: entry.channel ?? minimalChannelSnapshot(entry.video),
+    favoritedAt: entry.favoritedAt ?? Date.now(),
+  };
 }
 
 export function orderedFavoriteEntries(favorites: Record<string, FavoriteEntry>): FavoriteEntry[] {
-  return Object.values(favorites).sort((a, b) =>
-    b.favoritedAt - a.favoritedAt
-    || b.video.views - a.video.views
-    || a.key.localeCompare(b.key)
-  );
+  return Object.values(favorites)
+    .map((entry) => normalizeFavoriteEntry(entry))
+    .sort((a, b) =>
+      b.favoritedAt - a.favoritedAt
+      || b.video.views - a.video.views
+      || a.key.localeCompare(b.key)
+    );
 }
 
 export function selectFavoriteEntries(
@@ -19,4 +146,34 @@ export function selectFavoriteEntries(
 ): FavoriteEntry[] {
   const selected = new Set(selectedKeys);
   return orderedFavoriteEntries(favorites).filter((entry) => selected.has(entry.key));
+}
+
+export function groupFavoriteEntriesByChannel(entries: FavoriteEntry[]): FavoriteChannelGroup[] {
+  const groups = new Map<string, FavoriteChannelGroup>();
+
+  for (const rawEntry of entries) {
+    const entry = normalizeFavoriteEntry(rawEntry);
+    const key = profileKey(entry.channel.username || entry.video.author);
+    const existing = groups.get(key);
+    if (!existing) {
+      groups.set(key, {
+        key,
+        channel: entry.channel,
+        entries: [entry],
+        latestFavoritedAt: entry.favoritedAt,
+      });
+      continue;
+    }
+
+    existing.channel = mergeChannelSnapshots(existing.channel, entry.channel);
+    existing.entries.push(entry);
+    existing.latestFavoritedAt = Math.max(existing.latestFavoritedAt, entry.favoritedAt);
+  }
+
+  return [...groups.values()]
+    .map((group) => ({
+      ...group,
+      entries: group.entries.sort((a, b) => b.favoritedAt - a.favoritedAt || b.video.views - a.video.views),
+    }))
+    .sort((a, b) => b.latestFavoritedAt - a.latestFavoritedAt || a.key.localeCompare(b.key));
 }

--- a/projects/tiktok-research-sorter/lib/html-export.ts
+++ b/projects/tiktok-research-sorter/lib/html-export.ts
@@ -1,6 +1,7 @@
 import { enrichVideos } from './analytics';
+import { groupFavoriteEntriesByChannel } from './favorites';
 import { APP_VERSION } from './types';
-import type { FavoriteEntry } from './types';
+import type { ChannelSnapshot, FavoriteEntry } from './types';
 
 export interface FavoritesHtmlOptions {
   title?: string;
@@ -27,16 +28,35 @@ function safeHttpUrl(value: string | undefined): string | undefined {
 }
 
 function formatNumber(value: number | undefined): string {
-  return new Intl.NumberFormat('ru-RU').format(value ?? 0);
+  return value === undefined ? '—' : new Intl.NumberFormat('ru-RU').format(value);
 }
 
-function formatDate(timestampSeconds: number | undefined): string {
-  if (!timestampSeconds) return 'Дата не указана';
+function formatPercent(value: number | undefined): string {
+  return value === undefined ? '—' : `${value.toFixed(2)}%`;
+}
+
+function formatDateMs(timestamp: number | undefined): string {
+  if (!timestamp) return '—';
+  return new Intl.DateTimeFormat('ru-RU', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(timestamp));
+}
+
+function formatDateSeconds(timestampSeconds: number | undefined): string {
+  if (!timestampSeconds) return '—';
   return new Intl.DateTimeFormat('ru-RU', {
     day: '2-digit',
     month: 'long',
     year: 'numeric',
   }).format(new Date(timestampSeconds * 1000));
+}
+
+function yesNo(value: boolean | undefined): string {
+  return value === undefined ? '—' : value ? 'Да' : 'Нет';
 }
 
 function renderPreview(coverUrl: string | undefined, author: string): string {
@@ -45,63 +65,146 @@ function renderPreview(coverUrl: string | undefined, author: string): string {
   return `<img class="preview" src="${escapeHtml(safeCover)}" alt="Превью ролика @${escapeHtml(author)}" loading="lazy">`;
 }
 
+function renderAvatar(channel: ChannelSnapshot): string {
+  const avatarUrl = safeHttpUrl(channel.avatarUrl);
+  if (avatarUrl) {
+    return `<img src="${escapeHtml(avatarUrl)}" alt="Аватар @${escapeHtml(channel.username)}" loading="lazy">`;
+  }
+  const initials = (channel.displayName || channel.username)
+    .split(/\s+/u)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('') || 'TT';
+  return `<span>${escapeHtml(initials)}</span>`;
+}
+
+function renderDetail(label: string, value: unknown): string {
+  return `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(value ?? '—')}</strong></div>`;
+}
+
+function renderChannel(channel: ChannelSnapshot): string {
+  const profileUrl = safeHttpUrl(channel.profileUrl);
+  const website = safeHttpUrl(channel.website);
+  const hashtags = channel.strongestHashtags
+    .map((tag) => `<span>#${escapeHtml(tag.replace(/^#/u, ''))}</span>`)
+    .join('');
+
+  return `
+    <section class="channel-card" data-channel="${escapeHtml(channel.username.toLowerCase())}">
+      <div class="channel-head">
+        <a class="channel-avatar" href="${escapeHtml(profileUrl ?? '#')}" target="_blank" rel="noopener noreferrer">
+          ${renderAvatar(channel)}
+        </a>
+        <div class="channel-identity">
+          <div class="channel-title">
+            <h2>${escapeHtml(channel.displayName || `@${channel.username}`)}</h2>
+            ${channel.verified ? '<span class="verified" title="Проверенный аккаунт">✓</span>' : ''}
+            <span class="completeness ${escapeHtml(channel.completeness)}">${channel.completeness === 'full' ? 'полные данные' : 'частичные данные'}</span>
+          </div>
+          <a class="username" href="${escapeHtml(profileUrl ?? '#')}" target="_blank" rel="noopener noreferrer">@${escapeHtml(channel.username)}</a>
+          ${channel.bio ? `<p class="bio">${escapeHtml(channel.bio)}</p>` : '<p class="bio muted">Биография не указана.</p>'}
+          <div class="channel-links">
+            <a href="${escapeHtml(profileUrl ?? '#')}" target="_blank" rel="noopener noreferrer">Открыть профиль ↗</a>
+            ${website ? `<a href="${escapeHtml(website)}" target="_blank" rel="noopener noreferrer">Сайт ↗</a>` : ''}
+          </div>
+        </div>
+      </div>
+
+      <div class="channel-metrics">
+        <div><span>Подписчики</span><strong>${escapeHtml(formatNumber(channel.followers))}</strong></div>
+        <div><span>Подписки</span><strong>${escapeHtml(formatNumber(channel.following))}</strong></div>
+        <div><span>Друзья</span><strong>${escapeHtml(formatNumber(channel.friends))}</strong></div>
+        <div><span>Лайки профиля</span><strong>${escapeHtml(formatNumber(channel.totalLikes))}</strong></div>
+        <div><span>Видео в профиле</span><strong>${escapeHtml(formatNumber(channel.videoCount))}</strong></div>
+        <div><span>Собрано видео</span><strong>${escapeHtml(formatNumber(channel.collectedVideoCount))}</strong></div>
+        <div><span>Медиана просмотров</span><strong>${escapeHtml(formatNumber(channel.medianViews))}</strong></div>
+        <div><span>Средний ER</span><strong>${escapeHtml(formatPercent(channel.averageEngagementRate))}</strong></div>
+      </div>
+
+      <div class="channel-details">
+        ${renderDetail('User ID', channel.userId || '—')}
+        ${renderDetail('secUid', channel.secUid || '—')}
+        ${renderDetail('Регион', channel.region || '—')}
+        ${renderDetail('Язык', channel.language || '—')}
+        ${renderDetail('Дата создания', formatDateSeconds(channel.accountCreatedAt))}
+        ${renderDetail('Закрытый аккаунт', yesNo(channel.privateAccount))}
+        ${renderDetail('Коммерческий аккаунт', yesNo(channel.commerceAccount))}
+        ${renderDetail('Источник данных', channel.profileDataSource || '—')}
+        ${renderDetail('Последнее сканирование', formatDateMs(channel.lastScannedAt))}
+        ${renderDetail('Профиль обновлён', formatDateMs(channel.profileDataUpdatedAt || channel.capturedAt))}
+      </div>
+
+      <div class="channel-topics">
+        <span>Сильные темы канала</span>
+        <div>${hashtags || '<em>Недостаточно собранных роликов.</em>'}</div>
+      </div>
+    </section>`;
+}
+
+function renderVideoCard(entry: FavoriteEntry, rank: number, enrichedVideo: ReturnType<typeof enrichVideos>[number] | undefined): string {
+  const video = enrichedVideo ?? entry.video;
+  const videoUrl = safeHttpUrl(video.videoUrl);
+  const profileUrl = safeHttpUrl(video.profileUrl);
+  const hashtags = video.hashtags
+    .map((tag) => `<span>#${escapeHtml(tag.replace(/^#/u, ''))}</span>`)
+    .join('');
+  const description = video.description?.trim() || 'Без описания';
+  const engagement = 'engagementRate' in video && typeof video.engagementRate === 'number'
+    ? `${video.engagementRate.toFixed(2)}%`
+    : '—';
+
+  return `
+    <article class="video-card" data-video-key="${escapeHtml(entry.key)}">
+      <div class="rank">${rank}</div>
+      <a class="preview-link" href="${escapeHtml(videoUrl ?? '#')}" target="_blank" rel="noopener noreferrer">
+        ${renderPreview(video.coverUrl, video.author)}
+      </a>
+      <div class="content">
+        <div class="video-head">
+          <div>
+            <a class="author" href="${escapeHtml(profileUrl ?? '#')}" target="_blank" rel="noopener noreferrer">@${escapeHtml(video.author)}</a>
+            <div class="date">Опубликовано: ${escapeHtml(formatDateSeconds(video.publishedAt))}</div>
+            <div class="date">Добавлено в избранное: ${escapeHtml(formatDateMs(entry.favoritedAt))}</div>
+          </div>
+          <a class="open" href="${escapeHtml(videoUrl ?? '#')}" target="_blank" rel="noopener noreferrer">Открыть ролик ↗</a>
+        </div>
+        <p class="description">${escapeHtml(description)}</p>
+        <div class="video-metrics">
+          <div><span>Просмотры</span><strong>${escapeHtml(formatNumber(video.views))}</strong></div>
+          <div><span>Лайки</span><strong>${escapeHtml(formatNumber(video.likes))}</strong></div>
+          <div><span>Комментарии</span><strong>${escapeHtml(formatNumber(video.comments))}</strong></div>
+          <div><span>Репосты</span><strong>${escapeHtml(formatNumber(video.shares))}</strong></div>
+          <div><span>Сохранения</span><strong>${escapeHtml(formatNumber(video.saves))}</strong></div>
+          <div><span>ER</span><strong>${escapeHtml(engagement)}</strong></div>
+          <div><span>Длительность</span><strong>${video.durationSeconds === undefined ? '—' : `${escapeHtml(video.durationSeconds)} сек.`}</strong></div>
+          <div><span>Закреплён</span><strong>${video.isPinned ? 'Да' : 'Нет'}</strong></div>
+        </div>
+        ${video.audioTitle ? `<div class="audio">Аудио: ${escapeHtml(video.audioTitle)}</div>` : ''}
+        <div class="hashtags">${hashtags}</div>
+      </div>
+    </article>`;
+}
+
 export function generateFavoritesHtml(
   entries: FavoriteEntry[],
   options: FavoritesHtmlOptions = {},
 ): string {
-  const title = options.title?.trim() || 'Отобранные TikTok-ролики';
+  const title = options.title?.trim() || 'Отобранные TikTok-ролики и каналы';
   const generatedAt = options.generatedAt ?? Date.now();
   const enriched = enrichVideos(entries.map((entry) => entry.video));
   const enrichedByKey = new Map(entries.map((entry, index) => [entry.key, enriched[index]]));
+  const groups = groupFavoriteEntriesByChannel(entries);
 
-  const cards = entries.map((entry, index) => {
-    const video = enrichedByKey.get(entry.key) ?? entry.video;
-    const videoUrl = safeHttpUrl(video.videoUrl);
-    const profileUrl = safeHttpUrl(video.profileUrl);
-    const hashtags = video.hashtags
-      .map((tag) => `<span>#${escapeHtml(tag.replace(/^#/, ''))}</span>`)
-      .join('');
-    const description = video.description?.trim() || 'Без описания';
-    const engagement = 'engagementRate' in video && typeof video.engagementRate === 'number'
-      ? `${video.engagementRate.toFixed(2)}%`
-      : '—';
+  const channelSections = groups.map((group) => `
+    <section class="channel-section">
+      ${renderChannel(group.channel)}
+      <div class="videos">
+        ${group.entries.map((entry, index) => renderVideoCard(entry, index + 1, enrichedByKey.get(entry.key))).join('\n')}
+      </div>
+    </section>`).join('\n');
 
-    return `
-      <article class="card" data-video-key="${escapeHtml(entry.key)}">
-        <div class="rank">${index + 1}</div>
-        <a class="preview-link" href="${escapeHtml(videoUrl ?? '#')}" target="_blank" rel="noopener noreferrer">
-          ${renderPreview(video.coverUrl, video.author)}
-        </a>
-        <div class="content">
-          <div class="card-head">
-            <div>
-              <a class="author" href="${escapeHtml(profileUrl ?? '#')}" target="_blank" rel="noopener noreferrer">@${escapeHtml(video.author)}</a>
-              <div class="date">${escapeHtml(formatDate(video.publishedAt))}</div>
-            </div>
-            <a class="open" href="${escapeHtml(videoUrl ?? '#')}" target="_blank" rel="noopener noreferrer">Открыть ролик ↗</a>
-          </div>
-          <p class="description">${escapeHtml(description)}</p>
-          <div class="metrics">
-            <div><span>Просмотры</span><strong>${escapeHtml(formatNumber(video.views))}</strong></div>
-            <div><span>Лайки</span><strong>${escapeHtml(formatNumber(video.likes))}</strong></div>
-            <div><span>Комментарии</span><strong>${escapeHtml(formatNumber(video.comments))}</strong></div>
-            <div><span>Репосты</span><strong>${escapeHtml(formatNumber(video.shares))}</strong></div>
-            <div><span>Сохранения</span><strong>${escapeHtml(formatNumber(video.saves))}</strong></div>
-            <div><span>ER</span><strong>${escapeHtml(engagement)}</strong></div>
-          </div>
-          ${video.audioTitle ? `<div class="audio">Аудио: ${escapeHtml(video.audioTitle)}</div>` : ''}
-          <div class="hashtags">${hashtags}</div>
-        </div>
-      </article>`;
-  }).join('\n');
-
-  const generatedLabel = new Intl.DateTimeFormat('ru-RU', {
-    day: '2-digit',
-    month: 'long',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  }).format(new Date(generatedAt));
+  const generatedLabel = formatDateMs(generatedAt);
 
   return `<!doctype html>
 <html lang="ru">
@@ -114,42 +217,72 @@ export function generateFavoritesHtml(
     :root { color-scheme: light; font-family: Inter, Arial, sans-serif; color: #1d2230; background: #f3f5f9; }
     * { box-sizing: border-box; }
     body { margin: 0; background: #f3f5f9; }
-    .page { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 36px 0 60px; }
-    .header { background: linear-gradient(135deg, #171b2c, #34235d); color: #fff; border-radius: 24px; padding: 28px; margin-bottom: 22px; }
+    .page { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding: 36px 0 60px; }
+    .header { background: linear-gradient(135deg, #171b2c, #34235d); color: #fff; border-radius: 24px; padding: 28px; margin-bottom: 24px; }
     .header h1 { margin: 0; font-size: clamp(26px, 5vw, 44px); line-height: 1.05; }
     .header p { margin: 12px 0 0; color: #d4d3e8; line-height: 1.5; }
     .summary { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 18px; }
     .summary span { background: rgba(255,255,255,.12); border: 1px solid rgba(255,255,255,.16); border-radius: 999px; padding: 8px 12px; font-size: 13px; }
-    .grid { display: grid; gap: 18px; }
-    .card { position: relative; display: grid; grid-template-columns: 220px minmax(0,1fr); gap: 20px; background: #fff; border: 1px solid #e2e6ef; border-radius: 20px; padding: 16px; box-shadow: 0 14px 35px rgba(30,36,52,.08); }
+    .channel-section { display: grid; gap: 16px; margin-bottom: 28px; }
+    .channel-card, .video-card { background: #fff; border: 1px solid #e2e6ef; border-radius: 20px; box-shadow: 0 14px 35px rgba(30,36,52,.08); }
+    .channel-card { padding: 22px; border-top: 5px solid #6840d8; }
+    .channel-head { display: grid; grid-template-columns: 92px minmax(0,1fr); gap: 18px; align-items: start; }
+    .channel-avatar { width: 92px; height: 92px; border-radius: 50%; overflow: hidden; display: grid; place-items: center; text-decoration: none; background: linear-gradient(135deg, #2d3346, #6840d8); color: #fff; font-size: 26px; font-weight: 900; }
+    .channel-avatar img { width: 100%; height: 100%; object-fit: cover; }
+    .channel-title { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+    .channel-title h2 { margin: 0; font-size: 26px; }
+    .verified { width: 20px; height: 20px; border-radius: 50%; display: grid; place-items: center; background: #36a9ff; color: #fff; font-size: 12px; }
+    .completeness { border-radius: 999px; padding: 5px 8px; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; }
+    .completeness.full { color: #087f58; background: #e8faf2; border: 1px solid #bfe9d6; }
+    .completeness.partial { color: #8a6300; background: #fff6dc; border: 1px solid #efdfa8; }
+    .username { display: inline-block; margin-top: 5px; color: #6840d8; font-weight: 800; text-decoration: none; }
+    .bio { margin: 12px 0 0; color: #394052; line-height: 1.5; white-space: pre-wrap; }
+    .muted { color: #8b92a2; }
+    .channel-links { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 12px; }
+    .channel-links a, .open { color: #fff; background: #6840d8; border-radius: 10px; padding: 9px 12px; font-weight: 700; text-decoration: none; }
+    .channel-metrics, .video-metrics { display: grid; grid-template-columns: repeat(4, minmax(0,1fr)); gap: 10px; margin-top: 20px; }
+    .channel-metrics div, .video-metrics div { background: #f5f6fa; border: 1px solid #e7e9f0; border-radius: 12px; padding: 10px; }
+    .channel-metrics span, .video-metrics span, .channel-details span { display: block; color: #81889a; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; }
+    .channel-metrics strong, .video-metrics strong { display: block; margin-top: 5px; font-size: 17px; }
+    .channel-details { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 8px 18px; margin-top: 18px; padding-top: 18px; border-top: 1px solid #eceef4; }
+    .channel-details div { min-width: 0; }
+    .channel-details strong { display: block; margin-top: 4px; overflow-wrap: anywhere; font-size: 13px; }
+    .channel-topics { margin-top: 18px; }
+    .channel-topics > span { color: #81889a; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; }
+    .channel-topics > div, .hashtags { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 9px; }
+    .channel-topics div span, .hashtags span { color: #087f73; background: #e9faf7; border: 1px solid #c9eee8; border-radius: 999px; padding: 5px 8px; font-size: 12px; }
+    .channel-topics em { color: #8b92a2; font-size: 13px; }
+    .videos { display: grid; gap: 16px; }
+    .video-card { position: relative; display: grid; grid-template-columns: 220px minmax(0,1fr); gap: 20px; padding: 16px; }
     .rank { position: absolute; top: 24px; left: 24px; z-index: 2; background: rgba(0,0,0,.76); color: #fff; border-radius: 10px; padding: 6px 9px; font-weight: 800; }
     .preview-link { display: block; min-height: 300px; border-radius: 14px; overflow: hidden; background: #111522; text-decoration: none; }
     .preview { width: 100%; height: 100%; min-height: 300px; object-fit: cover; display: block; }
     .placeholder { display: grid; place-items: center; color: #aeb5c7; padding: 20px; text-align: center; }
     .content { min-width: 0; padding: 4px 4px 4px 0; }
-    .card-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; }
+    .video-head { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; }
     .author { color: #6840d8; font-size: 18px; font-weight: 800; text-decoration: none; }
     .date { margin-top: 5px; color: #7d8496; font-size: 13px; }
-    .open { color: #fff; background: #6840d8; border-radius: 10px; padding: 9px 12px; font-weight: 700; text-decoration: none; white-space: nowrap; }
     .description { margin: 20px 0; color: #303747; font-size: 16px; line-height: 1.55; white-space: pre-wrap; }
-    .metrics { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 10px; }
-    .metrics div { background: #f5f6fa; border: 1px solid #e7e9f0; border-radius: 12px; padding: 10px; }
-    .metrics span { display: block; color: #81889a; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; }
-    .metrics strong { display: block; margin-top: 5px; font-size: 17px; }
     .audio { margin-top: 15px; color: #5d6475; font-size: 13px; }
-    .hashtags { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 14px; }
-    .hashtags span { color: #087f73; background: #e9faf7; border: 1px solid #c9eee8; border-radius: 999px; padding: 5px 8px; font-size: 12px; }
     .empty { background: #fff; border: 1px dashed #cbd1df; border-radius: 18px; padding: 50px 20px; text-align: center; color: #6e7586; }
     .footer { margin-top: 26px; color: #7d8494; font-size: 12px; text-align: center; }
-    @media (max-width: 760px) {
-      .card { grid-template-columns: 1fr; }
+    @media (max-width: 820px) {
+      .channel-metrics, .video-metrics { grid-template-columns: repeat(2, minmax(0,1fr)); }
+      .video-card { grid-template-columns: 1fr; }
       .preview-link, .preview { min-height: 420px; max-height: 620px; }
-      .metrics { grid-template-columns: repeat(2, minmax(0,1fr)); }
+    }
+    @media (max-width: 560px) {
+      .channel-head { grid-template-columns: 1fr; }
+      .channel-avatar { width: 78px; height: 78px; }
+      .channel-details { grid-template-columns: 1fr; }
+      .video-head { display: grid; }
+      .open { justify-self: start; }
     }
     @media print {
       body { background: #fff; }
       .page { width: 100%; padding: 0; }
-      .header, .card { box-shadow: none; break-inside: avoid; }
+      .header, .channel-card, .video-card { box-shadow: none; }
+      .channel-card, .video-card { break-inside: avoid; }
     }
   </style>
 </head>
@@ -157,17 +290,18 @@ export function generateFavoritesHtml(
   <main class="page">
     <header class="header">
       <h1>${escapeHtml(title)}</h1>
-      <p>Отобранные ролики с кликабельными ссылками, описаниями, метриками и превью.</p>
+      <p>Выбранные TikTok-ролики с полной публичной информацией о каналах, ссылками, описаниями, метриками и превью.</p>
       <div class="summary">
+        <span>Каналов: ${groups.length}</span>
         <span>Роликов: ${entries.length}</span>
         <span>Создано: ${escapeHtml(generatedLabel)}</span>
         <span>TikTok Research Sorter v${APP_VERSION}</span>
       </div>
     </header>
-    <section class="grid">
-      ${cards || '<div class="empty">В подборке нет выбранных роликов.</div>'}
+    <section>
+      ${channelSections || '<div class="empty">В подборке нет выбранных роликов.</div>'}
     </section>
-    <footer class="footer">Страница создана локально. Ссылки и изображения открываются с публичных страниц TikTok.</footer>
+    <footer class="footer">Страница создана локально. Показаны только публичные данные, которые TikTok реально предоставил во время сбора. Внешние превью могут позднее перестать загружаться.</footer>
   </main>
 </body>
 </html>`;

--- a/projects/tiktok-research-sorter/lib/store.ts
+++ b/projects/tiktok-research-sorter/lib/store.ts
@@ -1,10 +1,18 @@
 import { browser } from 'wxt/browser';
 import { median } from './analytics';
-import { favoriteKey } from './favorites';
+import {
+  channelSnapshotFromProfile,
+  favoriteKey,
+  mergeChannelSnapshots,
+  minimalChannelSnapshot,
+  normalizeFavoriteEntry,
+  profileKey,
+} from './favorites';
 import { mergeDiscoveredVideos } from './tag-research';
 import { mergeVideoRecords } from './tiktok-parser';
 import type {
   DashboardData,
+  FavoriteEntry,
   ProfileRecord,
   ProfileSnapshot,
   ScanOptions,
@@ -37,14 +45,43 @@ function normalizeTagKey(tag: string): string {
   return tag.trim().replace(/^#/, '').toLowerCase();
 }
 
+function normalizeFavorites(favorites: Record<string, FavoriteEntry> | undefined): Record<string, FavoriteEntry> {
+  if (!favorites) return {};
+  return Object.fromEntries(
+    Object.entries(favorites).map(([storedKey, entry]) => {
+      const normalized = normalizeFavoriteEntry(entry as Partial<FavoriteEntry> & { video: VideoRecord });
+      return [storedKey || normalized.key, normalized];
+    }),
+  );
+}
+
 function normalizeDashboard(value: Partial<DashboardData> | undefined): DashboardData {
   if (!value) return structuredClone(initialState);
   return {
     profiles: value.profiles ?? {},
     tagResearch: value.tagResearch ?? {},
-    favorites: value.favorites ?? {},
+    favorites: normalizeFavorites(value.favorites),
     activeScan: value.activeScan ?? structuredClone(initialState.activeScan),
   };
+}
+
+function findProfile(dashboard: DashboardData, username: string): ProfileSnapshot | undefined {
+  const key = profileKey(username);
+  return Object.values(dashboard.profiles).find((profile) => profileKey(profile.username) === key);
+}
+
+function refreshFavoriteChannels(dashboard: DashboardData, profile: ProfileSnapshot): void {
+  const channel = channelSnapshotFromProfile(profile);
+  const username = profileKey(profile.username);
+
+  for (const [key, rawEntry] of Object.entries(dashboard.favorites)) {
+    const entry = normalizeFavoriteEntry(rawEntry);
+    if (profileKey(entry.video.author) !== username) continue;
+    dashboard.favorites[key] = {
+      ...entry,
+      channel: mergeChannelSnapshots(entry.channel, channel),
+    };
+  }
 }
 
 export async function loadDashboard(): Promise<DashboardData> {
@@ -90,7 +127,7 @@ function emptyProfile(username: string, profileUrl: string): ProfileSnapshot {
 
 export async function mergeProfileData(profile: ProfileRecord): Promise<DashboardData> {
   const dashboard = await loadDashboard();
-  const existing = dashboard.profiles[profile.username] ?? emptyProfile(profile.username, profile.profileUrl);
+  const existing = findProfile(dashboard, profile.username) ?? emptyProfile(profile.username, profile.profileUrl);
   const existingPriority = existing.profileDataSource ? sourcePriority[existing.profileDataSource] : 0;
   const incomingPriority = sourcePriority[profile.source];
   const canReplace = incomingPriority >= existingPriority;
@@ -100,21 +137,34 @@ export async function mergeProfileData(profile: ProfileRecord): Promise<Dashboar
     return current ?? incoming;
   };
 
-  dashboard.profiles[profile.username] = {
+  const mergedProfile: ProfileSnapshot = {
     ...existing,
+    username: choose(profile.username, existing.username) ?? existing.username,
     profileUrl: choose(profile.profileUrl, existing.profileUrl) ?? existing.profileUrl,
+    userId: choose(profile.userId, existing.userId),
+    secUid: choose(profile.secUid, existing.secUid),
     displayName: choose(profile.displayName, existing.displayName),
     bio: choose(profile.bio, existing.bio),
     avatarUrl: choose(profile.avatarUrl, existing.avatarUrl),
     followers: choose(profile.followers, existing.followers),
     following: choose(profile.following, existing.following),
+    friends: choose(profile.friends, existing.friends),
     totalLikes: choose(profile.totalLikes, existing.totalLikes),
     videoCount: choose(profile.videoCount, existing.videoCount),
     verified: choose(profile.verified, existing.verified),
+    privateAccount: choose(profile.privateAccount, existing.privateAccount),
+    commerceAccount: choose(profile.commerceAccount, existing.commerceAccount),
     website: choose(profile.website, existing.website),
+    region: choose(profile.region, existing.region),
+    language: choose(profile.language, existing.language),
+    accountCreatedAt: choose(profile.accountCreatedAt, existing.accountCreatedAt),
     profileDataUpdatedAt: Math.max(profile.collectedAt, existing.profileDataUpdatedAt ?? 0),
     profileDataSource: canReplace || !existing.profileDataSource ? profile.source : existing.profileDataSource,
   };
+
+  delete dashboard.profiles[existing.username];
+  dashboard.profiles[mergedProfile.username] = mergedProfile;
+  refreshFavoriteChannels(dashboard, mergedProfile);
 
   await saveDashboard(dashboard);
   return dashboard;
@@ -122,7 +172,7 @@ export async function mergeProfileData(profile: ProfileRecord): Promise<Dashboar
 
 export async function mergeVideoBatch(username: string, profileUrl: string, videos: VideoRecord[]): Promise<DashboardData> {
   const dashboard = await loadDashboard();
-  const existing = dashboard.profiles[username] ?? emptyProfile(username, profileUrl);
+  const existing = findProfile(dashboard, username) ?? emptyProfile(username, profileUrl);
   const merged = new Map(existing.videos.map((video) => [video.id, video]));
 
   for (const incoming of videos) {
@@ -133,7 +183,8 @@ export async function mergeVideoBatch(username: string, profileUrl: string, vide
   existing.videos = [...merged.values()];
   existing.medianViews = median(existing.videos.map((video) => video.views).filter((value) => value > 0));
   existing.lastScannedAt = Date.now();
-  dashboard.profiles[username] = existing;
+  dashboard.profiles[existing.username] = existing;
+  refreshFavoriteChannels(dashboard, existing);
   dashboard.activeScan.videosFound = existing.videos.length;
   dashboard.activeScan.updatedAt = Date.now();
   await saveDashboard(dashboard);
@@ -199,9 +250,11 @@ export async function toggleFavorite(video: VideoRecord): Promise<DashboardData>
   if (dashboard.favorites[key]) {
     delete dashboard.favorites[key];
   } else {
+    const profile = findProfile(dashboard, video.author);
     dashboard.favorites[key] = {
       key,
       video: structuredClone(video),
+      channel: profile ? channelSnapshotFromProfile(profile) : minimalChannelSnapshot(video),
       favoritedAt: Date.now(),
     };
   }
@@ -219,7 +272,8 @@ export async function removeFavorites(keys: string[]): Promise<DashboardData> {
 
 export async function clearProfile(username: string): Promise<DashboardData> {
   const dashboard = await loadDashboard();
-  delete dashboard.profiles[username];
+  const profile = findProfile(dashboard, username);
+  if (profile) delete dashboard.profiles[profile.username];
   await saveDashboard(dashboard);
   return dashboard;
 }

--- a/projects/tiktok-research-sorter/lib/tiktok-parser.ts
+++ b/projects/tiktok-research-sorter/lib/tiktok-parser.ts
@@ -31,6 +31,21 @@ function firstNumber(...values: unknown[]): number | undefined {
   return undefined;
 }
 
+function firstBoolean(...values: unknown[]): boolean | undefined {
+  for (const value of values) {
+    if (typeof value === 'boolean') return value;
+    if (value === 1 || value === '1' || value === 'true') return true;
+    if (value === 0 || value === '0' || value === 'false') return false;
+  }
+  return undefined;
+}
+
+function normalizeTimestampSeconds(...values: unknown[]): number | undefined {
+  const timestamp = firstNumber(...values);
+  if (timestamp === undefined) return undefined;
+  return timestamp > 10_000_000_000 ? Math.floor(timestamp / 1_000) : timestamp;
+}
+
 function extractUrl(value: unknown): string | undefined {
   if (typeof value === 'string' && value.trim()) return value.trim();
   const record = asRecord(value);
@@ -100,7 +115,6 @@ export function normalizeTikTokItem(
   if (!id || !author) return undefined;
 
   const description = firstString(item.desc, item.description, item.title) ?? '';
-  const publishedAt = firstNumber(item.createTime, item.create_time, item.createdAt);
   const profileUrl = `https://www.tiktok.com/@${author}`;
 
   return {
@@ -109,7 +123,7 @@ export function normalizeTikTokItem(
     profileUrl,
     videoUrl: `${profileUrl}/video/${id}`,
     description,
-    publishedAt: publishedAt && publishedAt > 10_000_000_000 ? Math.floor(publishedAt / 1_000) : publishedAt,
+    publishedAt: normalizeTimestampSeconds(item.createTime, item.create_time, item.createdAt),
     durationSeconds: normalizeDurationSeconds(videoRecord.duration, item.duration),
     views: firstNumber(stats.playCount, stats.play_count, stats.viewCount, stats.views) ?? 0,
     likes: firstNumber(stats.diggCount, stats.digg_count, stats.likeCount, stats.likes) ?? 0,
@@ -190,6 +204,8 @@ function normalizeProfileCandidate(
   if (!username) return undefined;
   if (fallbackUsername && username.toLowerCase() !== fallbackUsername.toLowerCase()) return undefined;
 
+  const userId = firstString(user.id, user.uid, user.userId, user.user_id, container.userId);
+  const secUid = firstString(user.secUid, user.sec_uid, container.secUid, container.sec_uid);
   const displayName = firstString(user.nickname, user.displayName, user.display_name, container.nickname);
   const bio = firstString(user.signature, user.bio, user.description, container.signature);
   const avatarUrl = sanitizeHttpUrl(extractUrl(user.avatarLarger))
@@ -199,6 +215,7 @@ function normalizeProfileCandidate(
     ?? sanitizeHttpUrl(extractUrl(container.avatarLarger));
   const followers = firstNumber(stats.followerCount, stats.follower_count, stats.followers);
   const following = firstNumber(stats.followingCount, stats.following_count, stats.following);
+  const friends = firstNumber(stats.friendCount, stats.friend_count, stats.friends);
   const totalLikes = firstNumber(stats.heartCount, stats.heart_count, stats.heart, stats.diggCount, stats.likes);
   const videoCount = firstNumber(stats.videoCount, stats.video_count, stats.videos);
   const website = sanitizeHttpUrl(
@@ -206,24 +223,46 @@ function normalizeProfileCandidate(
     ?? extractUrl(user.bio_link)
     ?? firstString(user.website, user.url),
   );
-  const verified = Boolean(user.verified ?? user.isVerified ?? user.is_verified);
+  const verified = firstBoolean(user.verified, user.isVerified, user.is_verified);
+  const privateAccount = firstBoolean(user.privateAccount, user.private_account, user.secret, user.isPrivate, user.is_private);
+  const commerceAccount = firstBoolean(
+    user.isCommerceUser,
+    user.is_commerce_user,
+    user.commerceUser,
+    user.commerce_user,
+    asRecord(user.commerceUserInfo) || asRecord(user.commerce_user_info) ? true : undefined,
+  );
+  const region = firstString(user.region, user.regionCode, user.region_code, user.accountRegion, user.account_region);
+  const language = firstString(user.language, user.languageCode, user.language_code, user.lang);
+  const accountCreatedAt = normalizeTimestampSeconds(user.createTime, user.create_time, user.createdAt, user.created_at);
 
-  const hasIdentityDetails = Boolean(displayName || bio || avatarUrl || website || verified);
-  const hasProfileStats = [followers, following, totalLikes, videoCount].some((value) => value !== undefined);
+  const hasIdentityDetails = Boolean(
+    userId || secUid || displayName || bio || avatarUrl || website || region || language
+    || verified !== undefined || privateAccount !== undefined || commerceAccount !== undefined
+  );
+  const hasProfileStats = [followers, following, friends, totalLikes, videoCount].some((value) => value !== undefined);
   if (!hasIdentityDetails && !hasProfileStats) return undefined;
 
   return {
     username,
     profileUrl: `https://www.tiktok.com/@${username}`,
+    userId,
+    secUid,
     displayName,
     bio,
     avatarUrl,
     followers,
     following,
+    friends,
     totalLikes,
     videoCount,
     verified,
+    privateAccount,
+    commerceAccount,
     website,
+    region,
+    language,
+    accountCreatedAt,
     collectedAt: Date.now(),
     source,
   };
@@ -258,27 +297,34 @@ export function extractProfileFromPayload(
   visit(payload, 0);
   return candidates.sort((a, b) => {
     const score = (profile: ProfileRecord) =>
-      Number(profile.followers !== undefined) * 4
-      + Number(profile.videoCount !== undefined) * 3
+      Number(profile.followers !== undefined) * 5
+      + Number(profile.videoCount !== undefined) * 4
+      + Number(profile.totalLikes !== undefined) * 3
       + Number(Boolean(profile.avatarUrl)) * 2
       + Number(Boolean(profile.bio))
-      + Number(Boolean(profile.displayName));
+      + Number(Boolean(profile.displayName))
+      + Number(Boolean(profile.userId))
+      + Number(Boolean(profile.secUid));
     return score(b) - score(a);
   })[0];
 }
 
-export function extractProfileFromDom(username: string): ProfileRecord {
+export function extractProfileFromDocument(
+  root: ParentNode,
+  username: string,
+  source: ProfileRecord['source'] = 'dom',
+): ProfileRecord {
   const text = (...selectors: string[]) => {
     for (const selector of selectors) {
-      const el = document.querySelector<HTMLElement>(selector);
+      const el = root.querySelector<HTMLElement>(selector);
       if (el?.textContent?.trim()) return el.textContent.trim();
     }
     return undefined;
   };
-  const avatar = document.querySelector<HTMLImageElement>(
+  const avatar = root.querySelector<HTMLImageElement>(
     '[data-e2e="user-avatar"] img[src], header [class*="avatar"] img[src], header img[data-e2e="user-avatar"]'
   );
-  const websiteAnchor = document.querySelector<HTMLAnchorElement>(
+  const websiteAnchor = root.querySelector<HTMLAnchorElement>(
     '[data-e2e="user-bio"] a[href], [data-e2e="user-link"] a[href], a[data-e2e="user-link"]'
   );
 
@@ -290,12 +336,18 @@ export function extractProfileFromDom(username: string): ProfileRecord {
     avatarUrl: sanitizeHttpUrl(avatar?.currentSrc || avatar?.src || undefined),
     followers: firstNumber(text('[data-e2e="followers-count"]', 'header [class*="follower-count"]')),
     following: firstNumber(text('[data-e2e="following-count"]', 'header [class*="following-count"]')),
+    friends: firstNumber(text('[data-e2e="friends-count"]', 'header [class*="friend-count"]')),
     totalLikes: firstNumber(text('[data-e2e="likes-count"]', 'header [class*="like-count"]', 'header [class*="heart-count"]')),
-    verified: Boolean(document.querySelector('[data-e2e="user-title"] svg, [data-e2e="verified-badge"], header [class*="verified"]')),
+    videoCount: firstNumber(text('[data-e2e="videos-count"]', 'header [class*="video-count"]')),
+    verified: Boolean(root.querySelector('[data-e2e="user-title"] svg, [data-e2e="verified-badge"], header [class*="verified"]')),
     website: sanitizeHttpUrl(websiteAnchor?.href),
     collectedAt: Date.now(),
-    source: 'dom',
+    source,
   };
+}
+
+export function extractProfileFromDom(username: string): ProfileRecord {
+  return extractProfileFromDocument(document, username, 'dom');
 }
 
 export function parseTikTokVideoUrl(value: string, baseUrl = 'https://www.tiktok.com'): { author: string; id: string; videoUrl: string } | undefined {

--- a/projects/tiktok-research-sorter/lib/types.ts
+++ b/projects/tiktok-research-sorter/lib/types.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = '0.4.0';
+export const APP_VERSION = '0.5.0';
 
 export type ScanStatus = 'idle' | 'scanning' | 'paused' | 'complete' | 'stopped' | 'blocked' | 'error';
 export type ScanMode = 'profile' | 'tag';
@@ -48,24 +48,26 @@ export interface EnrichedVideo extends VideoRecord {
   outlierScore?: number;
 }
 
-export interface FavoriteEntry {
-  key: string;
-  video: VideoRecord;
-  favoritedAt: number;
-}
-
 export interface ProfileRecord {
   username: string;
   profileUrl: string;
+  userId?: string;
+  secUid?: string;
   displayName?: string;
   bio?: string;
   avatarUrl?: string;
   followers?: number;
   following?: number;
+  friends?: number;
   totalLikes?: number;
   videoCount?: number;
   verified?: boolean;
+  privateAccount?: boolean;
+  commerceAccount?: boolean;
   website?: string;
+  region?: string;
+  language?: string;
+  accountCreatedAt?: number;
   collectedAt: number;
   source: 'api' | 'embedded-json' | 'dom';
 }
@@ -76,6 +78,21 @@ export interface ProfileSnapshot extends Omit<ProfileRecord, 'collectedAt' | 'so
   lastScannedAt: number;
   profileDataUpdatedAt?: number;
   profileDataSource?: ProfileRecord['source'];
+}
+
+export interface ChannelSnapshot extends Omit<ProfileSnapshot, 'videos'> {
+  collectedVideoCount: number;
+  averageEngagementRate?: number;
+  strongestHashtags: string[];
+  capturedAt: number;
+  completeness: 'partial' | 'full';
+}
+
+export interface FavoriteEntry {
+  key: string;
+  video: VideoRecord;
+  channel: ChannelSnapshot;
+  favoritedAt: number;
 }
 
 export interface ScanOptions {
@@ -116,6 +133,7 @@ export type RuntimeMessage =
   | { type: 'PING' }
   | { type: 'START_SCAN'; options: ScanOptions }
   | { type: 'STOP_SCAN' }
+  | { type: 'ENRICH_CHANNEL'; username: string }
   | { type: 'GET_DASHBOARD' }
   | { type: 'CLEAR_PROFILE'; username: string }
   | { type: 'CLEAR_TAG_RESEARCH'; tag: string }

--- a/projects/tiktok-research-sorter/logs/latest.md
+++ b/projects/tiktok-research-sorter/logs/latest.md
@@ -1,67 +1,57 @@
 # Latest Log — TikTok Research Sorter
 
 Date: 2026-07-14
-Version: `0.4.0`
-Issue: `#84`
-Pull request: `#85`
-Branch: `main`
-Status: integrated and validated
+Version: `0.5.0`
+Issue: `#86`
+Pull request: `#87`
+Branch: `agent/tiktok-research-sorter-channel-export-v0.5.0`
+Status: implementation complete; final GitHub validation pending
 
 ## Delivered
 
-- Star control on every profile and hashtag video card.
-- Durable Favorites storage independent from scanned profile and hashtag data.
-- Dedicated Favorites tab with live favorite count.
-- Checkbox selection of favorite videos.
-- Select all, clear selection, remove selected, and individual favorite removal.
-- Standalone HTML generation from only the checked favorites.
-- HTML cards with clickable video/profile links, descriptions, preview images, dates, audio titles, hashtags, and available metrics.
-- Responsive and print-friendly HTML layout suitable for sending as a file.
-- HTML escaping for user-controlled text and HTTP(S)-only external URL validation.
-- Backward-compatible dashboard migration for existing v0.3.0 installations.
-- Versioned exports and installation artifacts using `v0.4.0`.
+- Expanded public channel parsing for user ID, `secUid`, display name, biography, avatar, verification, website, followers, following, friends, total profile likes, public video count, region, language, account flags, and account creation date.
+- Durable channel snapshot attached to every new favorite.
+- Backward-compatible migration of v0.4.0 favorites to partial channel snapshots.
+- Automatic refresh of favorite channel snapshots when richer public profile data is collected.
+- Same-origin public profile enrichment after adding a favorite without navigating the visible TikTok page.
+- Manual `Обновить канал` action in Favorites.
+- Favorites grouped by channel.
+- Complete channel cards in the extension with public counters, identifiers, flags, dates, data source, and locally calculated analytics.
+- Selected-only standalone HTML grouped by channel.
+- Complete channel card before each channel’s selected videos in HTML.
+- HTML includes channel and video links, avatars/previews, descriptions, dates, audio, hashtags, video metrics, channel metrics, source, and timestamps.
+- Missing public fields displayed as unavailable instead of being invented.
+- Versioned HTML filename and installation artifacts using `v0.5.0`.
 
 ## Automated coverage added
 
-- stable case-insensitive favorite keys;
-- newest-first favorite ordering;
-- selected-only favorite extraction;
-- standalone HTML structure and version metadata;
-- inclusion of links, previews, descriptions, and metrics;
-- markup/script escaping;
-- rejection of `javascript:` and `data:` URLs;
-- omission of unselected favorites from generated HTML.
-
-## Final verification
-
-For PR #85 head `eb3328251cb256164237baefb66b25b449d222cb`:
-
-- Project Execution OS integrity run `29333836074`: passed;
-- TikTok Research Sorter CI run `29333836128`: passed;
-- Linux reproducible install: passed;
-- strict TypeScript check: passed;
-- all unit and regression tests: passed;
-- production Chrome MV3 build: passed;
-- versioned packaging and artifact upload: passed;
-- Windows zero-side-effect updater dry run: passed;
-- Windows full local-source updater validation: passed;
-- generated manifest version check: passed.
-
-PR #85 merged into `main` as commit `92f66e3fea0b96f30dfad8dc0de7aff5e1a5c696`.
-
-## Artifacts
-
-- unpacked Chrome MV3 extension;
-- `tiktok-research-sorter-extension-v0.4.0.zip`;
-- `tiktok-sorter-auto-updater-setup-v0.4.0.zip`;
-- `tiktok-research-sorter-source-v0.4.0.zip`.
-
-The installable extension ZIP was separately inspected: `manifest.json` is at the archive root, the archive contains 10 extension files, and the manifest declares version `0.4.0`.
+- complete public channel payload parsing;
+- identifiers, counters, flags, locale, website, and account date;
+- preservation of explicit false flags;
+- millisecond timestamp normalization;
+- unsafe profile website rejection;
+- legacy favorite migration to a partial channel snapshot;
+- rich channel snapshot creation from a scanned profile;
+- richer channel snapshot merging;
+- favorite grouping by case-insensitive channel identity;
+- selected-only channel-grouped HTML;
+- complete channel and video information in HTML;
+- channel and video markup escaping;
+- rejection of unsafe channel/video/avatar/preview URLs;
+- omission of unselected channels and videos.
 
 ## Product boundary
 
-The exported HTML is a local static file. Video and profile links point to public TikTok pages, and preview images use the public image URLs captured during scanning. TikTok can later expire those preview URLs. No TikTok access controls are bypassed.
+Only public fields TikTok actually provides are stored. TikTok can omit data, return a verification page, change its payloads, or expire external avatar/preview URLs. The extension does not bypass login, CAPTCHA, private accounts, paywalls, rate limits, or access controls.
+
+## Pending final evidence
+
+- Project Execution OS integrity CI;
+- Linux reproducible install, strict TypeScript, all tests, build, packaging, and artifact upload;
+- Windows updater dry-run, full local-source validation, and manifest version check;
+- installable v0.5.0 ZIP inspection;
+- PR #87 merge into `main`.
 
 ## Owner action
 
-None for code implementation, testing, packaging, merge, or repository delivery. The owner only needs to install the provided versioned extension ZIP.
+None during implementation and automated validation.

--- a/projects/tiktok-research-sorter/package.json
+++ b/projects/tiktok-research-sorter/package.json
@@ -1,9 +1,9 @@
 {
   "name": "tiktok-research-sorter",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
-  "description": "Local-first Chrome extension for TikTok profile and hashtag research with favorites and selected HTML export.",
+  "description": "Local-first Chrome extension for TikTok research with favorites, complete public channel snapshots, and selected HTML export.",
   "scripts": {
     "dev": "wxt",
     "build": "wxt build",

--- a/projects/tiktok-research-sorter/tests/channel-profile.test.ts
+++ b/projects/tiktok-research-sorter/tests/channel-profile.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { extractProfileFromPayload } from '../lib/tiktok-parser';
+
+describe('complete public channel profile parsing', () => {
+  it('extracts identifiers, public counters, flags, locale, website, and account date', () => {
+    const payload = {
+      userInfo: {
+        user: {
+          id: '7000000000000000001',
+          secUid: 'MS4wLjABAAAA-complete-profile',
+          uniqueId: 'completecreator',
+          nickname: 'Complete Creator',
+          signature: 'Wedding filmmaker and educator',
+          avatarLarger: 'https://example.com/avatar.jpg',
+          verified: true,
+          privateAccount: false,
+          isCommerceUser: true,
+          region: 'US',
+          language: 'en',
+          createTime: 1_550_000_000,
+          bioLink: { link: 'https://ignored.example', url: 'https://creator.example' },
+        },
+        stats: {
+          followerCount: 250000,
+          followingCount: 425,
+          friendCount: 88,
+          heartCount: 12500000,
+          videoCount: 678,
+        },
+      },
+    };
+
+    const profile = extractProfileFromPayload(payload, 'completecreator');
+    expect(profile).toMatchObject({
+      username: 'completecreator',
+      userId: '7000000000000000001',
+      secUid: 'MS4wLjABAAAA-complete-profile',
+      displayName: 'Complete Creator',
+      bio: 'Wedding filmmaker and educator',
+      avatarUrl: 'https://example.com/avatar.jpg',
+      followers: 250000,
+      following: 425,
+      friends: 88,
+      totalLikes: 12500000,
+      videoCount: 678,
+      verified: true,
+      privateAccount: false,
+      commerceAccount: true,
+      region: 'US',
+      language: 'en',
+      accountCreatedAt: 1_550_000_000,
+      website: 'https://creator.example/',
+    });
+  });
+
+  it('preserves explicit false flags instead of treating them as missing', () => {
+    const profile = extractProfileFromPayload({
+      userInfo: {
+        user: {
+          uniqueId: 'publiccreator',
+          nickname: 'Public Creator',
+          verified: false,
+          privateAccount: false,
+          isCommerceUser: false,
+        },
+      },
+    }, 'publiccreator');
+
+    expect(profile?.verified).toBe(false);
+    expect(profile?.privateAccount).toBe(false);
+    expect(profile?.commerceAccount).toBe(false);
+  });
+
+  it('converts millisecond account timestamps to seconds and rejects unsafe websites', () => {
+    const profile = extractProfileFromPayload({
+      userInfo: {
+        user: {
+          uniqueId: 'safecreator',
+          nickname: 'Safe Creator',
+          createTime: 1_550_000_000_000,
+          website: 'javascript:alert(1)',
+        },
+      },
+    }, 'safecreator');
+
+    expect(profile?.accountCreatedAt).toBe(1_550_000_000);
+    expect(profile?.website).toBeUndefined();
+  });
+});

--- a/projects/tiktok-research-sorter/tests/favorites-html.test.ts
+++ b/projects/tiktok-research-sorter/tests/favorites-html.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { favoriteKey, orderedFavoriteEntries, selectFavoriteEntries } from '../lib/favorites';
+import {
+  channelSnapshotFromProfile,
+  favoriteKey,
+  groupFavoriteEntriesByChannel,
+  mergeChannelSnapshots,
+  minimalChannelSnapshot,
+  orderedFavoriteEntries,
+  selectFavoriteEntries,
+} from '../lib/favorites';
 import { generateFavoritesHtml } from '../lib/html-export';
-import type { FavoriteEntry, VideoRecord } from '../lib/types';
+import type { ChannelSnapshot, FavoriteEntry, ProfileSnapshot, VideoRecord } from '../lib/types';
 
 function video(id: string, author: string, views: number, overrides: Partial<VideoRecord> = {}): VideoRecord {
   return {
@@ -27,18 +35,125 @@ function video(id: string, author: string, views: number, overrides: Partial<Vid
   };
 }
 
-function favorite(entryVideo: VideoRecord, favoritedAt: number): FavoriteEntry {
+function fullChannel(username: string, overrides: Partial<ChannelSnapshot> = {}): ChannelSnapshot {
+  return {
+    username,
+    profileUrl: `https://www.tiktok.com/@${username}`,
+    userId: '123456',
+    secUid: 'MS4wLjABAAAA-test',
+    displayName: 'Wedding Channel',
+    bio: 'Wedding creator and photographer',
+    avatarUrl: 'https://example.com/avatar.jpg',
+    followers: 125000,
+    following: 321,
+    friends: 77,
+    totalLikes: 9800000,
+    videoCount: 456,
+    verified: true,
+    privateAccount: false,
+    commerceAccount: true,
+    website: 'https://example.com',
+    region: 'US',
+    language: 'en',
+    accountCreatedAt: 1_600_000_000,
+    medianViews: 75000,
+    lastScannedAt: 1_700_000_000_000,
+    profileDataUpdatedAt: 1_700_000_100_000,
+    profileDataSource: 'api',
+    collectedVideoCount: 88,
+    averageEngagementRate: 4.25,
+    strongestHashtags: ['wedding', 'photography'],
+    capturedAt: 1_700_000_200_000,
+    completeness: 'full',
+    ...overrides,
+  };
+}
+
+function favorite(entryVideo: VideoRecord, favoritedAt: number, channel = fullChannel(entryVideo.author)): FavoriteEntry {
   return {
     key: favoriteKey(entryVideo),
     video: entryVideo,
+    channel,
     favoritedAt,
   };
 }
 
-describe('favorites', () => {
+describe('favorites and channel snapshots', () => {
   it('creates a stable case-insensitive key from author and video id', () => {
     expect(favoriteKey({ author: '@OlgaPhoto', id: '123' })).toBe('olgaphoto:123');
     expect(favoriteKey({ author: 'olgaphoto', id: '123' })).toBe('olgaphoto:123');
+  });
+
+  it('migrates an old favorite without channel data to a partial channel snapshot', () => {
+    const oldEntry = {
+      key: 'legacy:1',
+      video: video('1', 'legacy', 100),
+      favoritedAt: 1000,
+    } as unknown as FavoriteEntry;
+    const normalized = orderedFavoriteEntries({ [oldEntry.key]: oldEntry })[0];
+    expect(normalized?.channel.username).toBe('legacy');
+    expect(normalized?.channel.completeness).toBe('partial');
+  });
+
+  it('creates a rich channel snapshot from a scanned profile', () => {
+    const profile: ProfileSnapshot = {
+      username: 'creator',
+      profileUrl: 'https://www.tiktok.com/@creator',
+      userId: '42',
+      secUid: 'sec-42',
+      displayName: 'Creator Name',
+      bio: 'Creator bio',
+      avatarUrl: 'https://example.com/creator.jpg',
+      followers: 5000,
+      following: 100,
+      friends: 50,
+      totalLikes: 100000,
+      videoCount: 20,
+      verified: true,
+      privateAccount: false,
+      commerceAccount: false,
+      website: 'https://creator.example',
+      region: 'US',
+      language: 'en',
+      accountCreatedAt: 1_500_000_000,
+      videos: [video('1', 'creator', 1000), video('2', 'creator', 3000, { hashtags: ['tips'] })],
+      medianViews: 2000,
+      lastScannedAt: 1_700_000_000_000,
+      profileDataUpdatedAt: 1_700_000_100_000,
+      profileDataSource: 'api',
+    };
+    const channel = channelSnapshotFromProfile(profile);
+    expect(channel).toMatchObject({
+      username: 'creator',
+      followers: 5000,
+      following: 100,
+      friends: 50,
+      totalLikes: 100000,
+      videoCount: 20,
+      collectedVideoCount: 2,
+      medianViews: 2000,
+      completeness: 'full',
+    });
+    expect(channel.averageEngagementRate).toBeGreaterThan(0);
+    expect(channel.strongestHashtags).toContain('tips');
+  });
+
+  it('keeps richer channel fields when snapshots are merged', () => {
+    const partial = minimalChannelSnapshot(video('1', 'creator', 100));
+    const rich = fullChannel('creator');
+    const merged = mergeChannelSnapshots(partial, rich);
+    expect(merged.completeness).toBe('full');
+    expect(merged.followers).toBe(125000);
+    expect(merged.userId).toBe('123456');
+  });
+
+  it('groups multiple favorite videos under one channel', () => {
+    const first = favorite(video('1', 'creator', 100), 1000);
+    const second = favorite(video('2', 'Creator', 200), 2000, fullChannel('Creator'));
+    const groups = groupFavoriteEntriesByChannel([first, second]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.entries).toHaveLength(2);
+    expect(groups[0]?.channel.followers).toBe(125000);
   });
 
   it('orders newest favorites first and exports only checked entries', () => {
@@ -50,7 +165,7 @@ describe('favorites', () => {
     expect(selectFavoriteEntries(favorites, [first.key]).map((entry) => entry.key)).toEqual([first.key]);
   });
 
-  it('generates a standalone HTML page with links, preview, description, and metrics', () => {
+  it('generates standalone HTML with complete channel and video information', () => {
     const entry = favorite(video('777', 'creator', 123_456), 2000);
     const html = generateFavoritesHtml([entry], { title: 'Client shortlist', generatedAt: 1_700_000_000_000 });
 
@@ -61,17 +176,30 @@ describe('favorites', () => {
     expect(html).toContain('https://example.com/777.jpg');
     expect(html).toContain('Video 777');
     expect(html).toContain('data-video-key="creator:777"');
-    expect(html).toContain('TikTok Research Sorter v0.4.0');
+    expect(html).toContain('data-channel="creator"');
+    expect(html).toContain('Wedding Channel');
+    expect(html).toContain('125 000');
+    expect(html).toContain('MS4wLjABAAAA-test');
+    expect(html).toContain('Коммерческий аккаунт');
+    expect(html).toContain('TikTok Research Sorter v0.5.0');
   });
 
-  it('escapes user-controlled text and rejects non-http links and previews', () => {
+  it('escapes channel and video text and rejects non-http links and previews', () => {
+    const unsafeChannel = fullChannel('bad', {
+      displayName: '<script>alert("channel")</script>',
+      bio: '<img src=x onerror=alert(1)>',
+      profileUrl: 'javascript:alert(2)',
+      website: 'data:text/html,<script>alert(3)</script>',
+      avatarUrl: 'javascript:alert(4)',
+      strongestHashtags: ['<svg onload=alert(5)>'],
+    });
     const unsafe = favorite(video('9', 'bad', 1, {
       description: '<script>alert("x")</script>',
-      profileUrl: 'javascript:alert(1)',
-      videoUrl: 'javascript:alert(2)',
-      coverUrl: 'data:text/html,<script>alert(3)</script>',
-      hashtags: ['<img src=x onerror=alert(4)>'],
-    }), 3000);
+      profileUrl: 'javascript:alert(6)',
+      videoUrl: 'javascript:alert(7)',
+      coverUrl: 'data:text/html,<script>alert(8)</script>',
+      hashtags: ['<img src=x onerror=alert(9)>'],
+    }), 3000, unsafeChannel);
 
     const html = generateFavoritesHtml([unsafe], { generatedAt: 1_700_000_000_000 });
 
@@ -79,17 +207,20 @@ describe('favorites', () => {
     expect(html).not.toContain('javascript:');
     expect(html).not.toContain('data:text/html');
     expect(html).toContain('&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;');
+    expect(html).toContain('&lt;script&gt;alert(&quot;channel&quot;)&lt;/script&gt;');
     expect(html).toContain('Превью недоступно');
   });
 
-  it('keeps unselected favorites out of the generated selection', () => {
-    const selected = favorite(video('11', 'one', 10), 2000);
-    const omitted = favorite(video('22', 'two', 20), 1000);
+  it('keeps unselected favorites and their channels out of generated HTML', () => {
+    const selected = favorite(video('11', 'one', 10), 2000, fullChannel('one', { displayName: 'Selected Channel' }));
+    const omitted = favorite(video('22', 'two', 20), 1000, fullChannel('two', { displayName: 'Omitted Channel' }));
     const favorites = { [selected.key]: selected, [omitted.key]: omitted };
     const chosen = selectFavoriteEntries(favorites, [selected.key]);
     const html = generateFavoritesHtml(chosen, { generatedAt: 1_700_000_000_000 });
 
     expect(html).toContain('/video/11');
+    expect(html).toContain('Selected Channel');
     expect(html).not.toContain('/video/22');
+    expect(html).not.toContain('Omitted Channel');
   });
 });

--- a/projects/tiktok-research-sorter/wxt.config.ts
+++ b/projects/tiktok-research-sorter/wxt.config.ts
@@ -4,8 +4,8 @@ export default defineConfig({
   srcDir: '.',
   manifest: {
     name: 'TikTok Research Sorter',
-    description: 'Scan TikTok profiles and hashtag pages, save favorites, and export selected research as HTML.',
-    version: '0.4.0',
+    description: 'Research TikTok profiles and hashtags, save favorites with complete public channel data, and export selected HTML.',
+    version: '0.5.0',
     permissions: ['storage', 'sidePanel', 'activeTab', 'scripting'],
     host_permissions: ['https://www.tiktok.com/*', 'https://tiktok.com/*'],
     action: {


### PR DESCRIPTION
## Summary

Adds TikTok Research Sorter v0.5.0 complete public channel snapshots to Favorites and selected HTML exports.

## Delivered behavior

- captures public channel identifiers, identity, biography, avatar, verification, website, followers, following, friends, total likes, video count, region, language, account flags, and creation date when TikTok exposes them;
- stores channel analytics: collected video count, median views, average engagement, strongest hashtags, source, and timestamps;
- preserves channel snapshots independently from later profile/tag deletion;
- migrates v0.4.0 favorites without channel data to safe partial snapshots;
- automatically refreshes favorite channel snapshots when richer profile data is collected;
- requests same-origin public profile enrichment after a video is added to Favorites without navigating the visible page;
- groups Favorites UI by channel and renders complete channel cards;
- groups selected standalone HTML by channel and renders complete channel information before that channel's checked videos;
- marks missing fields unavailable rather than inventing values;
- keeps HTML escaping and HTTP(S)-only URL validation;
- versions extension metadata, HTML filename, documentation, CI artifacts, and packages as v0.5.0.

## Validation gate

- strict TypeScript;
- all existing and new channel/favorites/HTML tests;
- Linux build and versioned packaging;
- Windows updater validation;
- Project Execution OS integrity validation;
- installable ZIP with root-level manifest version 0.5.0.

Closes #86 after green validation and merge.