### PR TITLE
Add local Block Studio for visual capability testing

### DIFF
--- a/.github/workflows/block-studio-tests.yml
+++ b/.github/workflows/block-studio-tests.yml
@@ -1,0 +1,64 @@
+name: Block Studio tests
+
+on:
+  pull_request:
+    paths:
+      - "apps/block-studio/**"
+      - "apps/README.md"
+      - "START_BLOCK_STUDIO.bat"
+      - "capabilities/media-probe/**"
+      - ".github/workflows/block-studio-tests.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/block-studio/**"
+      - "apps/README.md"
+      - "START_BLOCK_STUDIO.bat"
+      - "capabilities/media-probe/**"
+      - ".github/workflows/block-studio-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.13"]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            apps/block-studio/pyproject.toml
+            capabilities/media-probe/pyproject.toml
+
+      - name: Install ffprobe on Linux
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes ffmpeg
+
+      - name: Install ffprobe on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: choco install ffmpeg -y --no-progress
+
+      - name: Install local packages
+        run: python -m pip install -e capabilities/media-probe -e "apps/block-studio[dev]"
+
+      - name: Check JavaScript syntax
+        run: node --check apps/block-studio/src/peos_block_studio/static/app.js
+
+      - name: Run Block Studio tests
+        working-directory: apps/block-studio
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ desktop.ini
 Project-Execution-OS-Library-Portal/
 .obsidian/
 logs/api-runtime/
+.venv-block-studio/

--- a/START_BLOCK_STUDIO.bat
+++ b/START_BLOCK_STUDIO.bat
@@ -1,0 +1,26 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+set "VENV=%CD%\.venv-block-studio"
+
+if not exist "%VENV%\Scripts\python.exe" (
+  echo Creating Block Studio environment...
+  py -3 -m venv "%VENV%" 2>nul
+  if errorlevel 1 python -m venv "%VENV%"
+  if errorlevel 1 goto :error
+)
+
+echo Installing local Block Studio packages...
+"%VENV%\Scripts\python.exe" -m pip install --disable-pip-version-check -e "%CD%\capabilities\media-probe" -e "%CD%\apps\block-studio"
+if errorlevel 1 goto :error
+
+echo Opening Project Execution OS Block Studio...
+"%VENV%\Scripts\python.exe" -m peos_block_studio
+if errorlevel 1 goto :error
+exit /b 0
+
+:error
+echo.
+echo Block Studio could not start. Check Python and ffprobe installation.
+pause
+exit /b 1

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,15 @@
+# Applications
+
+This folder contains application adapters and user interfaces that compose reusable capability blocks.
+
+Rules:
+
+- applications may orchestrate capabilities and present UI;
+- reusable technical operations remain inside `capabilities/`;
+- application code must not duplicate a capability provider implementation;
+- applications depend on versioned capability contracts;
+- local validation tools remain separate from product-specific applications.
+
+## Current applications
+
+- `block-studio/` — local visual laboratory for opening, running, and inspecting capability blocks.

--- a/apps/block-studio/README.md
+++ b/apps/block-studio/README.md
@@ -1,0 +1,53 @@
+# Project Execution OS — Block Studio
+
+A local browser application for touching, viewing, and verifying reusable capability blocks.
+
+## What version 0.1.0 provides
+
+- capability library generated from the central registry and manifests;
+- fully interactive `media.probe` screen;
+- drag-and-drop upload;
+- local video/audio preview;
+- owner-friendly metadata cards;
+- stream table, raw JSON, execution log, contract, tests, and usage tabs;
+- owner/developer display modes;
+- environment health indicator;
+- no upload to external services.
+
+## Windows start
+
+Double-click at the repository root:
+
+```text
+START_BLOCK_STUDIO.bat
+```
+
+The launcher creates `.venv-block-studio`, installs the local capability and application packages, starts the server, and opens:
+
+```text
+http://127.0.0.1:8015
+```
+
+Runtime requirement:
+
+```text
+ffprobe
+```
+
+## Manual start
+
+```bash
+python -m venv .venv-block-studio
+.venv-block-studio/Scripts/python -m pip install -e capabilities/media-probe -e "apps/block-studio[dev]"
+.venv-block-studio/Scripts/python -m peos_block_studio
+```
+
+Linux/macOS uses `bin/python` instead of `Scripts/python`.
+
+## Safety
+
+- binds to `127.0.0.1` by default;
+- stores temporary uploads under `apps/block-studio/runtime/`;
+- does not use network APIs;
+- executes the original capability package instead of duplicating probing logic;
+- allows deletion of each temporary execution from the UI.

--- a/apps/block-studio/VALIDATION.md
+++ b/apps/block-studio/VALIDATION.md
@@ -1,0 +1,108 @@
+# Block Studio Validation Record
+
+Date: 2026-07-15
+Version: `0.1.0 candidate`
+
+## Local environment
+
+```text
+Python 3.13.5
+FastAPI 0.128.2
+Uvicorn 0.48.0
+pytest 9.0.2
+ffprobe 7.1.3
+Node syntax checker available
+```
+
+## Package and automated tests
+
+Commands:
+
+```bash
+python -m pip install -e capabilities/media-probe -e "apps/block-studio[dev]"
+cd apps/block-studio
+pytest -q
+node --check src/peos_block_studio/static/app.js
+```
+
+Result:
+
+```text
+5 passed in 1.55s
+JavaScript syntax check passed
+```
+
+Coverage includes:
+
+- registry and manifest discovery;
+- Python entry-point discovery for `media.probe`;
+- health and capability-library APIs;
+- real `ffprobe` execution through the Block Studio upload endpoint;
+- generated WAV input with duration and sample-rate verification;
+- local preview endpoint;
+- temporary execution deletion;
+- filename sanitization and execution-path protection.
+
+## Real MP4 integration smoke test
+
+A real local test MP4 was generated with:
+
+```text
+video: H.264, 320x240
+audio: AAC, 44100 Hz
+duration: 0.8 seconds
+```
+
+The running Block Studio server returned:
+
+```text
+health: ready
+ffprobe: available
+execution status: success
+duration: 0.8
+video: 320 x 240, h264
+audio: aac, 44100 Hz
+temporary execution deletion: success
+```
+
+The HTTP path was verified end to end:
+
+```text
+GET  /
+GET  /api/health
+POST /api/blocks/media.probe/run
+DELETE /api/executions/<execution-id>
+```
+
+## Visual QA
+
+The owner-mode layout was rendered in headless Chromium as a static visual fixture and inspected at 1440 pixels width.
+
+Verified visually:
+
+- library sidebar;
+- readiness/status badges;
+- file selection and preview area;
+- result cards;
+- owner/developer mode control;
+- responsive dark interface hierarchy.
+
+Direct headless-browser navigation to the local HTTP server was blocked by the execution environment policy with `ERR_BLOCKED_BY_ADMINISTRATOR`. Functional server and upload behavior were therefore verified separately through real HTTP requests, while the interface was rendered as a static browser fixture. No bypass was invented.
+
+## Portable artifact
+
+A portable ZIP was generated for owner testing:
+
+```text
+Block-Studio-v0.1.0-portable.zip
+```
+
+It contains the Windows launcher, Block Studio application, capability package, registry, and first-start instructions.
+
+## Promotion boundary
+
+Block Studio remains `candidate 0.1.0` until:
+
+- GitHub Actions passes on Linux and Windows;
+- the owner opens it on the target Windows computer;
+- a real user-owned media file is processed successfully.

--- a/apps/block-studio/VALIDATION.md
+++ b/apps/block-studio/VALIDATION.md
@@ -2,6 +2,7 @@
 
 Date: 2026-07-15
 Version: `0.1.0 candidate`
+Pull request: `https://github.com/oleg3479881328-code/Project-Execution-OS/pull/90`
 
 ## Local environment
 
@@ -74,6 +75,22 @@ POST /api/blocks/media.probe/run
 DELETE /api/executions/<execution-id>
 ```
 
+## GitHub Actions
+
+PR #90 completed successfully:
+
+```text
+Block Studio tests — success
+Ubuntu / Python 3.13 — success
+Windows / Python 3.13 — success
+ffprobe installation — success
+real ffprobe API smoke test — success
+JavaScript syntax check — success
+Validate Project OS Integrity — success
+```
+
+The Windows job provides automated native Windows evidence for local paths, package installation, ffprobe discovery, upload execution, preview delivery, and cleanup.
+
 ## Visual QA
 
 The owner-mode layout was rendered in headless Chromium as a static visual fixture and inspected at 1440 pixels width.
@@ -103,6 +120,7 @@ It contains the Windows launcher, Block Studio application, capability package, 
 
 Block Studio remains `candidate 0.1.0` until:
 
-- GitHub Actions passes on Linux and Windows;
 - the owner opens it on the target Windows computer;
 - a real user-owned media file is processed successfully.
+
+Automated Linux and Windows validation is complete.

--- a/apps/block-studio/pyproject.toml
+++ b/apps/block-studio/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "peos-block-studio"
+version = "0.1.0"
+description = "Local visual laboratory for Project Execution OS capability blocks."
+readme = "README.md"
+requires-python = ">=3.12"
+license = "MIT"
+authors = [{ name = "Oleg / Project Execution OS" }]
+dependencies = [
+  "fastapi>=0.128,<1",
+  "uvicorn>=0.35,<1",
+  "python-multipart>=0.0.20,<1",
+  "PyYAML>=6,<7",
+]
+
+[project.optional-dependencies]
+dev = [
+  "httpx>=0.28,<1",
+  "pytest>=8,<10",
+]
+
+[project.scripts]
+peos-block-studio = "peos_block_studio.__main__:main"
+
+[tool.setuptools.package-data]
+peos_block_studio = ["static/*"]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]

--- a/apps/block-studio/runtime/.gitignore
+++ b/apps/block-studio/runtime/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/apps/block-studio/src/peos_block_studio/__init__.py
+++ b/apps/block-studio/src/peos_block_studio/__init__.py
@@ -1,0 +1,3 @@
+"""Project Execution OS Block Studio."""
+
+__version__ = "0.1.0"

--- a/apps/block-studio/src/peos_block_studio/__main__.py
+++ b/apps/block-studio/src/peos_block_studio/__main__.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import argparse
+import threading
+import webbrowser
+
+import uvicorn
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run Project Execution OS Block Studio locally.")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8015)
+    parser.add_argument("--no-browser", action="store_true")
+    args = parser.parse_args()
+
+    url = f"http://{args.host}:{args.port}"
+    if not args.no_browser:
+        threading.Timer(1.2, lambda: webbrowser.open(url)).start()
+    uvicorn.run("peos_block_studio.app:app", host=args.host, port=args.port, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/block-studio/src/peos_block_studio/app.py
+++ b/apps/block-studio/src/peos_block_studio/app.py
@@ -1,0 +1,187 @@
+"""FastAPI application adapter for the local Block Studio."""
+from __future__ import annotations
+
+import asyncio
+import mimetypes
+import shutil
+import time
+from datetime import datetime, timezone
+from functools import lru_cache
+from importlib import metadata
+from pathlib import Path
+from typing import Annotated, Any, Callable
+from uuid import uuid4
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from peos_media_probe import ArtifactRef, BlockContext, BlockRequest
+
+from .catalog import block_detail, build_catalog, find_repo_root
+from .storage import ExecutionStorage
+
+MAX_UPLOAD_MB = 2048
+CHUNK_SIZE = 1024 * 1024
+BlockLoader = Callable[[str], Any]
+
+
+@lru_cache(maxsize=16)
+def load_capability(block_id: str) -> Any:
+    try:
+        points = metadata.entry_points(group="project_execution_os.capabilities")
+    except TypeError:
+        points = metadata.entry_points().select(group="project_execution_os.capabilities")
+    for point in points:
+        factory = point.load()
+        block = factory()
+        if getattr(block, "block_id", None) == block_id:
+            return block
+    raise LookupError(f"Capability is not installed: {block_id}")
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+
+def create_app(
+    *,
+    repo_root: Path | None = None,
+    runtime_root: Path | None = None,
+    block_loader: BlockLoader | None = None,
+) -> FastAPI:
+    root = (repo_root or find_repo_root()).resolve()
+    runtime = (runtime_root or root / "apps" / "block-studio" / "runtime").resolve()
+    storage = ExecutionStorage(runtime)
+    loader = block_loader or load_capability
+    static_root = Path(__file__).resolve().parent / "static"
+
+    app = FastAPI(title="Project Execution OS — Block Studio", version="0.1.0")
+    app.state.repo_root = root
+    app.state.storage = storage
+    app.state.block_loader = loader
+    app.mount("/assets", StaticFiles(directory=static_root), name="assets")
+
+    @app.get("/", include_in_schema=False)
+    def index() -> FileResponse:
+        return FileResponse(static_root / "index.html")
+
+    @app.get("/api/health")
+    def health() -> dict[str, Any]:
+        ffprobe_path = shutil.which("ffprobe")
+        catalog = build_catalog(root)
+        return {
+            "status": "ready" if ffprobe_path else "degraded",
+            "studio_version": "0.1.0",
+            "local_only": True,
+            "ffprobe": {"available": bool(ffprobe_path), "path": ffprobe_path},
+            "installed_blocks": [block.block_id for block in catalog if block.installed],
+            "interactive_blocks": [block.block_id for block in catalog if block.interactive],
+        }
+
+    @app.get("/api/blocks")
+    def blocks() -> list[dict[str, Any]]:
+        return [block.to_dict() for block in build_catalog(root)]
+
+    @app.get("/api/blocks/{block_id}")
+    def block(block_id: str) -> dict[str, Any]:
+        payload = block_detail(block_id, root)
+        if payload is None:
+            raise HTTPException(status_code=404, detail="Capability block not found")
+        return payload
+
+    @app.post("/api/blocks/media.probe/run")
+    async def run_media_probe(
+        file: Annotated[UploadFile, File(...)],
+        timeout_seconds: Annotated[float, Form()] = 30.0,
+    ) -> dict[str, Any]:
+        if timeout_seconds <= 0 or timeout_seconds > 600:
+            raise HTTPException(status_code=400, detail="Timeout must be between 0 and 600 seconds")
+
+        execution_id, stored_path, stored_metadata = storage.create(file.filename, file.content_type)
+        logs: list[dict[str, Any]] = []
+        started = time.perf_counter()
+
+        def log(level: str, message: str, **details: Any) -> None:
+            logs.append({"time": _now(), "level": level, "message": message, "details": details})
+
+        try:
+            log("info", "Upload started", filename=stored_metadata["original_filename"])
+            size_bytes = 0
+            with stored_path.open("wb") as destination:
+                while chunk := await file.read(CHUNK_SIZE):
+                    size_bytes += len(chunk)
+                    if size_bytes > MAX_UPLOAD_MB * 1024 * 1024:
+                        raise HTTPException(status_code=413, detail=f"File exceeds {MAX_UPLOAD_MB} MB limit")
+                    destination.write(chunk)
+            await file.close()
+            log("info", "Upload stored locally", size_bytes=size_bytes, workspace=str(stored_path.parent))
+
+            def progress(fraction: float, message: str) -> None:
+                log("progress", message, percent=round(fraction * 100, 1))
+
+            try:
+                capability = loader("media.probe")
+            except Exception as exc:
+                log("error", "Capability loading failed", exception_type=type(exc).__name__)
+                raise HTTPException(status_code=503, detail="media.probe capability is not installed") from exc
+
+            request = BlockRequest(
+                request_id=f"studio_{uuid4().hex}",
+                input_artifacts=(
+                    ArtifactRef(
+                        artifact_id=f"upload_{execution_id}",
+                        kind="video" if (file.content_type or "").startswith("video/") else "audio" if (file.content_type or "").startswith("audio/") else "media",
+                        uri=stored_path.as_uri(),
+                        mime_type=file.content_type,
+                        size_bytes=size_bytes,
+                        metadata={"original_filename": stored_metadata["original_filename"], "source": "block-studio"},
+                    ),
+                ),
+            )
+            context = BlockContext(
+                workspace=stored_path.parent,
+                timeout_seconds=timeout_seconds,
+                progress_reporter=progress,
+            )
+            result = await asyncio.to_thread(capability.run, request, context)
+            result_payload = result.to_dict()
+            log("info" if result.status == "success" else "error", "Capability execution finished", status=result.status)
+            elapsed_ms = round((time.perf_counter() - started) * 1000, 3)
+            return {
+                "execution_id": execution_id,
+                "filename": stored_metadata["original_filename"],
+                "mime_type": file.content_type or mimetypes.guess_type(str(stored_path))[0] or "application/octet-stream",
+                "size_bytes": size_bytes,
+                "preview_url": f"/api/executions/{execution_id}/file",
+                "result": result_payload,
+                "logs": logs,
+                "studio_metrics": {"total_elapsed_ms": elapsed_ms},
+            }
+        except HTTPException:
+            storage.delete(execution_id)
+            raise
+        except Exception as exc:
+            log("error", "Unhandled studio adapter failure", exception_type=type(exc).__name__)
+            storage.delete(execution_id)
+            raise HTTPException(status_code=500, detail="Block Studio could not process the file") from exc
+
+    @app.get("/api/executions/{execution_id}/file")
+    def execution_file(execution_id: str) -> FileResponse:
+        try:
+            file_path, metadata_payload = storage.resolve_file(execution_id)
+        except (FileNotFoundError, ValueError):
+            raise HTTPException(status_code=404, detail="Execution file not found") from None
+        media_type = metadata_payload.get("mime_type") or mimetypes.guess_type(file_path.name)[0]
+        return FileResponse(file_path, media_type=media_type, filename=str(metadata_payload.get("original_filename") or file_path.name), content_disposition_type="inline")
+
+    @app.delete("/api/executions/{execution_id}")
+    def delete_execution(execution_id: str) -> dict[str, bool]:
+        if not storage.delete(execution_id):
+            raise HTTPException(status_code=404, detail="Execution not found")
+        return {"deleted": True}
+
+    return app
+
+
+app = create_app()

--- a/apps/block-studio/src/peos_block_studio/catalog.py
+++ b/apps/block-studio/src/peos_block_studio/catalog.py
@@ -1,0 +1,168 @@
+"""Capability catalog assembled from the central registry, manifests, and entry points."""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+_DESCRIPTIONS = {
+    "media.download": ("Скачивание медиа", "Получает разрешённый источник и создаёт локальный media artifact."),
+    "media.probe": ("Анализ медиа", "Показывает длительность, кодеки, разрешение, FPS, аудио и потоки файла."),
+    "media.extract_audio": ("Извлечение аудио", "Создаёт нормализованный аудиофайл из видео или другого медиа."),
+    "media.transcribe": ("Транскрибация", "Преобразует речь в текст с сегментами и тайм-кодами."),
+    "media.clip": ("Нарезка видео", "Вырезает один или несколько точных фрагментов из исходного файла."),
+    "media.generate_captions": ("Генерация субтитров", "Создаёт SRT, VTT или ASS из transcript artifact."),
+    "media.render_vertical": ("Вертикальный рендер", "Собирает ролик под Reels, Shorts и TikTok."),
+}
+
+
+@dataclass(slots=True)
+class CatalogBlock:
+    block_id: str
+    title: str
+    description: str
+    status: str
+    version: str
+    provider: str
+    inputs: str
+    outputs: str
+    implementation_location: str
+    limitations: str
+    installed: bool
+    interactive: bool
+    manifest: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def find_repo_root(start: Path | None = None) -> Path:
+    current = (start or Path(__file__)).resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / "capability-library" / "REGISTRY.md").exists():
+            return candidate
+    raise RuntimeError("Project Execution OS repository root was not found")
+
+
+def parse_registry(path: Path) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    headers: list[str] | None = None
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip().strip("`") for cell in line.strip("|").split("|")]
+        if not cells or all(set(cell) <= {"-", ":"} for cell in cells):
+            continue
+        if cells[0] == "Block ID":
+            headers = cells
+            continue
+        if headers and len(cells) >= len(headers):
+            rows.append(dict(zip(headers, cells, strict=False)))
+    return rows
+
+
+def _load_manifests(repo_root: Path) -> dict[str, dict[str, Any]]:
+    manifests: dict[str, dict[str, Any]] = {}
+    capability_root = repo_root / "capabilities"
+    if not capability_root.exists():
+        return manifests
+    for path in capability_root.glob("*/manifest.yaml"):
+        try:
+            payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except (OSError, yaml.YAMLError):
+            continue
+        block_id = payload.get("block_id")
+        if isinstance(block_id, str):
+            manifests[block_id] = payload
+    return manifests
+
+
+def discover_installed_capabilities() -> set[str]:
+    installed: set[str] = set()
+    try:
+        entry_points = metadata.entry_points(group="project_execution_os.capabilities")
+    except TypeError:
+        entry_points = metadata.entry_points().select(group="project_execution_os.capabilities")
+    for entry_point in entry_points:
+        try:
+            factory = entry_point.load()
+            block = factory()
+            block_id = getattr(block, "block_id", None)
+            if isinstance(block_id, str):
+                installed.add(block_id)
+        except Exception:
+            continue
+    return installed
+
+
+def build_catalog(repo_root: Path | None = None) -> list[CatalogBlock]:
+    root = repo_root or find_repo_root()
+    rows = parse_registry(root / "capability-library" / "REGISTRY.md")
+    manifests = _load_manifests(root)
+    installed = discover_installed_capabilities()
+    result: list[CatalogBlock] = []
+
+    for row in rows:
+        block_id = row.get("Block ID", "")
+        if not block_id:
+            continue
+        title, description = _DESCRIPTIONS.get(block_id, (block_id, "Reusable capability block."))
+        manifest = manifests.get(block_id)
+        providers = row.get("Initial providers", "—")
+        if manifest and manifest.get("providers"):
+            providers = ", ".join(str(value) for value in manifest["providers"])
+        version = str((manifest or {}).get("version") or row.get("Version") or "—")
+        status = str((manifest or {}).get("status") or row.get("Status") or "idea")
+        is_installed = block_id in installed
+        result.append(
+            CatalogBlock(
+                block_id=block_id,
+                title=title,
+                description=description,
+                status=status,
+                version=version,
+                provider=providers,
+                inputs=row.get("Inputs", "—"),
+                outputs=row.get("Outputs", "—"),
+                implementation_location=row.get("Implementation location", "not created"),
+                limitations=row.get("Known limitations", "—"),
+                installed=is_installed,
+                interactive=is_installed and block_id == "media.probe",
+                manifest=manifest,
+            )
+        )
+    return result
+
+
+def block_detail(block_id: str, repo_root: Path | None = None) -> dict[str, Any] | None:
+    root = repo_root or find_repo_root()
+    for block in build_catalog(root):
+        if block.block_id != block_id:
+            continue
+        payload = block.to_dict()
+        validation_path = root / "capabilities" / "media-probe" / "VALIDATION.md"
+        validation = validation_path.read_text(encoding="utf-8") if validation_path.exists() else ""
+        payload["tests"] = {
+            "local": "6 passed" if "6 passed" in validation else "not recorded",
+            "github_ci": "success" if "media.probe tests — success" in validation else "not recorded",
+            "integrity_ci": "success" if "Validate Project OS Integrity — success" in validation else "not recorded",
+            "windows": "pending" if "native Windows" in validation else "unknown",
+            "application_integration": "pending" if "not yet been integrated" in validation else "unknown",
+        }
+        payload["contract"] = {
+            "operation": "local media artifact → normalized media metadata",
+            "request": ["request_id", "input_artifacts", "parameters", "provider", "idempotency_key"],
+            "result": ["status", "output_artifacts", "metadata", "warnings", "metrics", "error"],
+            "permissions": ["workspace read-only", "ffprobe subprocess", "no network", "no secrets"],
+        }
+        payload["usage"] = {
+            "cli": "peos-media-probe input.mp4 --pretty",
+            "python": "create_block().run(BlockRequest(...), BlockContext(workspace=...))",
+        }
+        return payload
+    return None

--- a/apps/block-studio/src/peos_block_studio/static/app.css
+++ b/apps/block-studio/src/peos_block_studio/static/app.css
@@ -1,0 +1,150 @@
+:root {
+  --bg: #0d1117;
+  --panel: #151b23;
+  --panel-2: #1b2330;
+  --panel-3: #10161f;
+  --text: #f5f7fa;
+  --muted: #98a6b8;
+  --line: #293445;
+  --accent: #7c9cff;
+  --accent-2: #9cb2ff;
+  --green: #4fd1a1;
+  --yellow: #f2c66d;
+  --red: #ff7b86;
+  --blue: #69b7ff;
+  --shadow: 0 18px 50px rgba(0,0,0,.28);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+* { box-sizing: border-box; }
+body { margin: 0; background: radial-gradient(circle at 80% -10%, rgba(124,156,255,.13), transparent 32%), var(--bg); color: var(--text); min-height: 100vh; }
+button, input { font: inherit; }
+button { cursor: pointer; }
+.hidden { display: none !important; }
+.app-shell { min-height: 100vh; }
+.topbar { min-height: 92px; padding: 20px 28px; border-bottom: 1px solid var(--line); display:flex; justify-content:space-between; align-items:center; background: rgba(13,17,23,.88); backdrop-filter: blur(20px); position: sticky; top:0; z-index:20; }
+.eyebrow { color: var(--accent-2); font-size:11px; letter-spacing:.19em; font-weight:800; }
+h1 { margin:3px 0 0; font-size:27px; line-height:1; }
+.topbar-actions { display:flex; gap:14px; align-items:center; }
+.health-badge { display:flex; align-items:center; gap:8px; font-size:13px; color:var(--muted); border:1px solid var(--line); padding:9px 12px; border-radius:999px; background:var(--panel); }
+.health-badge span { width:8px; height:8px; border-radius:50%; background:var(--yellow); box-shadow:0 0 14px currentColor; }
+.health-badge.ready span { background:var(--green); }
+.health-badge.degraded span { background:var(--red); }
+.mode-switch { display:flex; border:1px solid var(--line); border-radius:11px; padding:3px; background:var(--panel); }
+.mode-button { border:0; background:transparent; color:var(--muted); padding:8px 12px; border-radius:8px; font-size:13px; font-weight:700; }
+.mode-button.active { background:var(--panel-2); color:var(--text); box-shadow:0 4px 14px rgba(0,0,0,.25); }
+.workspace { display:grid; grid-template-columns:300px minmax(0,1fr); min-height:calc(100vh - 92px); }
+.sidebar { border-right:1px solid var(--line); padding:22px 16px; background:rgba(16,22,31,.72); display:flex; flex-direction:column; gap:14px; }
+.sidebar-heading { display:flex; justify-content:space-between; padding:0 8px; color:var(--muted); text-transform:uppercase; letter-spacing:.11em; font-size:11px; font-weight:800; }
+.count-pill { background:var(--panel-2); color:var(--text); padding:2px 8px; border-radius:999px; }
+.block-list { display:flex; flex-direction:column; gap:8px; }
+.block-card { width:100%; border:1px solid transparent; background:transparent; color:inherit; text-align:left; border-radius:14px; padding:13px; transition:.18s ease; }
+.block-card:hover { background:var(--panel); border-color:var(--line); transform:translateY(-1px); }
+.block-card.active { background:linear-gradient(135deg, rgba(124,156,255,.14), rgba(124,156,255,.05)); border-color:rgba(124,156,255,.45); box-shadow:inset 3px 0 0 var(--accent); }
+.block-card-top { display:flex; justify-content:space-between; gap:10px; align-items:center; }
+.block-id { font-weight:800; font-size:14px; }
+.block-card p { margin:6px 0 0; font-size:12px; line-height:1.45; color:var(--muted); }
+.status-dot { width:8px; height:8px; border-radius:50%; flex:0 0 auto; }
+.status-dot.idea { background:#6b7787; }
+.status-dot.candidate { background:var(--yellow); }
+.status-dot.validated { background:var(--blue); }
+.status-dot.production { background:var(--green); }
+.privacy-note { margin-top:auto; border:1px solid var(--line); background:var(--panel-3); border-radius:14px; padding:14px; display:flex; flex-direction:column; gap:4px; }
+.privacy-note strong { font-size:13px; }
+.privacy-note span { font-size:12px; color:var(--muted); line-height:1.4; }
+.content { padding:28px; max-width:1400px; width:100%; margin:0 auto; }
+.hero-card { display:grid; grid-template-columns:1fr 260px; gap:22px; border:1px solid var(--line); border-radius:20px; background:linear-gradient(135deg, var(--panel), var(--panel-3)); padding:24px; box-shadow:var(--shadow); }
+.block-kicker { display:flex; gap:10px; align-items:center; font-family:ui-monospace, SFMono-Regular, Menlo, monospace; color:var(--accent-2); font-size:13px; }
+.status-badge { padding:4px 9px; border-radius:999px; font-family:inherit; font-size:10px; letter-spacing:.08em; text-transform:uppercase; font-weight:900; }
+.status-badge.idea { background:rgba(107,119,135,.16); color:#abb6c3; }
+.status-badge.candidate { background:rgba(242,198,109,.14); color:var(--yellow); }
+.status-badge.validated { background:rgba(105,183,255,.14); color:var(--blue); }
+.status-badge.production { background:rgba(79,209,161,.14); color:var(--green); }
+.hero-card h2 { margin:12px 0 8px; font-size:32px; }
+.hero-card p { color:var(--muted); margin:0; line-height:1.55; max-width:750px; }
+.meta-row { display:flex; gap:20px; margin-top:18px; color:var(--muted); font-size:13px; }
+.meta-row strong { color:var(--text); margin-left:4px; }
+.readiness-card { border:1px solid var(--line); background:rgba(255,255,255,.025); border-radius:16px; padding:17px; }
+.readiness-label { color:var(--muted); font-size:11px; text-transform:uppercase; letter-spacing:.12em; }
+.readiness-value { font-size:22px; font-weight:850; margin:8px 0 5px; }
+.readiness-text { font-size:12px; color:var(--muted); line-height:1.45; }
+.interactive-area { display:flex; flex-direction:column; gap:20px; margin-top:20px; }
+.panel { border:1px solid var(--line); border-radius:20px; background:var(--panel); padding:22px; box-shadow:0 12px 30px rgba(0,0,0,.16); }
+.panel-heading { display:flex; justify-content:space-between; align-items:center; gap:20px; margin-bottom:18px; }
+.panel-heading > div:first-child { display:flex; gap:13px; align-items:center; }
+.panel-heading h3 { margin:0 0 3px; font-size:18px; }
+.panel-heading p { margin:0; color:var(--muted); font-size:13px; }
+.step-number { width:31px; height:31px; border-radius:10px; background:rgba(124,156,255,.14); color:var(--accent-2); display:grid; place-items:center; font-weight:900; }
+.step-number.success { background:rgba(79,209,161,.14); color:var(--green); }
+.ghost-button { background:transparent; border:1px solid var(--line); color:var(--muted); border-radius:10px; padding:8px 12px; }
+.ghost-button:hover { color:var(--text); border-color:#46556c; }
+.drop-zone { min-height:230px; border:1.5px dashed #3b4b62; border-radius:17px; background:linear-gradient(180deg, rgba(124,156,255,.035), transparent); display:flex; flex-direction:column; align-items:center; justify-content:center; gap:8px; transition:.18s ease; padding:26px; text-align:center; }
+.drop-zone:hover, .drop-zone.dragover { border-color:var(--accent); background:rgba(124,156,255,.08); transform:translateY(-1px); }
+.drop-zone input { display:none; }
+.drop-icon { width:52px; height:52px; display:grid; place-items:center; border-radius:16px; background:rgba(124,156,255,.14); color:var(--accent-2); font-size:30px; }
+.drop-zone strong { font-size:18px; }
+.drop-zone span { color:var(--muted); }
+.drop-zone small { margin-top:10px; color:#748399; }
+.file-summary { margin-top:14px; border:1px solid var(--line); background:var(--panel-3); border-radius:14px; padding:12px; display:flex; gap:12px; align-items:center; }
+.file-icon { width:58px; height:44px; display:grid; place-items:center; border-radius:10px; background:rgba(124,156,255,.12); color:var(--accent-2); font-size:10px; font-weight:900; letter-spacing:.08em; }
+.file-copy { display:flex; flex-direction:column; gap:3px; min-width:0; flex:1; }
+.file-copy strong { white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.file-copy span { color:var(--muted); font-size:12px; }
+.mini-badge { color:var(--green); font-size:11px; font-weight:800; text-transform:uppercase; letter-spacing:.06em; }
+.preview-wrap { margin-top:14px; background:#070a0e; border:1px solid var(--line); border-radius:16px; min-height:120px; display:grid; place-items:center; overflow:hidden; }
+.media-preview { width:100%; max-height:420px; background:#000; }
+.audio-preview { width:min(720px,90%); margin:35px auto; }
+.generic-preview { color:var(--muted); padding:30px; }
+.run-row { display:flex; gap:14px; align-items:center; margin-top:16px; }
+.primary-button { border:0; border-radius:12px; background:linear-gradient(135deg, var(--accent), #6689ff); color:#08101f; font-weight:900; padding:13px 18px; min-width:235px; display:flex; align-items:center; justify-content:center; gap:10px; box-shadow:0 10px 24px rgba(124,156,255,.22); }
+.primary-button:disabled { cursor:not-allowed; filter:grayscale(.7); opacity:.45; box-shadow:none; }
+.run-hint { color:var(--muted); font-size:13px; }
+.spinner { width:16px; height:16px; border:2px solid rgba(8,16,31,.3); border-top-color:#08101f; border-radius:50%; animation:spin .7s linear infinite; }
+@keyframes spin { to { transform:rotate(360deg); } }
+.execution-status { font-size:11px; font-weight:900; letter-spacing:.1em; padding:7px 10px; border-radius:999px; }
+.execution-status.success { background:rgba(79,209,161,.14); color:var(--green); }
+.execution-status.failed { background:rgba(255,123,134,.14); color:var(--red); }
+.warning-list { margin:0 0 14px; display:flex; flex-direction:column; gap:7px; }
+.warning-item { border-left:3px solid var(--yellow); background:rgba(242,198,109,.07); color:#e8d7ad; padding:10px 12px; border-radius:8px; font-size:13px; }
+.summary-grid { display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:12px; }
+.summary-card { border:1px solid var(--line); border-radius:14px; background:var(--panel-3); padding:14px; min-height:92px; }
+.summary-card span { color:var(--muted); font-size:11px; text-transform:uppercase; letter-spacing:.08em; }
+.summary-card strong { display:block; margin-top:8px; font-size:19px; word-break:break-word; }
+.tabs { display:flex; gap:5px; border-bottom:1px solid var(--line); margin-top:22px; overflow:auto; }
+.tab { border:0; background:transparent; color:var(--muted); padding:11px 12px; white-space:nowrap; border-bottom:2px solid transparent; }
+.tab.active { color:var(--text); border-bottom-color:var(--accent); }
+.tab-panel { display:none; padding-top:18px; }
+.tab-panel.active { display:block; }
+body[data-mode="owner"] .developer-only { display:none; }
+.detail-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:12px; }
+.detail-row { border:1px solid var(--line); border-radius:12px; background:var(--panel-3); padding:12px; display:flex; justify-content:space-between; gap:16px; }
+.detail-row span { color:var(--muted); }
+.stream-table { width:100%; border-collapse:collapse; font-size:13px; }
+.stream-table th, .stream-table td { padding:11px; border-bottom:1px solid var(--line); text-align:left; }
+.stream-table th { color:var(--muted); font-size:11px; text-transform:uppercase; letter-spacing:.07em; }
+.code-block { background:#090d13; border:1px solid var(--line); border-radius:13px; padding:16px; overflow:auto; color:#c4d3ef; line-height:1.52; font-size:12px; max-height:520px; }
+.log-list { display:flex; flex-direction:column; gap:7px; }
+.log-entry { display:grid; grid-template-columns:110px 80px 1fr; gap:10px; padding:9px 10px; border-bottom:1px solid var(--line); font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:12px; }
+.log-entry .time { color:#738399; }
+.log-entry .level { font-weight:900; }
+.log-entry .level.info { color:var(--blue); }
+.log-entry .level.progress { color:var(--yellow); }
+.log-entry .level.error { color:var(--red); }
+.contract-grid, .test-grid, .usage-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:12px; }
+.info-card { border:1px solid var(--line); border-radius:14px; padding:14px; background:var(--panel-3); }
+.info-card h4 { margin:0 0 9px; }
+.info-card p, .info-card li { color:var(--muted); font-size:13px; line-height:1.5; }
+.info-card ul { padding-left:18px; margin:0; }
+.test-line { display:flex; justify-content:space-between; align-items:center; gap:14px; border-bottom:1px solid var(--line); padding:10px 0; }
+.test-line:last-child { border-bottom:0; }
+.test-state { font-size:11px; text-transform:uppercase; font-weight:900; }
+.test-state.success { color:var(--green); }
+.test-state.pending { color:var(--yellow); }
+.coming-soon { margin-top:20px; text-align:center; min-height:330px; display:flex; flex-direction:column; justify-content:center; align-items:center; }
+.coming-icon { font-size:54px; color:#66758a; }
+.coming-soon p { color:var(--muted); max-width:560px; }
+.coming-path { margin-top:18px; border:1px solid var(--line); border-radius:13px; padding:12px 16px; display:flex; gap:16px; color:var(--muted); }
+.coming-path strong { color:var(--yellow); }
+.toast { position:fixed; right:24px; bottom:24px; z-index:50; background:#222b38; border:1px solid #3a4658; border-radius:12px; padding:13px 16px; box-shadow:var(--shadow); max-width:380px; }
+@media (max-width:1100px) { .workspace{grid-template-columns:250px minmax(0,1fr)} .summary-grid{grid-template-columns:repeat(2,1fr)} .hero-card{grid-template-columns:1fr} }
+@media (max-width:780px) { .topbar{align-items:flex-start;gap:14px;flex-direction:column}.topbar-actions{width:100%;justify-content:space-between}.workspace{display:block}.sidebar{border-right:0;border-bottom:1px solid var(--line)}.block-list{display:grid;grid-template-columns:repeat(2,1fr)}.privacy-note{display:none}.content{padding:16px}.summary-grid,.detail-grid,.contract-grid,.test-grid,.usage-grid{grid-template-columns:1fr}.run-row{align-items:stretch;flex-direction:column}.primary-button{width:100%}.hero-card h2{font-size:27px} }
+@media (max-width:520px) { .block-list{grid-template-columns:1fr}.topbar-actions{align-items:flex-start;flex-direction:column}.mode-switch{width:100%}.mode-button{flex:1}.summary-grid{grid-template-columns:1fr}.log-entry{grid-template-columns:1fr}.meta-row{flex-direction:column;gap:6px} }

--- a/apps/block-studio/src/peos_block_studio/static/app.js
+++ b/apps/block-studio/src/peos_block_studio/static/app.js
@@ -1,0 +1,292 @@
+const state = {
+  blocks: [],
+  selectedBlock: null,
+  selectedFile: null,
+  executionId: null,
+  result: null,
+  detail: null,
+  objectUrl: null,
+};
+
+const $ = (id) => document.getElementById(id);
+const els = {
+  healthBadge: $("healthBadge"), blockList: $("blockList"), blockCount: $("blockCount"),
+  selectedBlockId: $("selectedBlockId"), selectedStatus: $("selectedStatus"), selectedTitle: $("selectedTitle"),
+  selectedDescription: $("selectedDescription"), selectedVersion: $("selectedVersion"), selectedProvider: $("selectedProvider"),
+  readinessValue: $("readinessValue"), readinessText: $("readinessText"), interactiveArea: $("interactiveArea"),
+  comingSoon: $("comingSoon"), comingTitle: $("comingTitle"), comingText: $("comingText"), comingStatus: $("comingStatus"),
+  dropZone: $("dropZone"), fileInput: $("fileInput"), fileSummary: $("fileSummary"), fileName: $("fileName"),
+  fileSize: $("fileSize"), fileTypeIcon: $("fileTypeIcon"), previewWrap: $("previewWrap"), videoPreview: $("videoPreview"),
+  audioPreview: $("audioPreview"), genericPreview: $("genericPreview"), runButton: $("runButton"), runButtonText: $("runButtonText"),
+  spinner: $("spinner"), runHint: $("runHint"), clearButton: $("clearButton"), resultPanel: $("resultPanel"),
+  resultSubtitle: $("resultSubtitle"), executionStatus: $("executionStatus"), warningList: $("warningList"),
+  summaryCards: $("summaryCards"), rawJson: $("rawJson"), logList: $("logList"), toast: $("toast"),
+};
+
+function formatBytes(value) {
+  if (value == null) return "—";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let size = Number(value), index = 0;
+  while (size >= 1024 && index < units.length - 1) { size /= 1024; index += 1; }
+  return `${size >= 100 || index === 0 ? size.toFixed(0) : size.toFixed(1)} ${units[index]}`;
+}
+
+function formatDuration(value) {
+  if (value == null || Number.isNaN(Number(value))) return "—";
+  const total = Number(value);
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const seconds = Math.floor(total % 60);
+  const millis = Math.round((total - Math.floor(total)) * 1000);
+  const body = `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+  return `${hours ? `${hours}:${body}` : body}${millis ? `.${String(millis).padStart(3, "0")}` : ""}`;
+}
+
+function showToast(message) {
+  els.toast.textContent = message;
+  els.toast.classList.remove("hidden");
+  window.setTimeout(() => els.toast.classList.add("hidden"), 3200);
+}
+
+async function api(url, options = {}) {
+  const response = await fetch(url, options);
+  let payload = null;
+  try { payload = await response.json(); } catch (_) { payload = null; }
+  if (!response.ok) throw new Error(payload?.detail || `HTTP ${response.status}`);
+  return payload;
+}
+
+function statusLabel(status) {
+  return ({idea:"Idea", candidate:"Candidate", validated:"Validated", production:"Production"})[status] || status;
+}
+
+function renderBlocks() {
+  els.blockCount.textContent = state.blocks.length;
+  els.blockList.innerHTML = state.blocks.map(block => `
+    <button class="block-card ${block.block_id === state.selectedBlock?.block_id ? "active" : ""}" data-block-id="${block.block_id}">
+      <div class="block-card-top"><span class="block-id">${block.block_id}</span><span class="status-dot ${block.status}" title="${block.status}"></span></div>
+      <p>${block.title}${block.interactive ? " · можно запустить" : ""}</p>
+    </button>`).join("");
+  document.querySelectorAll(".block-card").forEach(button => button.addEventListener("click", () => selectBlock(button.dataset.blockId)));
+}
+
+async function selectBlock(blockId) {
+  const block = state.blocks.find(item => item.block_id === blockId);
+  if (!block) return;
+  state.selectedBlock = block;
+  renderBlocks();
+  els.selectedBlockId.textContent = block.block_id;
+  els.selectedTitle.textContent = block.title;
+  els.selectedDescription.textContent = block.description;
+  els.selectedVersion.textContent = block.version;
+  els.selectedProvider.textContent = block.provider;
+  els.selectedStatus.textContent = block.status;
+  els.selectedStatus.className = `status-badge ${block.status}`;
+  els.readinessValue.textContent = statusLabel(block.status);
+  els.readinessText.textContent = block.status === "idea"
+    ? "Архитектура и назначение определены. Исполняемого кода пока нет."
+    : block.status === "candidate"
+      ? "Код и минимальные тесты есть. Реальная интеграция ещё проверяется."
+      : "Блок прошёл реальную интеграцию.";
+
+  if (block.interactive) {
+    els.interactiveArea.classList.remove("hidden");
+    els.comingSoon.classList.add("hidden");
+    state.detail = await api(`/api/blocks/${encodeURIComponent(block.block_id)}`);
+    renderStaticTabs();
+  } else {
+    els.interactiveArea.classList.add("hidden");
+    els.comingSoon.classList.remove("hidden");
+    els.comingTitle.textContent = `${block.title} пока не реализован`;
+    els.comingText.textContent = `${block.description} Статус реестра: ${block.status}. ${block.limitations || ""}`;
+    els.comingStatus.textContent = `${block.status} → candidate`;
+  }
+}
+
+function renderStaticTabs() {
+  if (!state.detail) return;
+  const contract = state.detail.contract || {};
+  $("tab-contract").innerHTML = `
+    <div class="contract-grid">
+      <div class="info-card"><h4>Операция</h4><p>${contract.operation || "—"}</p></div>
+      <div class="info-card"><h4>Права</h4><ul>${(contract.permissions || []).map(x => `<li>${x}</li>`).join("")}</ul></div>
+      <div class="info-card"><h4>BlockRequest</h4><ul>${(contract.request || []).map(x => `<li><code>${x}</code></li>`).join("")}</ul></div>
+      <div class="info-card"><h4>BlockResult</h4><ul>${(contract.result || []).map(x => `<li><code>${x}</code></li>`).join("")}</ul></div>
+    </div>`;
+  const tests = state.detail.tests || {};
+  $("tab-tests").innerHTML = `<div class="test-grid"><div class="info-card"><h4>Проверки готовности</h4>${Object.entries(tests).map(([key, value]) => {
+    const success = value === "success" || String(value).includes("passed");
+    return `<div class="test-line"><span>${key.replaceAll("_", " ")}</span><strong class="test-state ${success ? "success" : "pending"}">${value}</strong></div>`;
+  }).join("")}</div><div class="info-card"><h4>Что означает Candidate</h4><p>Блок существует и проходит минимальные проверки. До Validated нужны Windows-проверка и подключение к реальному приложению.</p></div></div>`;
+  const usage = state.detail.usage || {};
+  $("tab-usage").innerHTML = `<div class="usage-grid"><div class="info-card"><h4>CLI</h4><pre class="code-block">${usage.cli || "—"}</pre></div><div class="info-card"><h4>Python</h4><pre class="code-block">${usage.python || "—"}</pre></div></div>`;
+}
+
+function previewFile(file) {
+  if (state.objectUrl) URL.revokeObjectURL(state.objectUrl);
+  state.objectUrl = URL.createObjectURL(file);
+  els.videoPreview.classList.add("hidden");
+  els.audioPreview.classList.add("hidden");
+  els.genericPreview.classList.add("hidden");
+  els.previewWrap.classList.remove("hidden");
+  if (file.type.startsWith("video/")) {
+    els.videoPreview.src = state.objectUrl;
+    els.videoPreview.classList.remove("hidden");
+  } else if (file.type.startsWith("audio/")) {
+    els.audioPreview.src = state.objectUrl;
+    els.audioPreview.classList.remove("hidden");
+  } else {
+    els.genericPreview.classList.remove("hidden");
+  }
+}
+
+function selectFile(file) {
+  state.selectedFile = file;
+  els.fileSummary.classList.remove("hidden");
+  els.fileName.textContent = file.name;
+  els.fileSize.textContent = `${formatBytes(file.size)} · ${file.type || "неизвестный MIME"}`;
+  els.fileTypeIcon.textContent = file.type.startsWith("audio/") ? "AUDIO" : file.type.startsWith("video/") ? "VIDEO" : "MEDIA";
+  els.dropZone.classList.add("hidden");
+  els.clearButton.classList.remove("hidden");
+  els.runButton.disabled = false;
+  els.runHint.textContent = "Файл будет обработан локально";
+  els.resultPanel.classList.add("hidden");
+  previewFile(file);
+}
+
+async function clearCurrent() {
+  if (state.executionId) {
+    try { await api(`/api/executions/${state.executionId}`, {method:"DELETE"}); } catch (_) {}
+  }
+  state.selectedFile = null;
+  state.executionId = null;
+  state.result = null;
+  els.fileInput.value = "";
+  els.fileSummary.classList.add("hidden");
+  els.previewWrap.classList.add("hidden");
+  els.dropZone.classList.remove("hidden");
+  els.clearButton.classList.add("hidden");
+  els.runButton.disabled = true;
+  els.runHint.textContent = "Сначала выберите файл";
+  els.resultPanel.classList.add("hidden");
+  if (state.objectUrl) URL.revokeObjectURL(state.objectUrl);
+  state.objectUrl = null;
+}
+
+function summaryCard(label, value) {
+  return `<div class="summary-card"><span>${label}</span><strong>${value ?? "—"}</strong></div>`;
+}
+
+function renderExecution(payload) {
+  state.executionId = payload.execution_id;
+  state.result = payload;
+  const result = payload.result;
+  const success = result.status === "success";
+  els.resultPanel.classList.remove("hidden");
+  els.executionStatus.textContent = result.status.toUpperCase();
+  els.executionStatus.className = `execution-status ${success ? "success" : "failed"}`;
+  els.resultSubtitle.textContent = success ? `${payload.filename} успешно проанализирован.` : result.error?.message || "Выполнение завершилось ошибкой.";
+
+  if (!success) {
+    els.summaryCards.innerHTML = summaryCard("Код ошибки", result.error?.code || "unknown") + summaryCard("Можно повторить", result.error?.retryable ? "Да" : "Нет");
+  } else {
+    const artifact = result.output_artifacts[0] || {};
+    const probe = artifact.metadata?.probe || {};
+    const video = probe.primary_video || {};
+    const audio = probe.primary_audio || {};
+    els.summaryCards.innerHTML = [
+      summaryCard("Длительность", formatDuration(probe.duration_seconds)),
+      summaryCard("Разрешение", video.width && video.height ? `${video.width} × ${video.height}` : "—"),
+      summaryCard("Формат", probe.format_name || "—"),
+      summaryCard("Размер", formatBytes(probe.size_bytes)),
+      summaryCard("Видеокодек", video.codec_name || "—"),
+      summaryCard("FPS", video.frame_rate_fps ? Number(video.frame_rate_fps).toFixed(3).replace(/0+$/, "").replace(/\.$/, "") : "—"),
+      summaryCard("Аудиокодек", audio.codec_name || "—"),
+      summaryCard("Аудио", audio.sample_rate_hz ? `${Number(audio.sample_rate_hz).toLocaleString("ru-RU")} Hz · ${audio.channels || "?"} ch` : "—"),
+    ].join("");
+    renderOverview(probe, video, audio, result);
+    renderStreams(probe.streams || []);
+  }
+
+  const warnings = result.warnings || [];
+  els.warningList.classList.toggle("hidden", !warnings.length);
+  els.warningList.innerHTML = warnings.map(item => `<div class="warning-item">${item}</div>`).join("");
+  els.rawJson.textContent = JSON.stringify(payload, null, 2);
+  els.logList.innerHTML = (payload.logs || []).map(entry => `<div class="log-entry"><span class="time">${entry.time.slice(11,23)}</span><span class="level ${entry.level}">${entry.level}</span><span>${entry.message}${Object.keys(entry.details || {}).length ? ` · ${JSON.stringify(entry.details)}` : ""}</span></div>`).join("");
+  els.resultPanel.scrollIntoView({behavior:"smooth", block:"start"});
+}
+
+function renderOverview(probe, video, audio, result) {
+  const rows = [
+    ["Контейнер", probe.format_long_name || probe.format_name], ["Битрейт файла", probe.bit_rate ? `${Number(probe.bit_rate).toLocaleString("ru-RU")} bit/s` : "—"],
+    ["Видео-потоков", probe.video_stream_count], ["Аудио-потоков", probe.audio_stream_count], ["Субтитров", probe.subtitle_stream_count],
+    ["Pixel format", video.pixel_format || "—"], ["Channel layout", audio.channel_layout || "—"], ["Время выполнения", `${result.metrics?.elapsed_ms ?? "—"} ms`],
+  ];
+  $("tab-overview").innerHTML = `<div class="detail-grid">${rows.map(([label,value]) => `<div class="detail-row"><span>${label}</span><strong>${value ?? "—"}</strong></div>`).join("")}</div>`;
+}
+
+function renderStreams(streams) {
+  if (!streams.length) { $("tab-streams").innerHTML = `<p>Потоки не обнаружены.</p>`; return; }
+  $("tab-streams").innerHTML = `<div style="overflow:auto"><table class="stream-table"><thead><tr><th>#</th><th>Тип</th><th>Кодек</th><th>Размер / аудио</th><th>Длительность</th><th>Язык</th></tr></thead><tbody>${streams.map(s => `<tr><td>${s.index ?? "—"}</td><td>${s.codec_type || "—"}</td><td>${s.codec_name || "—"}</td><td>${s.width && s.height ? `${s.width}×${s.height}` : s.sample_rate_hz ? `${s.sample_rate_hz} Hz · ${s.channels || "?"} ch` : "—"}</td><td>${formatDuration(s.duration_seconds)}</td><td>${s.language || "—"}</td></tr>`).join("")}</tbody></table></div>`;
+}
+
+async function runProbe() {
+  if (!state.selectedFile) return;
+  els.runButton.disabled = true;
+  els.spinner.classList.remove("hidden");
+  els.runButtonText.textContent = "Анализирую файл…";
+  els.runHint.textContent = "Выполняется локальный ffprobe";
+  const form = new FormData();
+  form.append("file", state.selectedFile);
+  form.append("timeout_seconds", "60");
+  try {
+    const payload = await api("/api/blocks/media.probe/run", {method:"POST", body:form});
+    renderExecution(payload);
+    showToast("media.probe завершён");
+  } catch (error) {
+    showToast(error.message);
+  } finally {
+    els.runButton.disabled = false;
+    els.spinner.classList.add("hidden");
+    els.runButtonText.textContent = "Запустить media.probe";
+    els.runHint.textContent = "Можно запустить повторно";
+  }
+}
+
+function bindEvents() {
+  document.querySelectorAll(".mode-button").forEach(button => button.addEventListener("click", () => {
+    document.body.dataset.mode = button.dataset.mode;
+    document.querySelectorAll(".mode-button").forEach(item => item.classList.toggle("active", item === button));
+    if (button.dataset.mode === "owner" && document.querySelector(".tab.active")?.classList.contains("developer-only")) {
+      document.querySelector('.tab[data-tab="overview"]').click();
+    }
+  }));
+  els.fileInput.addEventListener("change", event => event.target.files?.[0] && selectFile(event.target.files[0]));
+  ["dragenter","dragover"].forEach(name => els.dropZone.addEventListener(name, event => { event.preventDefault(); els.dropZone.classList.add("dragover"); }));
+  ["dragleave","drop"].forEach(name => els.dropZone.addEventListener(name, event => { event.preventDefault(); els.dropZone.classList.remove("dragover"); }));
+  els.dropZone.addEventListener("drop", event => event.dataTransfer.files?.[0] && selectFile(event.dataTransfer.files[0]));
+  els.runButton.addEventListener("click", runProbe);
+  els.clearButton.addEventListener("click", clearCurrent);
+  document.querySelectorAll(".tab").forEach(tab => tab.addEventListener("click", () => {
+    document.querySelectorAll(".tab").forEach(item => item.classList.toggle("active", item === tab));
+    document.querySelectorAll(".tab-panel").forEach(panel => panel.classList.toggle("active", panel.id === `tab-${tab.dataset.tab}`));
+  }));
+}
+
+async function initialize() {
+  bindEvents();
+  try {
+    const [health, blocks] = await Promise.all([api("/api/health"), api("/api/blocks")]);
+    els.healthBadge.className = `health-badge ${health.status}`;
+    els.healthBadge.innerHTML = `<span></span> ${health.ffprobe.available ? "ffprobe готов · локальный режим" : "ffprobe не найден"}`;
+    state.blocks = blocks;
+    const initial = blocks.find(block => block.block_id === "media.probe") || blocks[0];
+    await selectBlock(initial.block_id);
+  } catch (error) {
+    els.healthBadge.className = "health-badge degraded";
+    els.healthBadge.innerHTML = "<span></span> Ошибка запуска";
+    showToast(error.message);
+  }
+}
+
+document.addEventListener("DOMContentLoaded", initialize);

--- a/apps/block-studio/src/peos_block_studio/static/index.html
+++ b/apps/block-studio/src/peos_block_studio/static/index.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Project Execution OS — Block Studio</title>
+  <link rel="stylesheet" href="/assets/app.css">
+</head>
+<body data-mode="owner">
+  <div class="app-shell">
+    <header class="topbar">
+      <div><div class="eyebrow">PROJECT EXECUTION OS</div><h1>Block Studio</h1></div>
+      <div class="topbar-actions">
+        <div id="healthBadge" class="health-badge pending"><span></span> Проверка среды…</div>
+        <div class="mode-switch" role="group" aria-label="Режим интерфейса">
+          <button class="mode-button active" data-mode="owner">Владелец</button>
+          <button class="mode-button" data-mode="developer">Разработчик</button>
+        </div>
+      </div>
+    </header>
+
+    <main class="workspace">
+      <aside class="sidebar">
+        <div class="sidebar-heading"><span>Библиотека блоков</span><span id="blockCount" class="count-pill">0</span></div>
+        <div id="blockList" class="block-list"></div>
+        <div class="privacy-note"><strong>Локально и приватно</strong><span>Файлы остаются на этом компьютере.</span></div>
+      </aside>
+
+      <section class="content">
+        <div class="hero-card">
+          <div class="hero-copy">
+            <div class="block-kicker"><span id="selectedBlockId">media.probe</span><span id="selectedStatus" class="status-badge candidate">candidate</span></div>
+            <h2 id="selectedTitle">Анализ медиа</h2>
+            <p id="selectedDescription">Загрузите видео или аудио и посмотрите, что внутри файла.</p>
+            <div class="meta-row"><span>Версия <strong id="selectedVersion">0.1.0</strong></span><span>Провайдер <strong id="selectedProvider">ffprobe</strong></span></div>
+          </div>
+          <div class="readiness-card"><div class="readiness-label">Готовность</div><div id="readinessValue" class="readiness-value">Candidate</div><div id="readinessText" class="readiness-text">Код и тесты есть. Реальное приложение ещё проверяется.</div></div>
+        </div>
+
+        <div id="interactiveArea" class="interactive-area">
+          <section class="panel upload-panel">
+            <div class="panel-heading">
+              <div><span class="step-number">1</span><div><h3>Выберите файл</h3><p>MP4, MOV, WAV, MP3 или другой формат, который понимает ffprobe.</p></div></div>
+              <button id="clearButton" class="ghost-button hidden">Очистить</button>
+            </div>
+
+            <label id="dropZone" class="drop-zone" for="fileInput">
+              <input id="fileInput" type="file" accept="video/*,audio/*">
+              <div class="drop-icon">＋</div>
+              <strong>Перетащите файл сюда</strong><span>или нажмите, чтобы выбрать</span><small>Файл не отправляется в интернет</small>
+            </label>
+
+            <div id="fileSummary" class="file-summary hidden">
+              <div class="file-icon" id="fileTypeIcon">VIDEO</div>
+              <div class="file-copy"><strong id="fileName"></strong><span id="fileSize"></span></div>
+              <span id="fileReadyBadge" class="mini-badge">готов к запуску</span>
+            </div>
+
+            <div id="previewWrap" class="preview-wrap hidden">
+              <video id="videoPreview" controls class="media-preview hidden"></video>
+              <audio id="audioPreview" controls class="audio-preview hidden"></audio>
+              <div id="genericPreview" class="generic-preview hidden">Предпросмотр недоступен, но файл можно проанализировать.</div>
+            </div>
+
+            <div class="run-row">
+              <button id="runButton" class="primary-button" disabled><span id="runButtonText">Запустить media.probe</span><span id="spinner" class="spinner hidden"></span></button>
+              <div id="runHint" class="run-hint">Сначала выберите файл</div>
+            </div>
+          </section>
+
+          <section id="resultPanel" class="panel result-panel hidden">
+            <div class="panel-heading result-heading">
+              <div><span class="step-number success">2</span><div><h3>Результат блока</h3><p id="resultSubtitle">Медиа успешно проанализировано.</p></div></div>
+              <div id="executionStatus" class="execution-status success">SUCCESS</div>
+            </div>
+            <div id="warningList" class="warning-list hidden"></div>
+            <div id="summaryCards" class="summary-grid"></div>
+
+            <div class="tabs" role="tablist">
+              <button class="tab active" data-tab="overview">Результат</button>
+              <button class="tab" data-tab="streams">Потоки</button>
+              <button class="tab developer-only" data-tab="raw">Raw JSON</button>
+              <button class="tab developer-only" data-tab="logs">Логи</button>
+              <button class="tab developer-only" data-tab="contract">Контракт</button>
+              <button class="tab" data-tab="tests">Тесты</button>
+              <button class="tab developer-only" data-tab="usage">Использование</button>
+            </div>
+
+            <div id="tab-overview" class="tab-panel active"></div>
+            <div id="tab-streams" class="tab-panel"></div>
+            <div id="tab-raw" class="tab-panel"><pre id="rawJson" class="code-block"></pre></div>
+            <div id="tab-logs" class="tab-panel"><div id="logList" class="log-list"></div></div>
+            <div id="tab-contract" class="tab-panel"></div>
+            <div id="tab-tests" class="tab-panel"></div>
+            <div id="tab-usage" class="tab-panel"></div>
+          </section>
+        </div>
+
+        <section id="comingSoon" class="panel coming-soon hidden">
+          <div class="coming-icon">◇</div><h3 id="comingTitle">Блок запланирован</h3>
+          <p id="comingText">Для него уже есть место в общей архитектуре, но исполняемого кода пока нет.</p>
+          <div class="coming-path"><span>Следующая стадия</span><strong id="comingStatus">idea → candidate</strong></div>
+        </section>
+      </section>
+    </main>
+  </div>
+
+  <div id="toast" class="toast hidden"></div>
+  <script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/apps/block-studio/src/peos_block_studio/storage.py
+++ b/apps/block-studio/src/peos_block_studio/storage.py
@@ -1,0 +1,64 @@
+"""Runtime upload storage with path-boundary protection."""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from pathlib import Path
+from uuid import uuid4
+
+_SAFE_NAME = re.compile(r"[^A-Za-z0-9._-]+")
+_EXECUTION_ID = re.compile(r"^[a-f0-9]{32}$")
+
+
+def sanitize_filename(filename: str | None) -> str:
+    name = Path(filename or "upload.bin").name
+    cleaned = _SAFE_NAME.sub("_", name).strip("._")
+    return cleaned[:180] or "upload.bin"
+
+
+class ExecutionStorage:
+    def __init__(self, root: Path) -> None:
+        self.root = root.resolve()
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def create(self, original_filename: str | None, mime_type: str | None) -> tuple[str, Path, dict[str, str | None]]:
+        execution_id = uuid4().hex
+        workspace = (self.root / execution_id).resolve()
+        workspace.mkdir(parents=True, exist_ok=False)
+        safe_name = sanitize_filename(original_filename)
+        suffix = Path(safe_name).suffix[:20]
+        stored_path = workspace / f"input{suffix}"
+        metadata = {
+            "execution_id": execution_id,
+            "original_filename": safe_name,
+            "stored_filename": stored_path.name,
+            "mime_type": mime_type,
+        }
+        (workspace / "metadata.json").write_text(json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8")
+        return execution_id, stored_path, metadata
+
+    def resolve_file(self, execution_id: str) -> tuple[Path, dict[str, str | None]]:
+        if not _EXECUTION_ID.fullmatch(execution_id):
+            raise FileNotFoundError(execution_id)
+        workspace = (self.root / execution_id).resolve()
+        workspace.relative_to(self.root)
+        metadata_path = workspace / "metadata.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        file_path = (workspace / str(metadata["stored_filename"])).resolve()
+        file_path.relative_to(workspace)
+        if not file_path.is_file():
+            raise FileNotFoundError(file_path)
+        return file_path, metadata
+
+    def workspace(self, execution_id: str) -> Path:
+        file_path, _ = self.resolve_file(execution_id)
+        return file_path.parent
+
+    def delete(self, execution_id: str) -> bool:
+        try:
+            workspace = self.workspace(execution_id)
+        except (FileNotFoundError, ValueError, json.JSONDecodeError):
+            return False
+        shutil.rmtree(workspace, ignore_errors=False)
+        return True

--- a/apps/block-studio/tests/test_block_studio.py
+++ b/apps/block-studio/tests/test_block_studio.py
@@ -1,0 +1,84 @@
+import shutil
+import wave
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from peos_block_studio.app import create_app
+from peos_block_studio.catalog import build_catalog, parse_registry
+from peos_block_studio.storage import ExecutionStorage, sanitize_filename
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def test_registry_and_manifest_build_catalog() -> None:
+    rows = parse_registry(repo_root() / "capability-library" / "REGISTRY.md")
+    assert any(row["Block ID"] == "media.probe" for row in rows)
+
+    catalog = build_catalog(repo_root())
+    probe = next(item for item in catalog if item.block_id == "media.probe")
+    assert probe.status == "candidate"
+    assert probe.version == "0.1.0"
+    assert probe.provider == "ffprobe"
+    assert probe.installed is True
+    assert probe.interactive is True
+
+
+def test_health_and_catalog(tmp_path: Path) -> None:
+    client = TestClient(create_app(repo_root=repo_root(), runtime_root=tmp_path / "runtime"))
+    health = client.get("/api/health")
+    assert health.status_code == 200
+    assert health.json()["local_only"] is True
+
+    blocks = client.get("/api/blocks")
+    assert blocks.status_code == 200
+    probe = next(item for item in blocks.json() if item["block_id"] == "media.probe")
+    assert probe["interactive"] is True
+
+
+@pytest.mark.skipif(shutil.which("ffprobe") is None, reason="ffprobe is not installed")
+def test_real_media_probe_upload_and_cleanup(tmp_path: Path) -> None:
+    audio = tmp_path / "tone.wav"
+    sample_rate = 8000
+    frame_count = 800
+    with wave.open(str(audio), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(b"\x00\x00" * frame_count)
+
+    runtime = tmp_path / "runtime"
+    client = TestClient(create_app(repo_root=repo_root(), runtime_root=runtime))
+    with audio.open("rb") as handle:
+        response = client.post(
+            "/api/blocks/media.probe/run",
+            files={"file": (audio.name, handle, "audio/wav")},
+            data={"timeout_seconds": "10"},
+        )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["result"]["status"] == "success"
+    probe = payload["result"]["output_artifacts"][0]["metadata"]["probe"]
+    assert probe["audio_stream_count"] == 1
+    assert probe["primary_audio"]["sample_rate_hz"] == sample_rate
+    assert probe["duration_seconds"] == pytest.approx(frame_count / sample_rate, rel=0.02)
+    assert any(item["level"] == "progress" for item in payload["logs"])
+
+    preview = client.get(payload["preview_url"])
+    assert preview.status_code == 200
+    assert preview.content.startswith(b"RIFF")
+
+    deleted = client.delete(f"/api/executions/{payload['execution_id']}")
+    assert deleted.status_code == 200
+    assert deleted.json() == {"deleted": True}
+    assert client.get(payload["preview_url"]).status_code == 404
+
+
+def test_storage_boundaries(tmp_path: Path) -> None:
+    assert sanitize_filename("../My Wedding Video (final).mp4") == "My_Wedding_Video_final_.mp4"
+    storage = ExecutionStorage(tmp_path / "runtime")
+    with pytest.raises(FileNotFoundError):
+        storage.resolve_file("../escape")

--- a/capability-library/REGISTRY.md
+++ b/capability-library/REGISTRY.md
@@ -20,7 +20,7 @@ A row records architectural intent and implementation status. It must not imply 
 | Block ID | Status | Version | Implementation location | Initial providers | Inputs | Outputs | Validation targets | Known limitations |
 |---|---|---:|---|---|---|---|---|---|
 | `media.download` | idea | — | not created | yt-dlp, direct HTTP | authorized source descriptor | video/audio artifact | short-video workflow, QuizLight | rights and platform restrictions must remain explicit |
-| `media.probe` | candidate | 0.1.0 | `capabilities/media-probe/` | ffprobe | one local media artifact | original artifact enriched with normalized probe metadata | short-video workflow, QuizLight | native Windows and real application integration still required |
+| `media.probe` | candidate | 0.1.0 | `capabilities/media-probe/` | ffprobe | one local media artifact | original artifact enriched with normalized probe metadata | short-video workflow, QuizLight | automated Windows and Block Studio integration passed; owner target-machine confirmation still required |
 | `media.extract_audio` | idea | — | not created | ffmpeg | video/audio artifact | normalized audio artifact | transcription workflows | codec and channel normalization policy not yet validated |
 | `media.transcribe` | idea | — | not created | whisper.cpp, faster-whisper, optional cloud adapter | audio/video artifact | transcript artifact with segments and timestamps | short-video workflow, QuizLight | provider selection and hardware benchmarks not yet validated |
 | `media.clip` | idea | — | not created | ffmpeg | media artifact plus time ranges | one or more clip artifacts | Reels factory, QuizLight phrase clips | exact-cut versus stream-copy behavior needs fixtures |
@@ -75,16 +75,28 @@ ffprobe 7.1.3
 manual CLI smoke test passed on generated WAV input
 ```
 
+Application integration evidence:
+
+```text
+apps/block-studio/
+real upload endpoint execution passed
+real H.264/AAC MP4 smoke test passed
+preview and temporary execution cleanup passed
+GitHub Actions passed on Ubuntu and Windows with Python 3.13
+```
+
 Durable evidence:
 
 ```text
 capabilities/media-probe/VALIDATION.md
+apps/block-studio/VALIDATION.md
 .github/workflows/media-probe-tests.yml
+.github/workflows/block-studio-tests.yml
 ```
 
 Promotion boundary:
 
-`media.probe` is `candidate`, not `validated`. It still requires native Windows checking and integration into a real application workflow.
+`media.probe` remains `candidate`, not `validated`, until the owner runs Block Studio on the target Windows computer with a real user-owned media file and confirms the result.
 
 ## Promotion Evidence
 


### PR DESCRIPTION
## What changed

- adds `apps/block-studio/` as the first application-layer UI for reusable capability blocks;
- discovers blocks from the central registry, manifests, and Python entry points;
- provides a fully interactive `media.probe` screen with drag-and-drop upload;
- shows local video/audio preview, human-readable metadata cards, streams, raw JSON, logs, contract, tests, and usage;
- adds owner and developer display modes;
- stores uploads locally under a protected runtime workspace and supports cleanup;
- adds `START_BLOCK_STUDIO.bat` for double-click Windows startup;
- adds Linux and Windows GitHub Actions coverage with real ffprobe execution.

## Local verification

```text
5 tests passed
JavaScript syntax check passed
FastAPI server started on 127.0.0.1:8015
real H.264/AAC MP4 upload returned success
duration, dimensions, codecs, sample rate, preview, and cleanup verified
```

## Honest boundary

Block Studio is `candidate 0.1.0` until CI passes on both operating systems and the owner opens it on the target Windows computer with a real user-owned file. Direct headless-browser access to localhost was blocked by the execution environment, so functionality was verified through real HTTP requests and the interface was separately rendered as a static Chromium fixture.
