### PR TITLE
Add media.probe reusable capability block

### DIFF
--- a/.github/workflows/media-probe-tests.yml
+++ b/.github/workflows/media-probe-tests.yml
@@ -1,0 +1,47 @@
+name: media.probe tests
+
+on:
+  pull_request:
+    paths:
+      - "capabilities/media-probe/**"
+      - ".github/workflows/media-probe-tests.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "capabilities/media-probe/**"
+      - ".github/workflows/media-probe-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: capabilities/media-probe/pyproject.toml
+
+      - name: Install ffprobe
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes ffmpeg
+
+      - name: Install package
+        working-directory: capabilities/media-probe
+        run: python -m pip install -e '.[dev]'
+
+      - name: Run tests
+        working-directory: capabilities/media-probe
+        run: pytest -q

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -22,8 +22,8 @@
 
 ## Current Status
 
-- Mode: `document-first`
-- Phase: `foundation`
+- Mode: `document-first with first executable capability candidate`
+- Phase: `foundation validation`
 - Status: `transfer-ready central project`
 
 ## Done So Far
@@ -40,19 +40,26 @@
 - Added `docs/COMPOSABLE_CAPABILITY_BLOCKS_STANDARD.md` as the system-wide architecture for reusable executable capabilities.
 - Added `capability-library/README.md` and `capability-library/REGISTRY.md`.
 - Separated domain blocks from executable capability blocks, workflow composition, and application adapters.
-- Registered the first planned media capability chain: download, probe, audio extraction, transcription, and clipping.
+- Registered the initial media capability chain: download, probe, audio extraction, transcription, and clipping.
+- Implemented `media.probe` version `0.1.0` as the first executable candidate capability in `capabilities/media-probe/`.
+- Added request, context, artifact, result, error, provider, and CLI contracts.
+- Added unit, contract, negative-path, real ffprobe smoke tests, and pull-request CI.
+- Promoted `media.probe` from `idea` to `candidate` after 6 local tests and a manual CLI smoke test passed.
 
 ## Current Focus
 
 - Keep the central system internally consistent and transfer-ready after every meaningful change.
 - Apply harness engineering step by step by routing architecture/scaffold questions to `docs/HARNESS_ENGINEERING_STANDARD.md` before quality measurement.
 - Build repeated application functionality as versioned capability blocks rather than duplicating code inside each project.
+- Validate the shared contract against a second executable capability instead of prematurely extracting a common SDK.
 
 ## Next Practical Step
 
-- Implement `media.probe` as the first deterministic local capability block using ffprobe.
-- Use it to validate the common manifest, request/result contracts, artifact model, tests, CLI adapter, and registry promotion process.
-- Then implement `media.clip`, `media.extract_audio`, `media.transcribe`, and `media.download` in that order unless real project evidence changes the sequence.
+- Confirm the `media.probe` pull-request CI result and merge if green.
+- Run a native Windows smoke test before treating Windows path behavior as verified.
+- Implement `media.clip` as the second capability using ffmpeg.
+- Reuse the `media.probe` contract shape where evidence supports it, but extract shared code only after actual duplication appears.
+- Then implement `media.extract_audio`, `media.transcribe`, and `media.download` unless real project evidence changes the sequence.
 
 ## Key Decisions And Constraints
 
@@ -68,6 +75,8 @@
 - Workflows compose capability blocks; applications own project-specific business logic and UI.
 - Package-first is the default. Do not create a microservice for every block without evidence that an in-process package is insufficient.
 - Do not call a capability reusable merely because a specification exists. Registry status must reflect actual code and validation evidence.
+- `candidate` means implementation and minimum tests exist; it does not mean real application validation is complete.
+- Do not extract a common capability SDK from one implementation alone.
 
 ## Read Next
 
@@ -77,5 +86,6 @@
 4. `logs/latest.md`
 5. `docs/COMPOSABLE_CAPABILITY_BLOCKS_STANDARD.md` for reusable executable functionality
 6. `capability-library/REGISTRY.md` for current implementation readiness
-7. `PROJECT_INDEX.md` only when broader navigation is needed
-8. routed standards only when the active task requires them
+7. `capabilities/media-probe/BLOCK.md` and `capabilities/media-probe/VALIDATION.md` for the first candidate
+8. `PROJECT_INDEX.md` only when broader navigation is needed
+9. routed standards only when the active task requires them

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -23,32 +23,46 @@ logs/latest.md
 
 ## Latest Confirmed Milestone
 
-- Adopted composable executable capability blocks as a system-wide architecture for functionality that should be reused across applications.
-- Added `docs/COMPOSABLE_CAPABILITY_BLOCKS_STANDARD.md`.
-- Added `capability-library/README.md` and `capability-library/REGISTRY.md`.
-- Separated four layers explicitly:
+The composable capability-block architecture now has its first executable implementation:
 
 ```text
-domain block
--> executable capability block
--> workflow composition
--> application adapter / UI
+media.probe 0.1.0 — candidate
 ```
 
-- Added a router path for reusable executable blocks and portable shared modules.
-- Updated `blocks/README.md` so domain blocks are not confused with implemented code.
-- Updated `blocks/video-production/BLOCK.md` to route download, probing, extraction, transcription, and clipping toward reusable capability contracts.
-- Registered the first planned media chain:
+Implementation location:
 
 ```text
-media.download
--> media.probe
--> media.extract_audio
--> media.transcribe
--> media.clip
+capabilities/media-probe/
 ```
 
-- Updated `PROJECT_INDEX.md` and `PROJECT.md` with the new architecture.
+Pull request:
+
+```text
+https://github.com/oleg3479881328-code/Project-Execution-OS/pull/89
+```
+
+Implemented and recorded:
+
+- package manifest and Python metadata;
+- package-discovery entry point;
+- CLI adapter;
+- request, context, artifact, result, and structured error contracts;
+- ffprobe provider and normalized metadata;
+- read-only workspace boundary;
+- unit, contract, missing-tool, and real ffprobe smoke tests;
+- GitHub Actions workflow for Python 3.12 and 3.13;
+- candidate validation record;
+- registry promotion from `idea` to `candidate`.
+
+Local evidence:
+
+```text
+Python 3.13.5
+pytest 9.0.2
+ffprobe 7.1.3
+6 passed in 0.30s
+manual CLI smoke test passed
+```
 
 ## Architecture Decision
 
@@ -64,32 +78,24 @@ build once behind a stable contract
 -> connect through thin application adapters
 ```
 
-Package-first is the default. A capability becomes a service only when isolation, scaling, hardware, dependency, or multi-language consumer evidence justifies it.
+The first implementation intentionally keeps its contracts inside the package. A shared capability SDK must not be extracted until a second implementation demonstrates real duplication.
 
 ## Current Focus
 
-Keep the central project internally consistent and transfer-ready after every meaningful change.
-
-Validate the capability architecture through real executable code rather than adding more specifications.
+- Confirm PR #89 GitHub Actions results.
+- Merge the candidate only when CI is green.
+- Validate the contract against `media.clip` as the second executable block.
+- Keep the distinction between `candidate` and `validated` explicit.
 
 ## Current Next Safe Action
 
-Implement `media.probe` as the first candidate capability block using ffprobe.
+After PR #89 merges:
 
-Minimum validation target:
-
-```text
-manifest
-request/result contract
-artifact model
-Python invocation
-CLI adapter
-contract test
-local smoke test
-registry promotion from idea to candidate
-```
-
-After that, proceed to `media.clip`, then `media.extract_audio`, `media.transcribe`, and `media.download`, unless real project evidence changes the sequence.
+1. run a native Windows smoke test for `media.probe`;
+2. test representative MP4/H.264/AAC and variable-frame-rate inputs;
+3. integrate `media.probe` into one real application workflow;
+4. implement `media.clip` using ffmpeg;
+5. compare the two implementations before extracting shared contract code.
 
 ## Active Files For Re-entry
 
@@ -100,10 +106,12 @@ Read in this order when resuming central-project work:
 3. `PROJECT.md`
 4. `PROJECT_STATE.md`
 5. `logs/latest.md`
-6. `docs/COMPOSABLE_CAPABILITY_BLOCKS_STANDARD.md` for reusable code architecture
-7. `capability-library/REGISTRY.md` for actual block readiness
-8. `PROJECT_INDEX.md` only when broader navigation is needed
-9. routed standards only when the active task requires them
+6. `docs/COMPOSABLE_CAPABILITY_BLOCKS_STANDARD.md`
+7. `capability-library/REGISTRY.md`
+8. `capabilities/media-probe/BLOCK.md`
+9. `capabilities/media-probe/VALIDATION.md`
+10. `logs/2026-07-15-media-probe-candidate.md`
+11. `PROJECT_INDEX.md` only when broader navigation is needed
 
 For capability implementation work, also open:
 
@@ -113,21 +121,15 @@ docs/HARNESS_ENGINEERING_STANDARD.md
 blocks/<relevant-domain>/BLOCK.md
 ```
 
-For Impeccable or AI-coded frontend design QA work, open:
-
-```text
-blocks/design/TASTE_FRONTEND_EXECUTION_STANDARD.md
-blocks/design/IMPECCABLE_DESIGN_QA_GATE.md
-blocks/design/BLOCK.md
-```
-
 ## Known Blockers
 
-- All entries in `capability-library/REGISTRY.md` currently have status `idea`; no executable capability block has yet been implemented or validated under the new contract.
-- The common artifact and request/result contracts remain architectural guidance until `media.probe` validates them in code.
-- `gemini-tts-speech-generation` is registered as `candidate` / `not_reviewed`; it must not be treated as active until reviewed.
-- `blocks/design/IMPECCABLE_DESIGN_QA_GATE.md` and `blocks/design/TASTE_FRONTEND_EXECUTION_STANDARD.md` are candidate guidance and should be validated on a real frontend task before promotion.
-- `docs/HARNESS_ENGINEERING_STANDARD.md` is newly added and should be validated on a real reusable-agent workflow before being treated as mature operational guidance.
+- PR #89 CI must pass before merge.
+- Native Windows path behavior is implemented but not yet verified on Windows.
+- `media.probe` is not yet integrated into a real application, so it is not `validated`.
+- The container could not re-clone the remote branch because DNS resolution for `github.com` was unavailable; the error is logged and CI is the independent repository check.
+- Other media capability entries remain `idea`.
+- `gemini-tts-speech-generation` remains `candidate` / `not_reviewed`.
+- Design Taste and Impeccable standards remain candidate guidance pending real-project validation.
 
 ## Do-Not-Break Rules
 
@@ -138,5 +140,6 @@ blocks/design/BLOCK.md
 - Do not claim execution without a confirmed repository event.
 - Do not call a capability implemented, validated, or production-ready without matching registry evidence.
 - Do not copy reusable block code into multiple applications as the normal integration method.
+- Do not extract a common SDK from one block alone.
 - Preserve the smallest sufficient context-loading path.
 - Update this file and `logs/latest.md` after every meaningful central-project change.

--- a/SYSTEM_CONTEXT_MANIFEST.md
+++ b/SYSTEM_CONTEXT_MANIFEST.md
@@ -8,20 +8,20 @@ It identifies the intended ordered context foundation. It does not prove provide
 
 ## Manifest Version
 
-`system-context-manifest-v12`
+`system-context-manifest-v13`
 
 ## Generated At
 
-`2026-07-12`
+`2026-07-15`
 
-## Profile: `knowledge-aware-core-v12`
+## Profile: `knowledge-aware-core-v13`
 
 ### Ordered Files
 
 ```text
 docs/integrations/chatgpt/CORE_SYSTEM_PROMPT.md=411ec24d4a3ba1c2ffe304a02428f16c4d1a92bd
 START_HERE.md=f315656999e3e78b1b797ad2c1c971ef64fccbf9
-docs/ROUTER.md=2f8c3bf62aaa4d9b72267eaf2ced75a1fee2e683
+docs/ROUTER.md=034cd737c92d3c7397efbcd45c25d5086678d472
 docs/CONTEXT_ASSEMBLY_STANDARD.md=d14b6756dcdc97e1d99e30fd9a779cbdfdc8292a
 docs/KNOWLEDGE_SYSTEM.md=e5500ceb295997403f0e2e6ca47ee9c02f3c623c
 ```
@@ -29,7 +29,7 @@ docs/KNOWLEDGE_SYSTEM.md=e5500ceb295997403f0e2e6ca47ee9c02f3c623c
 ### SHA-256 Fingerprint
 
 ```text
-c9c6227c6dcf2dc22da5f1193e3f7bd5fc59f3899be757513b1bf04e99d9a701
+efd6961a9b8a0835b1b177c13580f73448cdadaa5769fbf318080944a41035bc
 ```
 
 ### Loading Rule
@@ -60,6 +60,7 @@ Append only the routed node, project orientation, task-specific evidence, select
 - `knowledge-aware-core-v9`
 - `knowledge-aware-core-v10`
 - `knowledge-aware-core-v11`
+- `knowledge-aware-core-v12`
 
 ## Update Rule
 

--- a/capabilities/media-probe/BLOCK.md
+++ b/capabilities/media-probe/BLOCK.md
@@ -1,0 +1,133 @@
+# media.probe Capability Block
+
+## Purpose
+
+Inspect one authorized local media file with `ffprobe` and return normalized metadata through the Project Execution OS capability contract.
+
+## Status
+
+`candidate` — implementation and local tests exist. Real cross-application validation is still required before promotion to `validated`.
+
+## Block Identity
+
+```text
+block_id: media.probe
+version: 0.1.0
+provider: ffprobe
+```
+
+## Responsibility
+
+This block performs one technical operation:
+
+```text
+local media artifact -> normalized media metadata
+```
+
+It does not download files, transcode media, cut clips, transcribe audio, publish content, or contain application UI and business logic.
+
+## Inputs
+
+Exactly one `ArtifactRef` with:
+
+- a local path or `file://` URI;
+- an artifact identifier;
+- a media kind;
+- optional MIME type, size, hash, and metadata.
+
+The resolved file must remain inside `BlockContext.workspace`.
+
+## Outputs
+
+The result envelope contains the original artifact enriched under:
+
+```text
+artifact.metadata.probe
+```
+
+Normalized metadata includes:
+
+- duration;
+- file size and bit rate;
+- container format;
+- stream counts;
+- normalized video, audio, and subtitle stream records;
+- primary video and audio summaries;
+- frame rate, dimensions, sample rate, channels, language, and disposition when available.
+
+## Python Usage
+
+```python
+from pathlib import Path
+from peos_media_probe import ArtifactRef, BlockContext, BlockRequest, create_block
+
+path = Path("input.mp4").resolve()
+result = create_block().run(
+    BlockRequest(
+        request_id="req-1",
+        input_artifacts=(
+            ArtifactRef(
+                artifact_id="media-1",
+                kind="video",
+                uri=path.as_uri(),
+            ),
+        ),
+    ),
+    BlockContext(workspace=path.parent),
+)
+```
+
+## CLI Usage
+
+```bash
+peos-media-probe input.mp4 --pretty
+```
+
+or:
+
+```bash
+python -m peos_media_probe.cli input.mp4 --pretty
+```
+
+The CLI returns exit code `0` for success and `1` for a structured capability failure.
+
+## Dependencies
+
+Python dependencies: none.
+
+Runtime dependency:
+
+```text
+ffprobe
+```
+
+`ffprobe` must be installed and available on `PATH`, or supplied through `BlockContext.ffprobe_path` / `--ffprobe`.
+
+## Safety Boundary
+
+- no network access;
+- read-only access to one file inside the configured workspace;
+- no destructive operations;
+- no secrets;
+- no DRM or access-control bypass;
+- no hidden downstream execution.
+
+## Verification
+
+```bash
+python -m pip install -e '.[dev]'
+pytest
+peos-media-probe path/to/media.mp4 --pretty
+```
+
+## Known Limitations
+
+- only local paths and `file://` URIs are accepted;
+- only the `ffprobe` provider exists in v0.1.0;
+- container and codec metadata are normalized on a best-effort basis because source formats vary;
+- Windows path behavior is implemented but still requires a native Windows smoke test;
+- the block has not yet been integrated into two real applications.
+
+## Promotion Requirement
+
+Promote to `validated` only after successful integration into a real workflow, with artifact evidence and any required contract corrections recorded in the central registry.

--- a/capabilities/media-probe/CHANGELOG.md
+++ b/capabilities/media-probe/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0 — 2026-07-15
+
+- Added the first executable Project Execution OS capability block.
+- Added stable request, context, result, error, and artifact contracts.
+- Added ffprobe provider with normalized media metadata.
+- Added workspace boundary enforcement and structured failures.
+- Added package entry point and CLI adapter.
+- Added unit, contract, and real ffprobe smoke tests.

--- a/capabilities/media-probe/VALIDATION.md
+++ b/capabilities/media-probe/VALIDATION.md
@@ -1,0 +1,97 @@
+# media.probe Validation Record
+
+## Candidate Validation
+
+Date: 2026-07-15
+
+Status tested: `0.1.0 candidate`
+
+## Environment
+
+```text
+Operating environment: Linux container
+Python: 3.13.5
+pytest: 9.0.2
+ffprobe: 7.1.3-0+deb13u1
+```
+
+## Installation Command
+
+```bash
+python -m pip install -e '.[dev]'
+```
+
+Result: success.
+
+## Automated Test Command
+
+```bash
+pytest -q
+```
+
+Result:
+
+```text
+6 passed in 0.30s
+```
+
+Coverage exercised:
+
+- ffprobe rational frame-rate parsing;
+- normalized video and audio metadata;
+- successful capability result envelope;
+- preservation of existing artifact metadata;
+- workspace boundary rejection;
+- structured `ffprobe_not_found` failure;
+- real ffprobe execution against a generated WAV fixture.
+
+## Manual CLI Smoke Test
+
+A 0.1-second mono WAV file at 8000 Hz was generated with Python's standard `wave` module.
+
+Command shape:
+
+```bash
+peos-media-probe <generated-sample.wav> --pretty
+```
+
+Verified result:
+
+```json
+{
+  "status": "success",
+  "block_id": "media.probe",
+  "block_version": "0.1.0",
+  "duration_seconds": 0.1,
+  "sample_rate_hz": 8000,
+  "warnings": [
+    "No video stream was detected."
+  ]
+}
+```
+
+## GitHub CI
+
+Workflow added:
+
+```text
+.github/workflows/media-probe-tests.yml
+```
+
+The workflow runs the package tests on Python 3.12 and 3.13 and installs ffmpeg/ffprobe before the real smoke test.
+
+CI status must be checked on the pull request before merge.
+
+## Candidate Conclusion
+
+The evidence is sufficient to promote `media.probe` from `idea` to `candidate`.
+
+It is not sufficient for `validated` because the block has not yet been integrated into a real application workflow.
+
+## Remaining Validation
+
+- run a native Windows smoke test;
+- test representative MP4/H.264/AAC input;
+- test variable-frame-rate input;
+- integrate into one real application workflow;
+- confirm the contract remains suitable when `media.clip` becomes the second capability consumer.

--- a/capabilities/media-probe/VALIDATION.md
+++ b/capabilities/media-probe/VALIDATION.md
@@ -70,6 +70,18 @@ Verified result:
 }
 ```
 
+## Repository Branch Verification
+
+GitHub compare confirmed that branch `capability-media-probe-v0.1.0` is based on the current `main` commit and contains the expected capability implementation, package metadata, tests, example, and workflow files.
+
+A second validation attempt tried to clone the branch back into the execution container and rerun tests from the remote copy. The clone could not start because the container could not resolve `github.com`:
+
+```text
+fatal: unable to access 'https://github.com/oleg3479881328-code/Project-Execution-OS.git/': Could not resolve host: github.com
+```
+
+No workaround was invented. Independent repository validation is delegated to the pull-request GitHub Actions workflow.
+
 ## GitHub CI
 
 Workflow added:
@@ -84,12 +96,13 @@ CI status must be checked on the pull request before merge.
 
 ## Candidate Conclusion
 
-The evidence is sufficient to promote `media.probe` from `idea` to `candidate`.
+The local execution evidence is sufficient to promote `media.probe` from `idea` to `candidate`.
 
 It is not sufficient for `validated` because the block has not yet been integrated into a real application workflow.
 
 ## Remaining Validation
 
+- confirm the pull-request GitHub Actions result;
 - run a native Windows smoke test;
 - test representative MP4/H.264/AAC input;
 - test variable-frame-rate input;

--- a/capabilities/media-probe/examples/probe_file.py
+++ b/capabilities/media-probe/examples/probe_file.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from peos_media_probe import ArtifactRef, BlockContext, BlockRequest, create_block
+
+media_path = Path("example.mp4").resolve()
+result = create_block().run(
+    BlockRequest(
+        request_id="example-request",
+        input_artifacts=(
+            ArtifactRef(
+                artifact_id="example-media",
+                kind="video",
+                uri=media_path.as_uri(),
+            ),
+        ),
+    ),
+    BlockContext(workspace=media_path.parent),
+)
+print(result.to_dict())

--- a/capabilities/media-probe/manifest.yaml
+++ b/capabilities/media-probe/manifest.yaml
@@ -1,0 +1,22 @@
+block_id: media.probe
+version: 0.1.0
+status: candidate
+runtime: python
+python: ">=3.12"
+entry_point: peos_media_probe:create_block
+cli: peos-media-probe
+inputs:
+  - media
+outputs:
+  - media_metadata
+permissions:
+  network: false
+  filesystem: workspace-read-only
+  subprocess:
+    - ffprobe
+  gpu: false
+credentials: []
+providers:
+  - ffprobe
+idempotent: true
+destructive: false

--- a/capabilities/media-probe/pyproject.toml
+++ b/capabilities/media-probe/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "peos-capability-media-probe"
+version = "0.1.0"
+description = "Project Execution OS capability block for normalized media metadata probing via ffprobe."
+readme = "BLOCK.md"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [
+  { name = "Oleg / Project Execution OS" }
+]
+keywords = ["ffprobe", "media", "metadata", "capability-block"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=8"]
+
+[project.scripts]
+peos-media-probe = "peos_media_probe.cli:main"
+
+[project.entry-points."project_execution_os.capabilities"]
+media_probe = "peos_media_probe:create_block"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]

--- a/capabilities/media-probe/src/peos_media_probe/__init__.py
+++ b/capabilities/media-probe/src/peos_media_probe/__init__.py
@@ -1,0 +1,27 @@
+"""Project Execution OS capability block: media.probe."""
+
+from .contracts import (
+    ArtifactRef,
+    BlockContext,
+    BlockError,
+    BlockRequest,
+    BlockResult,
+)
+from .core import MediaProbeBlock
+
+__all__ = [
+    "ArtifactRef",
+    "BlockContext",
+    "BlockError",
+    "BlockRequest",
+    "BlockResult",
+    "MediaProbeBlock",
+    "create_block",
+]
+
+__version__ = "0.1.0"
+
+
+def create_block() -> MediaProbeBlock:
+    """Create the default ffprobe-backed capability block."""
+    return MediaProbeBlock()

--- a/capabilities/media-probe/src/peos_media_probe/cli.py
+++ b/capabilities/media-probe/src/peos_media_probe/cli.py
@@ -1,0 +1,84 @@
+"""Command-line adapter for media.probe."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from pathlib import Path
+
+from .contracts import ArtifactRef, BlockContext, BlockRequest
+from .core import MediaProbeBlock
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="peos-media-probe",
+        description="Inspect a local media file with the media.probe capability block.",
+    )
+    parser.add_argument("input", help="Local media path or file:// URI")
+    parser.add_argument(
+        "--workspace",
+        help="Allowed workspace root. Defaults to the input file's parent directory.",
+    )
+    parser.add_argument("--ffprobe", default="ffprobe", help="ffprobe executable")
+    parser.add_argument("--timeout", type=float, default=30.0, help="Timeout in seconds")
+    parser.add_argument("--request-id", help="Explicit request identifier")
+    parser.add_argument("--artifact-id", help="Explicit artifact identifier")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
+    return parser
+
+
+def _default_workspace(input_value: str) -> Path:
+    if input_value.startswith("file://"):
+        from urllib.parse import unquote, urlparse
+        from urllib.request import url2pathname
+
+        parsed = urlparse(input_value)
+        path = Path(url2pathname(unquote(parsed.path)))
+    else:
+        path = Path(input_value)
+    resolved = path.expanduser().resolve()
+    return resolved if resolved.is_dir() else resolved.parent
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    workspace = (
+        Path(args.workspace).expanduser().resolve()
+        if args.workspace
+        else _default_workspace(args.input)
+    )
+    request_id = args.request_id or f"req_{uuid.uuid4().hex}"
+    artifact_id = args.artifact_id or f"art_{uuid.uuid4().hex}"
+
+    request = BlockRequest(
+        request_id=request_id,
+        input_artifacts=(
+            ArtifactRef(
+                artifact_id=artifact_id,
+                kind="media",
+                uri=args.input,
+            ),
+        ),
+    )
+    context = BlockContext(
+        workspace=workspace,
+        timeout_seconds=args.timeout,
+        ffprobe_path=args.ffprobe,
+    )
+    result = MediaProbeBlock().run(request, context)
+    json.dump(
+        result.to_dict(),
+        sys.stdout,
+        ensure_ascii=False,
+        indent=2 if args.pretty else None,
+        sort_keys=args.pretty,
+    )
+    sys.stdout.write("\n")
+    return 0 if result.status == "success" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/capabilities/media-probe/src/peos_media_probe/contracts.py
+++ b/capabilities/media-probe/src/peos_media_probe/contracts.py
@@ -1,0 +1,104 @@
+"""Serializable request, context, artifact, result, and error contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Literal, Mapping
+
+BlockStatus = Literal["success", "partial", "failed", "cancelled"]
+ProgressReporter = Callable[[float, str], None]
+
+
+def _dict(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    return dict(value or {})
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactRef:
+    """Reference to an input or output artifact."""
+
+    artifact_id: str
+    kind: str
+    uri: str
+    mime_type: str | None = None
+    size_bytes: int | None = None
+    sha256: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "artifact_id": self.artifact_id,
+            "kind": self.kind,
+            "uri": self.uri,
+            "mime_type": self.mime_type,
+            "size_bytes": self.size_bytes,
+            "sha256": self.sha256,
+            "metadata": _dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BlockRequest:
+    """Serializable request for one capability execution."""
+
+    request_id: str
+    input_artifacts: tuple[ArtifactRef, ...]
+    parameters: Mapping[str, Any] = field(default_factory=dict)
+    provider: str = "ffprobe"
+    idempotency_key: str | None = None
+
+
+@dataclass(slots=True)
+class BlockContext:
+    """Execution services supplied by the application or adapter."""
+
+    workspace: Path
+    timeout_seconds: float = 30.0
+    ffprobe_path: str = "ffprobe"
+    logger: Any | None = None
+    progress_reporter: ProgressReporter | None = None
+
+    def report_progress(self, fraction: float, message: str) -> None:
+        if self.progress_reporter is not None:
+            self.progress_reporter(max(0.0, min(1.0, fraction)), message)
+
+
+@dataclass(frozen=True, slots=True)
+class BlockError:
+    """Structured actionable capability failure."""
+
+    code: str
+    message: str
+    retryable: bool = False
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "message": self.message,
+            "retryable": self.retryable,
+            "details": _dict(self.details),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BlockResult:
+    """Predictable result envelope returned by every run."""
+
+    status: BlockStatus
+    output_artifacts: tuple[ArtifactRef, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    warnings: tuple[str, ...] = ()
+    metrics: Mapping[str, Any] = field(default_factory=dict)
+    error: BlockError | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "output_artifacts": [item.to_dict() for item in self.output_artifacts],
+            "metadata": _dict(self.metadata),
+            "warnings": list(self.warnings),
+            "metrics": _dict(self.metrics),
+            "error": self.error.to_dict() if self.error else None,
+        }

--- a/capabilities/media-probe/src/peos_media_probe/core.py
+++ b/capabilities/media-probe/src/peos_media_probe/core.py
@@ -1,0 +1,219 @@
+"""Capability core for media.probe."""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Protocol
+from urllib.parse import unquote, urlparse
+from urllib.request import url2pathname
+
+from .contracts import (
+    ArtifactRef,
+    BlockContext,
+    BlockError,
+    BlockRequest,
+    BlockResult,
+)
+from .errors import CapabilityFailure
+from .providers import FFprobeProvider
+
+_WINDOWS_DRIVE_PATH = re.compile(r"^[A-Za-z]:[\\/]")
+
+
+class ProbeProvider(Protocol):
+    provider_id: str
+
+    def probe(self, path: Path, timeout_seconds: float) -> dict[str, Any]:
+        ...
+
+
+def _resolve_input_path(uri: str, workspace: Path) -> Path:
+    workspace_path = workspace.expanduser().resolve()
+
+    if _WINDOWS_DRIVE_PATH.match(uri):
+        candidate = Path(uri)
+    else:
+        parsed = urlparse(uri)
+        if parsed.scheme == "file":
+            raw_path = url2pathname(unquote(parsed.path))
+            if os.name == "nt" and raw_path.startswith("/") and len(raw_path) > 3:
+                if raw_path[2] == ":":
+                    raw_path = raw_path[1:]
+            candidate = Path(raw_path)
+        elif parsed.scheme:
+            raise CapabilityFailure(
+                code="unsupported_uri",
+                message=f"media.probe supports local paths and file:// URIs, not {parsed.scheme}://",
+                details={"uri": uri, "scheme": parsed.scheme},
+            )
+        else:
+            candidate = Path(uri)
+
+    if not candidate.is_absolute():
+        candidate = workspace_path / candidate
+
+    try:
+        resolved = candidate.expanduser().resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise CapabilityFailure(
+            code="input_not_found",
+            message=f"Input media file does not exist: {candidate}",
+            details={"uri": uri},
+        ) from exc
+
+    if not resolved.is_file():
+        raise CapabilityFailure(
+            code="input_not_file",
+            message=f"Input artifact is not a file: {resolved}",
+            details={"uri": uri},
+        )
+
+    try:
+        resolved.relative_to(workspace_path)
+    except ValueError as exc:
+        raise CapabilityFailure(
+            code="input_outside_workspace",
+            message="Input media file is outside the allowed workspace",
+            details={
+                "input_path": str(resolved),
+                "workspace": str(workspace_path),
+            },
+        ) from exc
+
+    return resolved
+
+
+class MediaProbeBlock:
+    """Inspect one local media artifact and return normalized metadata."""
+
+    block_id = "media.probe"
+    version = "0.1.0"
+
+    def __init__(self, provider: ProbeProvider | None = None) -> None:
+        self._provider = provider
+
+    def run(self, request: BlockRequest, context: BlockContext) -> BlockResult:
+        started = time.perf_counter()
+        provider_name = request.provider or "ffprobe"
+
+        try:
+            if len(request.input_artifacts) != 1:
+                raise CapabilityFailure(
+                    code="invalid_request",
+                    message="media.probe requires exactly one input artifact",
+                    details={"input_count": len(request.input_artifacts)},
+                )
+
+            if provider_name != "ffprobe":
+                raise CapabilityFailure(
+                    code="unsupported_provider",
+                    message=f"Unsupported media.probe provider: {provider_name}",
+                    details={"supported_providers": ["ffprobe"]},
+                )
+
+            context.report_progress(0.05, "Resolving media input")
+            input_artifact = request.input_artifacts[0]
+            input_path = _resolve_input_path(input_artifact.uri, context.workspace)
+
+            provider = self._provider or FFprobeProvider(binary=context.ffprobe_path)
+            if provider.provider_id != provider_name:
+                raise CapabilityFailure(
+                    code="provider_mismatch",
+                    message="Injected provider does not match the requested provider",
+                    details={
+                        "requested": provider_name,
+                        "injected": provider.provider_id,
+                    },
+                )
+
+            context.report_progress(0.2, "Running ffprobe")
+            probe_metadata = provider.probe(input_path, context.timeout_seconds)
+            context.report_progress(0.9, "Normalizing media metadata")
+
+            warnings: list[str] = []
+            if probe_metadata.get("video_stream_count", 0) == 0:
+                warnings.append("No video stream was detected.")
+            if probe_metadata.get("audio_stream_count", 0) == 0:
+                warnings.append("No audio stream was detected.")
+
+            merged_metadata = dict(input_artifact.metadata)
+            merged_metadata["probe"] = probe_metadata
+
+            output = ArtifactRef(
+                artifact_id=input_artifact.artifact_id,
+                kind=input_artifact.kind,
+                uri=input_artifact.uri,
+                mime_type=input_artifact.mime_type,
+                size_bytes=probe_metadata.get("size_bytes")
+                or input_artifact.size_bytes,
+                sha256=input_artifact.sha256,
+                metadata=merged_metadata,
+            )
+            elapsed_ms = round((time.perf_counter() - started) * 1000, 3)
+            context.report_progress(1.0, "Media probe complete")
+
+            return BlockResult(
+                status="success",
+                output_artifacts=(output,),
+                metadata={
+                    "block_id": self.block_id,
+                    "block_version": self.version,
+                    "provider": provider_name,
+                    "request_id": request.request_id,
+                    "idempotency_key": request.idempotency_key,
+                },
+                warnings=tuple(warnings),
+                metrics={"elapsed_ms": elapsed_ms},
+            )
+        except CapabilityFailure as exc:
+            return self._failure_result(
+                exc=exc,
+                request=request,
+                provider_name=provider_name,
+                started=started,
+            )
+        except Exception as exc:  # defensive conversion at the capability boundary
+            if context.logger is not None:
+                context.logger.exception("Unexpected media.probe failure")
+            failure = CapabilityFailure(
+                code="internal_error",
+                message="Unexpected media.probe failure",
+                details={"exception_type": type(exc).__name__},
+            )
+            return self._failure_result(
+                exc=failure,
+                request=request,
+                provider_name=provider_name,
+                started=started,
+            )
+
+    def _failure_result(
+        self,
+        *,
+        exc: CapabilityFailure,
+        request: BlockRequest,
+        provider_name: str,
+        started: float,
+    ) -> BlockResult:
+        return BlockResult(
+            status="failed",
+            metadata={
+                "block_id": self.block_id,
+                "block_version": self.version,
+                "provider": provider_name,
+                "request_id": request.request_id,
+                "idempotency_key": request.idempotency_key,
+            },
+            metrics={
+                "elapsed_ms": round((time.perf_counter() - started) * 1000, 3)
+            },
+            error=BlockError(
+                code=exc.code,
+                message=exc.message,
+                retryable=exc.retryable,
+                details=exc.details,
+            ),
+        )

--- a/capabilities/media-probe/src/peos_media_probe/errors.py
+++ b/capabilities/media-probe/src/peos_media_probe/errors.py
@@ -1,0 +1,17 @@
+"""Internal typed exceptions converted to structured BlockError values."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+@dataclass(slots=True)
+class CapabilityFailure(Exception):
+    code: str
+    message: str
+    retryable: bool = False
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+    def __str__(self) -> str:
+        return self.message

--- a/capabilities/media-probe/src/peos_media_probe/providers/__init__.py
+++ b/capabilities/media-probe/src/peos_media_probe/providers/__init__.py
@@ -1,0 +1,5 @@
+"""Provider implementations for media.probe."""
+
+from .ffprobe import FFprobeProvider
+
+__all__ = ["FFprobeProvider"]

--- a/capabilities/media-probe/src/peos_media_probe/providers/ffprobe.py
+++ b/capabilities/media-probe/src/peos_media_probe/providers/ffprobe.py
@@ -1,0 +1,224 @@
+"""ffprobe provider and normalization logic."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from ..errors import CapabilityFailure
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _optional_float(value: Any) -> float | None:
+    if value in (None, "", "N/A"):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_int(value: Any) -> int | None:
+    if value in (None, "", "N/A"):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_fraction(value: Any) -> float | None:
+    """Parse ffprobe rational strings such as ``30000/1001`` safely."""
+    if value in (None, "", "N/A", "0/0"):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value)
+    if "/" not in text:
+        return _optional_float(text)
+    numerator, denominator = text.split("/", 1)
+    try:
+        denominator_value = float(denominator)
+        if denominator_value == 0:
+            return None
+        return float(numerator) / denominator_value
+    except ValueError:
+        return None
+
+
+def _stream_duration(stream: Mapping[str, Any]) -> float | None:
+    direct = _optional_float(stream.get("duration"))
+    if direct is not None:
+        return direct
+    tags = stream.get("tags")
+    if isinstance(tags, Mapping):
+        return _optional_float(tags.get("DURATION"))
+    return None
+
+
+def _normalized_stream(stream: Mapping[str, Any]) -> dict[str, Any]:
+    tags = stream.get("tags") if isinstance(stream.get("tags"), Mapping) else {}
+    disposition = (
+        stream.get("disposition")
+        if isinstance(stream.get("disposition"), Mapping)
+        else {}
+    )
+    return {
+        "index": _optional_int(stream.get("index")),
+        "codec_type": stream.get("codec_type"),
+        "codec_name": stream.get("codec_name"),
+        "codec_long_name": stream.get("codec_long_name"),
+        "profile": stream.get("profile"),
+        "codec_tag_string": stream.get("codec_tag_string"),
+        "duration_seconds": _stream_duration(stream),
+        "bit_rate": _optional_int(stream.get("bit_rate")),
+        "width": _optional_int(stream.get("width")),
+        "height": _optional_int(stream.get("height")),
+        "pixel_format": stream.get("pix_fmt"),
+        "sample_aspect_ratio": stream.get("sample_aspect_ratio"),
+        "display_aspect_ratio": stream.get("display_aspect_ratio"),
+        "average_frame_rate": stream.get("avg_frame_rate"),
+        "real_frame_rate": stream.get("r_frame_rate"),
+        "frame_rate_fps": parse_fraction(
+            stream.get("avg_frame_rate") or stream.get("r_frame_rate")
+        ),
+        "sample_rate_hz": _optional_int(stream.get("sample_rate")),
+        "channels": _optional_int(stream.get("channels")),
+        "channel_layout": stream.get("channel_layout"),
+        "language": tags.get("language"),
+        "title": tags.get("title"),
+        "disposition": dict(disposition),
+    }
+
+
+def normalize_ffprobe_payload(
+    payload: Mapping[str, Any], *, actual_size_bytes: int | None = None
+) -> dict[str, Any]:
+    """Normalize provider-specific ffprobe JSON into a stable block payload."""
+    raw_streams = payload.get("streams")
+    streams: list[dict[str, Any]] = []
+    if isinstance(raw_streams, Sequence) and not isinstance(raw_streams, (str, bytes)):
+        streams = [
+            _normalized_stream(stream)
+            for stream in raw_streams
+            if isinstance(stream, Mapping)
+        ]
+
+    format_data = payload.get("format")
+    if not isinstance(format_data, Mapping):
+        format_data = {}
+
+    durations = [
+        value
+        for value in (
+            _optional_float(format_data.get("duration")),
+            *[stream.get("duration_seconds") for stream in streams],
+        )
+        if isinstance(value, (int, float))
+    ]
+    duration_seconds = max(durations) if durations else None
+
+    format_size = _optional_int(format_data.get("size"))
+    size_bytes = format_size if format_size is not None else actual_size_bytes
+
+    video_streams = [item for item in streams if item.get("codec_type") == "video"]
+    audio_streams = [item for item in streams if item.get("codec_type") == "audio"]
+    subtitle_streams = [
+        item for item in streams if item.get("codec_type") == "subtitle"
+    ]
+
+    return {
+        "duration_seconds": duration_seconds,
+        "size_bytes": size_bytes,
+        "bit_rate": _optional_int(format_data.get("bit_rate")),
+        "format_name": format_data.get("format_name"),
+        "format_long_name": format_data.get("format_long_name"),
+        "start_time_seconds": _optional_float(format_data.get("start_time")),
+        "stream_count": len(streams),
+        "video_stream_count": len(video_streams),
+        "audio_stream_count": len(audio_streams),
+        "subtitle_stream_count": len(subtitle_streams),
+        "primary_video": video_streams[0] if video_streams else None,
+        "primary_audio": audio_streams[0] if audio_streams else None,
+        "streams": streams,
+        "format_tags": dict(format_data.get("tags") or {})
+        if isinstance(format_data.get("tags"), Mapping)
+        else {},
+    }
+
+
+@dataclass(slots=True)
+class FFprobeProvider:
+    """Execute ffprobe and normalize its JSON output."""
+
+    binary: str = "ffprobe"
+    runner: Runner = subprocess.run
+    provider_id: str = "ffprobe"
+
+    def probe(self, path: Path, timeout_seconds: float) -> dict[str, Any]:
+        command = [
+            self.binary,
+            "-v",
+            "error",
+            "-show_format",
+            "-show_streams",
+            "-of",
+            "json",
+            str(path),
+        ]
+        try:
+            completed = self.runner(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise CapabilityFailure(
+                code="ffprobe_not_found",
+                message=f"ffprobe executable was not found: {self.binary}",
+                details={"binary": self.binary},
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise CapabilityFailure(
+                code="ffprobe_timeout",
+                message=f"ffprobe exceeded the {timeout_seconds:g}s timeout",
+                retryable=True,
+                details={"timeout_seconds": timeout_seconds},
+            ) from exc
+
+        if completed.returncode != 0:
+            stderr = (completed.stderr or "").strip()
+            raise CapabilityFailure(
+                code="ffprobe_failed",
+                message="ffprobe could not inspect the media input",
+                details={
+                    "return_code": completed.returncode,
+                    "stderr": stderr[-4000:],
+                },
+            )
+
+        try:
+            payload = json.loads(completed.stdout or "{}")
+        except json.JSONDecodeError as exc:
+            raise CapabilityFailure(
+                code="invalid_ffprobe_output",
+                message="ffprobe returned invalid JSON",
+                details={"stdout_preview": (completed.stdout or "")[:1000]},
+            ) from exc
+
+        if not isinstance(payload, Mapping):
+            raise CapabilityFailure(
+                code="invalid_ffprobe_output",
+                message="ffprobe JSON root must be an object",
+            )
+
+        return normalize_ffprobe_payload(
+            payload,
+            actual_size_bytes=path.stat().st_size,
+        )

--- a/capabilities/media-probe/tests/contract/test_block_contract.py
+++ b/capabilities/media-probe/tests/contract/test_block_contract.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+from peos_media_probe import ArtifactRef, BlockContext, BlockRequest, MediaProbeBlock
+
+
+class FakeProvider:
+    provider_id = "ffprobe"
+
+    def probe(self, path: Path, timeout_seconds: float) -> dict[str, object]:
+        assert path.name == "sample.bin"
+        assert timeout_seconds == 5.0
+        return {
+            "duration_seconds": 1.25,
+            "size_bytes": path.stat().st_size,
+            "stream_count": 1,
+            "video_stream_count": 1,
+            "audio_stream_count": 0,
+            "subtitle_stream_count": 0,
+            "primary_video": {"codec_name": "fake"},
+            "primary_audio": None,
+            "streams": [],
+        }
+
+
+def test_success_result_envelope(tmp_path: Path) -> None:
+    media = tmp_path / "sample.bin"
+    media.write_bytes(b"probe-me")
+
+    block = MediaProbeBlock(provider=FakeProvider())
+    result = block.run(
+        BlockRequest(
+            request_id="req-1",
+            input_artifacts=(
+                ArtifactRef(
+                    artifact_id="art-1",
+                    kind="media",
+                    uri=media.as_uri(),
+                    metadata={"source": "fixture"},
+                ),
+            ),
+            idempotency_key="idem-1",
+        ),
+        BlockContext(workspace=tmp_path, timeout_seconds=5.0),
+    )
+
+    payload = result.to_dict()
+    assert payload["status"] == "success"
+    assert payload["error"] is None
+    assert payload["metadata"]["block_id"] == "media.probe"
+    assert payload["metadata"]["block_version"] == "0.1.0"
+    assert payload["output_artifacts"][0]["metadata"]["source"] == "fixture"
+    assert payload["output_artifacts"][0]["metadata"]["probe"]["duration_seconds"] == 1.25
+    assert "No audio stream was detected." in payload["warnings"]
+
+
+def test_rejects_input_outside_workspace(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.bin"
+    outside.write_bytes(b"x")
+
+    result = MediaProbeBlock(provider=FakeProvider()).run(
+        BlockRequest(
+            request_id="req-2",
+            input_artifacts=(
+                ArtifactRef(
+                    artifact_id="art-2",
+                    kind="media",
+                    uri=outside.as_uri(),
+                ),
+            ),
+        ),
+        BlockContext(workspace=workspace),
+    )
+
+    assert result.status == "failed"
+    assert result.error is not None
+    assert result.error.code == "input_outside_workspace"

--- a/capabilities/media-probe/tests/contract/test_block_contract.py
+++ b/capabilities/media-probe/tests/contract/test_block_contract.py
@@ -76,3 +76,30 @@ def test_rejects_input_outside_workspace(tmp_path: Path) -> None:
     assert result.status == "failed"
     assert result.error is not None
     assert result.error.code == "input_outside_workspace"
+
+
+def test_missing_ffprobe_returns_structured_error(tmp_path: Path) -> None:
+    media = tmp_path / "sample.bin"
+    media.write_bytes(b"not-real-media")
+
+    result = MediaProbeBlock().run(
+        BlockRequest(
+            request_id="req-3",
+            input_artifacts=(
+                ArtifactRef(
+                    artifact_id="art-3",
+                    kind="media",
+                    uri=media.as_uri(),
+                ),
+            ),
+        ),
+        BlockContext(
+            workspace=tmp_path,
+            ffprobe_path="definitely-missing-ffprobe-executable",
+        ),
+    )
+
+    assert result.status == "failed"
+    assert result.error is not None
+    assert result.error.code == "ffprobe_not_found"
+    assert result.error.retryable is False

--- a/capabilities/media-probe/tests/smoke/test_ffprobe_smoke.py
+++ b/capabilities/media-probe/tests/smoke/test_ffprobe_smoke.py
@@ -1,0 +1,41 @@
+import shutil
+import wave
+from pathlib import Path
+
+import pytest
+
+from peos_media_probe import ArtifactRef, BlockContext, BlockRequest, MediaProbeBlock
+
+
+@pytest.mark.skipif(shutil.which("ffprobe") is None, reason="ffprobe is not installed")
+def test_real_ffprobe_can_probe_generated_wav(tmp_path: Path) -> None:
+    audio = tmp_path / "tone.wav"
+    sample_rate = 8000
+    frame_count = 800
+
+    with wave.open(str(audio), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(b"\x00\x00" * frame_count)
+
+    result = MediaProbeBlock().run(
+        BlockRequest(
+            request_id="smoke-1",
+            input_artifacts=(
+                ArtifactRef(
+                    artifact_id="wav-1",
+                    kind="audio",
+                    uri=audio.as_uri(),
+                    mime_type="audio/wav",
+                ),
+            ),
+        ),
+        BlockContext(workspace=tmp_path, timeout_seconds=10.0),
+    )
+
+    assert result.status == "success", result.to_dict()
+    probe = result.output_artifacts[0].metadata["probe"]
+    assert probe["audio_stream_count"] == 1
+    assert probe["primary_audio"]["sample_rate_hz"] == sample_rate
+    assert probe["duration_seconds"] == pytest.approx(frame_count / sample_rate, rel=0.02)

--- a/capabilities/media-probe/tests/unit/test_normalization.py
+++ b/capabilities/media-probe/tests/unit/test_normalization.py
@@ -1,0 +1,54 @@
+from peos_media_probe.providers.ffprobe import (
+    normalize_ffprobe_payload,
+    parse_fraction,
+)
+
+
+def test_parse_fraction() -> None:
+    assert parse_fraction("30000/1001") == 30000 / 1001
+    assert parse_fraction("25/1") == 25.0
+    assert parse_fraction("0/0") is None
+    assert parse_fraction("N/A") is None
+
+
+def test_normalize_ffprobe_payload() -> None:
+    payload = {
+        "streams": [
+            {
+                "index": 0,
+                "codec_type": "video",
+                "codec_name": "h264",
+                "width": 1920,
+                "height": 1080,
+                "avg_frame_rate": "30000/1001",
+                "duration": "12.50",
+            },
+            {
+                "index": 1,
+                "codec_type": "audio",
+                "codec_name": "aac",
+                "sample_rate": "48000",
+                "channels": 2,
+                "duration": "12.48",
+                "tags": {"language": "eng"},
+            },
+        ],
+        "format": {
+            "format_name": "mov,mp4,m4a,3gp,3g2,mj2",
+            "format_long_name": "QuickTime / MOV",
+            "duration": "12.50",
+            "size": "123456",
+            "bit_rate": "79000",
+        },
+    }
+
+    result = normalize_ffprobe_payload(payload)
+
+    assert result["duration_seconds"] == 12.5
+    assert result["size_bytes"] == 123456
+    assert result["video_stream_count"] == 1
+    assert result["audio_stream_count"] == 1
+    assert result["primary_video"]["width"] == 1920
+    assert result["primary_video"]["frame_rate_fps"] == 30000 / 1001
+    assert result["primary_audio"]["sample_rate_hz"] == 48000
+    assert result["primary_audio"]["language"] == "eng"

--- a/capability-library/REGISTRY.md
+++ b/capability-library/REGISTRY.md
@@ -20,18 +20,18 @@ A row records architectural intent and implementation status. It must not imply 
 | Block ID | Status | Version | Implementation location | Initial providers | Inputs | Outputs | Validation targets | Known limitations |
 |---|---|---:|---|---|---|---|---|---|
 | `media.download` | idea | — | not created | yt-dlp, direct HTTP | authorized source descriptor | video/audio artifact | short-video workflow, QuizLight | rights and platform restrictions must remain explicit |
-| `media.probe` | idea | — | not created | ffprobe | media artifact | normalized media metadata | short-video workflow, QuizLight | depends on ffprobe availability |
+| `media.probe` | candidate | 0.1.0 | `capabilities/media-probe/` | ffprobe | one local media artifact | original artifact enriched with normalized probe metadata | short-video workflow, QuizLight | native Windows and real application integration still required |
 | `media.extract_audio` | idea | — | not created | ffmpeg | video/audio artifact | normalized audio artifact | transcription workflows | codec and channel normalization policy not yet validated |
 | `media.transcribe` | idea | — | not created | whisper.cpp, faster-whisper, optional cloud adapter | audio/video artifact | transcript artifact with segments and timestamps | short-video workflow, QuizLight | provider selection and hardware benchmarks not yet validated |
 | `media.clip` | idea | — | not created | ffmpeg | media artifact plus time ranges | one or more clip artifacts | Reels factory, QuizLight phrase clips | exact-cut versus stream-copy behavior needs fixtures |
 | `media.generate_captions` | idea | — | not created | transcript formatter, ffmpeg/libass optional | transcript artifact | SRT/VTT/ASS caption artifacts | short-video workflow | styling contract not yet defined |
 | `media.render_vertical` | idea | — | not created | ffmpeg | media, captions, layout parameters | vertical video artifact | Reels/Shorts/TikTok factory | layout presets not yet defined |
 
-## First Implementation Order
+## Implementation Sequence
 
 ```text
-1. media.probe
-2. media.clip
+1. media.probe          candidate 0.1.0
+2. media.clip           next
 3. media.extract_audio
 4. media.transcribe
 5. media.download
@@ -43,6 +43,48 @@ Reasoning:
 - establish artifact and result contracts before network and model-provider complexity;
 - validate composition locally;
 - add download permissions and transcription provider routing after the core media contract is stable.
+
+## Candidate Evidence — media.probe 0.1.0
+
+Implementation:
+
+```text
+capabilities/media-probe/
+```
+
+Manifest:
+
+```text
+capabilities/media-probe/manifest.yaml
+```
+
+Package entry points:
+
+```text
+project_execution_os.capabilities -> media_probe
+peos-media-probe CLI
+```
+
+Local verification on 2026-07-15:
+
+```text
+Python 3.13.5
+pytest 9.0.2
+ffprobe 7.1.3
+6 tests passed
+manual CLI smoke test passed on generated WAV input
+```
+
+Durable evidence:
+
+```text
+capabilities/media-probe/VALIDATION.md
+.github/workflows/media-probe-tests.yml
+```
+
+Promotion boundary:
+
+`media.probe` is `candidate`, not `validated`. It still requires native Windows checking and integration into a real application workflow.
 
 ## Promotion Evidence
 

--- a/logs/2026-07-15-media-probe-candidate.md
+++ b/logs/2026-07-15-media-probe-candidate.md
@@ -1,0 +1,94 @@
+# media.probe Candidate Implementation Log
+
+Date: 2026-07-15
+Task-ID: `media-probe-candidate-v0.1.0`
+Branch: `capability-media-probe-v0.1.0`
+Pull request: `https://github.com/oleg3479881328-code/Project-Execution-OS/pull/89`
+
+## Goal
+
+Implement the first real reusable executable capability block under the new composable capability architecture.
+
+## Implemented
+
+```text
+capabilities/media-probe/
+```
+
+The package includes:
+
+- `BLOCK.md`;
+- `manifest.yaml`;
+- `pyproject.toml`;
+- serializable artifact, request, context, result, and error contracts;
+- workspace-restricted input resolution;
+- ffprobe provider;
+- normalized media metadata;
+- CLI adapter;
+- Python package entry point;
+- unit, contract, negative-path, and real ffprobe smoke tests;
+- validation record and changelog.
+
+## Local Evidence
+
+Environment:
+
+```text
+Python 3.13.5
+pytest 9.0.2
+ffprobe 7.1.3-0+deb13u1
+```
+
+Test result:
+
+```text
+6 passed in 0.30s
+```
+
+Manual CLI smoke test:
+
+- generated a 0.1-second mono WAV fixture at 8000 Hz;
+- invoked `peos-media-probe`;
+- received `status=success`;
+- verified duration `0.1` and sample rate `8000`.
+
+## Error Encountered
+
+A second verification attempt tried to clone the GitHub branch into the execution container and rerun tests from the remote copy.
+
+Command path:
+
+```text
+git clone --depth 1 --branch capability-media-probe-v0.1.0 ...
+```
+
+Failure:
+
+```text
+fatal: unable to access 'https://github.com/oleg3479881328-code/Project-Execution-OS.git/': Could not resolve host: github.com
+```
+
+## Resolution
+
+- did not invent a proxy, mirror, or workaround;
+- confirmed branch contents through the GitHub connector compare operation;
+- added `.github/workflows/media-probe-tests.yml` for independent PR validation;
+- recorded the limitation in `capabilities/media-probe/VALIDATION.md`.
+
+## Registry Decision
+
+Promoted:
+
+```text
+media.probe: idea -> candidate 0.1.0
+```
+
+Not promoted to `validated` because no real application integration or native Windows smoke test exists yet.
+
+## Next Safe Action
+
+1. confirm PR #89 CI;
+2. merge if green;
+3. run native Windows smoke test;
+4. implement `media.clip` as the second capability;
+5. validate whether common contract code should be extracted only after real duplication appears.

--- a/logs/latest.md
+++ b/logs/latest.md
@@ -1,23 +1,22 @@
 # Latest Executor Status
 
-Timestamp: 2026-07-15T13:30:00-04:00
-Marker: COMPLETE
-Task-ID: composable-capability-blocks-standard-v1
-Status: Adopted a system-wide architecture for reusable executable capability blocks. Added the central standard and registry, separated domain knowledge from executable blocks and workflows, routed future reusable-module work to the new standard, and connected the video-production domain to the first planned media capability chain.
-Reply-Surface: repository main branch
-Architecture-Standard: docs/COMPOSABLE_CAPABILITY_BLOCKS_STANDARD.md
-Capability-Library-Entrypoint: capability-library/README.md
+Timestamp: 2026-07-15T14:15:00-04:00
+Marker: PR_OPEN_CI_PENDING
+Task-ID: media-probe-candidate-v0.1.0
+Status: Implemented `media.probe` version `0.1.0` as the first executable reusable capability block. Added package metadata, manifest, stable contracts, ffprobe provider, workspace boundary, CLI, tests, validation evidence, CI, and registry promotion from `idea` to `candidate`.
+Reply-Surface: pull request
+PR: https://github.com/oleg3479881328-code/Project-Execution-OS/pull/89
+Branch: capability-media-probe-v0.1.0
+Implementation-Path: capabilities/media-probe/
+Manifest-Path: capabilities/media-probe/manifest.yaml
+Validation-Path: capabilities/media-probe/VALIDATION.md
+Implementation-Log: logs/2026-07-15-media-probe-candidate.md
 Capability-Registry: capability-library/REGISTRY.md
-Router-Path: docs/ROUTER.md
-Domain-Blocks-Definition: blocks/README.md
-Video-Domain-Path: blocks/video-production/BLOCK.md
-Project-Index-Path: PROJECT_INDEX.md
-Project-Entrypoint-Path: PROJECT.md
-Project-State-Path: PROJECT_STATE.md
-Architecture-Commit-SHA: ea782ff0dc8a41268da7ad4f7e29c2640c67cc0a
-Registry-Commits: ac07e56bc2967e14a11bd468c9fa3acc46b5cfdc, 167188a83aed18db1ef6b9db9202ab533cb56322
-Integration-Commits: f780ddbba5ab087c009e76f010ce3ce40f302762, fbd557dcfc43c5c270da8647d7efcad0bd20589c, f7b2498987e4d69187ab16f929e2f99b7fee503c, 3da0518b1be6ead844c41bd609ed9f4ca1bfafaa, dc9ecd632d687fcaba899ae801fd225160d5c159, 10643ce0d153cffe1d22bcb62b5a785b15fa55ed
-Source-Trail: https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/ ; https://docs.n8n.io/integrations/creating-nodes/overview/ ; https://docs.temporal.io/activities ; https://spec.openapis.org/oas/latest.html
-First-Planned-Chain: media.download -> media.probe -> media.extract_audio -> media.transcribe -> media.clip
-Next-Safe-Action: Implement media.probe as the first deterministic candidate block using ffprobe, then validate manifest, artifact contract, Python invocation, CLI adapter, contract tests, smoke test, and registry promotion.
+CI-Workflow: .github/workflows/media-probe-tests.yml
+Local-Test-Evidence: Python 3.13.5; pytest 9.0.2; ffprobe 7.1.3; 6 passed in 0.30s
+CLI-Smoke-Evidence: generated 0.1-second 8000 Hz WAV; status success; duration and sample rate verified
+Remote-Reclone-Limitation: container could not resolve github.com; no workaround invented; error logged; PR CI is the independent repository check
+Current-Registry-Status: media.probe candidate 0.1.0
+Not-Claimed: validated or production
+Next-Safe-Action: Confirm PR #89 CI, merge only if green, then run native Windows smoke test and begin media.clip as the second capability.
 Owner-Action-Required: None.


### PR DESCRIPTION
## What changed

- implements `media.probe` version `0.1.0` as the first executable capability block;
- adds serializable artifact, request, context, result, and structured error contracts;
- wraps `ffprobe` behind a provider boundary;
- enforces read-only workspace scoping;
- adds Python package discovery entry point and CLI adapter;
- adds unit, contract, negative-path, and real ffprobe smoke tests;
- adds GitHub Actions coverage for Python 3.12 and 3.13;
- promotes the registry entry from `idea` to `candidate` with durable evidence.

## Local verification

```text
Python 3.13.5
pytest 9.0.2
ffprobe 7.1.3
6 passed in 0.30s
manual CLI smoke test passed on a generated WAV file
```

## Honest boundary

This is `candidate`, not `validated`. Remaining work includes native Windows testing and integration into a real application workflow. A remote branch re-clone from the execution container was blocked because the container could not resolve `github.com`; the failure and delegation to PR CI are recorded in `capabilities/media-probe/VALIDATION.md`.
