### PR TITLE
Fix YouTube title metrics after delayed card rendering

### DIFF
--- a/projects/tiktok-research-sorter/entrypoints/sidepanel/youtube-title-enhancer.ts
+++ b/projects/tiktok-research-sorter/entrypoints/sidepanel/youtube-title-enhancer.ts
@@ -1,5 +1,6 @@
 const TITLE_LIMIT = 100;
 const ENHANCED_ATTR = 'youtubeTitleEnhanced';
+const USER_EDITED_ATTR = 'youtubeTitleEdited';
 
 function parseLocalizedCompactNumber(source: string): number | undefined {
   const normalized = source
@@ -167,8 +168,20 @@ function injectStyles(): void {
   document.head.append(style);
 }
 
+function refreshEnhancedCard(card: HTMLElement): void {
+  const input = card.querySelector<HTMLTextAreaElement>('.youtube-title-input');
+  if (!input || input.dataset[USER_EDITED_ATTR] === 'true') return;
+
+  const nextTitle = buildYouTubeTitle(card);
+  if (input.value !== nextTitle) input.value = nextTitle;
+}
+
 function enhanceCard(card: HTMLElement): void {
-  if (card.dataset[ENHANCED_ATTR] === 'true') return;
+  const existingInput = card.querySelector<HTMLTextAreaElement>('.youtube-title-input');
+  if (existingInput) {
+    refreshEnhancedCard(card);
+    return;
+  }
 
   const videoCopy = card.querySelector<HTMLElement>('.video-copy');
   if (!videoCopy) return;
@@ -195,6 +208,9 @@ function enhanceCard(card: HTMLElement): void {
   input.spellcheck = false;
   input.value = buildYouTubeTitle(card);
   input.setAttribute('aria-label', 'YouTube title');
+  input.addEventListener('input', () => {
+    input.dataset[USER_EDITED_ATTR] = 'true';
+  });
 
   copyButton.addEventListener('click', async () => {
     try {
@@ -235,7 +251,11 @@ function scheduleEnhancement(): void {
 
 const root = document.getElementById('root');
 if (root) {
-  new MutationObserver(scheduleEnhancement).observe(root, { childList: true, subtree: true });
+  new MutationObserver(scheduleEnhancement).observe(root, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+  });
 }
 
 scheduleEnhancement();


### PR DESCRIPTION
Fixes intermittent `0 views 0 likes` values in the copy-ready YouTube title block.

Changes:
- refresh an existing title block when card metrics change;
- observe text-node changes as well as added/removed nodes;
- preserve a title after the user edits it manually;
- recreate the block if React replaces the card subtree.

The issue was caused by marking a card as enhanced before all metrics had finished rendering, after which the block was never recalculated.