### PR TITLE
Implement isolated Ollama MVP adapter for AI Hands

### DIFF
--- a/projects/ai-hands/AGENTS.md
+++ b/projects/ai-hands/AGENTS.md
@@ -11,6 +11,16 @@ Before project work:
 5. Read `projects/ai-hands/logs/latest.md` only when the latest executor status, blocker, result, or continuation state is relevant.
 6. Read only the minimum additional files required for the active task.
 
+## Authority And Role Contract
+
+- The owner defines product intent, constraints, and priorities.
+- ChatGPT is the controller, architect, task author, and reviewer unless the owner explicitly assigns those responsibilities elsewhere.
+- The executor implements the supplied specification, runs approved commands, gathers evidence, and reports results.
+- The executor must not silently change architecture, product scope, model strategy, safety boundaries, or acceptance criteria.
+- When a material decision is missing, the executor stops at the decision boundary and returns verified facts, options, and a blocker instead of choosing a new direction.
+- Small reversible implementation details may be resolved locally only when they do not alter the specified architecture or outcome.
+- A local model is a bounded mechanical worker. Its proposals are untrusted until checked by deterministic guards and controller review.
+
 ## Project-Specific Guardrails
 
 - This directory is an internal subproject. Never run nested `git init` here.
@@ -27,7 +37,7 @@ Before project work:
 
 ## Working Rule
 
-The controller decides and verifies. The local executor performs bounded mechanical work. Codex or another stronger executor may be used for escalation, but the project must not depend on a single model provider.
+The controller decides, specifies, and verifies. The executor performs bounded implementation and experimentation. Codex or another stronger executor may be used for escalation, but the project must not depend on a single model provider.
 
 ## Central Standards
 

--- a/projects/ai-hands/mvp/.review-fix-marker
+++ b/projects/ai-hands/mvp/.review-fix-marker
@@ -1,0 +1,1 @@
+Review hardening completed for PR #98.

--- a/projects/ai-hands/mvp/.review-fix-marker
+++ b/projects/ai-hands/mvp/.review-fix-marker
@@ -1,1 +1,0 @@
-Review hardening completed for PR #98.

--- a/projects/ai-hands/mvp/README.md
+++ b/projects/ai-hands/mvp/README.md
@@ -2,11 +2,15 @@
 
 This MVP proves one narrow controller-led execution loop without changing Cline or its existing DeepSeek configuration.
 
+## Existing-solution decision
+
+The installed Cline + Ollama donor path was tested first in Issue #97. The headless path required a TTY or hung, and therefore did not satisfy the required bounded non-interactive execution contract. The project then moved to this minimal adapter as the smallest controlled fallback. Evidence: https://github.com/oleg3479881328-code/Project-Execution-OS/issues/97
+
 ## Role contract
 
 - The owner defines product intent and priorities.
 - ChatGPT is the controller, architect, task author, and reviewer.
-- The executor runs the supplied code, captures evidence, and reports blockers. It must not redesign the architecture or silently broaden scope.
+- The executor runs supplied code, captures evidence, and reports blockers. It must not redesign the architecture or silently broaden scope.
 - The local Ollama model performs one bounded mechanical edit proposed in structured JSON.
 
 ## Safety boundary
@@ -14,12 +18,16 @@ This MVP proves one narrow controller-led execution loop without changing Cline 
 The adapter:
 
 - works only inside the exact resolved workspace from the task packet;
+- requires the active Git branch to equal the controller-supplied `expected_branch`;
+- refuses `main`, `master`, `trunk`, detached HEAD, and non-Git workspaces;
 - permits exactly one existing target file;
 - rejects path traversal and attempts to change another file;
 - never executes model-proposed commands;
-- runs only the controller-supplied validation command as an argv array with `shell=False`;
-- restores the original file if validation fails or execution raises an error;
-- does not touch Cline settings, DeepSeek credentials, Git remotes, branches, or external accounts.
+- accepts only the exact workspace-local PowerShell validation form ending in `validate.ps1`;
+- runs validation with `shell=False`;
+- restores the original file if validation fails, execution errors, or the operator interrupts validation;
+- includes `next_recommended_action` in every report;
+- does not touch Cline settings, DeepSeek credentials, Git remotes, or external accounts.
 
 ## Run
 
@@ -37,16 +45,18 @@ See `task.example.json`. The controller must specify:
 - already-downloaded Ollama model;
 - exact target file relative to that workspace;
 - exact edit instruction;
-- one deterministic allowlisted validation command.
+- exact non-default branch expected to be active;
+- the allowlisted workspace-local `validate.ps1` command.
 
 ## Expected output
 
-The process prints one JSON report containing status, model summary, unified diff, validation command, exit code, stdout, stderr, or a precise error. Successful write status is `COMPLETE`. Failed validation is `VALIDATION_FAILED_ROLLED_BACK`.
+The process prints one JSON report containing status, model summary, unified diff, validation evidence, errors when present, and the next recommended action. Successful write status is `COMPLETE`. Failed or interrupted validation is rolled back.
 
 ## MVP acceptance test
 
-1. Create a disposable directory and Git repository.
-2. Create `notes.txt` containing `alpha`, `beta`, and `gamma` on separate lines.
-3. Create a deterministic validation script that succeeds only when `delta` is present and `beta` is absent.
-4. Run the adapter with `qwen3:4b`.
-5. Confirm the report says `COMPLETE`, the diff changes only `notes.txt`, and the existing Cline/DeepSeek configuration remains unchanged.
+1. Create a disposable Git repository.
+2. Create and switch to `smoke/nondefault` before running the adapter.
+3. Create `notes.txt` containing `alpha`, `beta`, and `gamma` on separate lines.
+4. Create `validate.ps1` that succeeds only when `delta` is present and `beta` is absent.
+5. Run the adapter with `qwen3:4b` and `expected_branch` set to `smoke/nondefault`.
+6. Confirm the report says `COMPLETE`, validation says `VALIDATION_OK`, the diff changes only `notes.txt`, and Cline/DeepSeek remain unchanged.

--- a/projects/ai-hands/mvp/README.md
+++ b/projects/ai-hands/mvp/README.md
@@ -1,0 +1,52 @@
+# AI Hands MVP — Isolated Ollama Adapter
+
+This MVP proves one narrow controller-led execution loop without changing Cline or its existing DeepSeek configuration.
+
+## Role contract
+
+- The owner defines product intent and priorities.
+- ChatGPT is the controller, architect, task author, and reviewer.
+- The executor runs the supplied code, captures evidence, and reports blockers. It must not redesign the architecture or silently broaden scope.
+- The local Ollama model performs one bounded mechanical edit proposed in structured JSON.
+
+## Safety boundary
+
+The adapter:
+
+- works only inside the exact resolved workspace from the task packet;
+- permits exactly one existing target file;
+- rejects path traversal and attempts to change another file;
+- never executes model-proposed commands;
+- runs only the controller-supplied validation command as an argv array with `shell=False`;
+- restores the original file if validation fails or execution raises an error;
+- does not touch Cline settings, DeepSeek credentials, Git remotes, branches, or external accounts.
+
+## Run
+
+```powershell
+python projects/ai-hands/mvp/ai_hands.py C:\path\to\task.json
+```
+
+Use `--dry-run` to request and validate the model proposal without writing the file or running validation.
+
+## Task packet
+
+See `task.example.json`. The controller must specify:
+
+- absolute disposable workspace path;
+- already-downloaded Ollama model;
+- exact target file relative to that workspace;
+- exact edit instruction;
+- one deterministic allowlisted validation command.
+
+## Expected output
+
+The process prints one JSON report containing status, model summary, unified diff, validation command, exit code, stdout, stderr, or a precise error. Successful write status is `COMPLETE`. Failed validation is `VALIDATION_FAILED_ROLLED_BACK`.
+
+## MVP acceptance test
+
+1. Create a disposable directory and Git repository.
+2. Create `notes.txt` containing `alpha`, `beta`, and `gamma` on separate lines.
+3. Create a deterministic validation script that succeeds only when `delta` is present and `beta` is absent.
+4. Run the adapter with `qwen3:4b`.
+5. Confirm the report says `COMPLETE`, the diff changes only `notes.txt`, and the existing Cline/DeepSeek configuration remains unchanged.

--- a/projects/ai-hands/mvp/ai_hands.py
+++ b/projects/ai-hands/mvp/ai_hands.py
@@ -1,17 +1,12 @@
 #!/usr/bin/env python3
-"""AI Hands MVP: bounded local-model file edit through Ollama.
-
-The controller supplies an exact task packet. The local model may propose one
-full-file replacement in JSON. This adapter validates the proposal, applies it
-inside the approved workspace only, runs one allowlisted validation command,
-and prints a machine-readable execution report.
-"""
+"""AI Hands MVP: bounded local-model file edit through Ollama."""
 
 from __future__ import annotations
 
 import argparse
 import difflib
 import json
+import os
 import subprocess
 import sys
 import urllib.error
@@ -31,6 +26,7 @@ class Task:
     model: str
     instruction: str
     target_file: str
+    expected_branch: str
     validation_command: list[str]
     ollama_url: str = "http://127.0.0.1:11434"
 
@@ -40,11 +36,15 @@ def load_task(path: Path) -> Task:
     command = raw.get("validation_command")
     if not isinstance(command, list) or not command or not all(isinstance(x, str) for x in command):
         raise ExecutionError("validation_command must be a non-empty string array")
+    expected_branch = str(raw.get("expected_branch", "")).strip()
+    if not expected_branch:
+        raise ExecutionError("expected_branch is required")
     return Task(
         workspace=Path(raw["workspace"]).expanduser().resolve(),
         model=str(raw["model"]),
         instruction=str(raw["instruction"]),
         target_file=str(raw["target_file"]),
+        expected_branch=expected_branch,
         validation_command=command,
         ollama_url=str(raw.get("ollama_url", "http://127.0.0.1:11434")).rstrip("/"),
     )
@@ -61,6 +61,28 @@ def resolve_target(task: Task) -> Path:
     if not target.is_file():
         raise ExecutionError(f"target file does not exist: {target}")
     return target
+
+
+def git_output(workspace: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=workspace, text=True, capture_output=True,
+        timeout=20, shell=False, check=False,
+    )
+    if result.returncode != 0:
+        raise ExecutionError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def verify_isolated_branch(task: Task) -> None:
+    if git_output(task.workspace, "rev-parse", "--is-inside-work-tree") != "true":
+        raise ExecutionError("workspace is not a Git worktree")
+    branch = git_output(task.workspace, "branch", "--show-current")
+    if not branch:
+        raise ExecutionError("detached HEAD is not allowed")
+    if branch != task.expected_branch:
+        raise ExecutionError(f"current branch {branch!r} does not match expected_branch {task.expected_branch!r}")
+    if branch.lower() in {"main", "master", "trunk"}:
+        raise ExecutionError("refusing to write on a default-style branch")
 
 
 def build_prompt(task: Task, current_content: str) -> str:
@@ -80,12 +102,6 @@ CURRENT FILE CONTENT:
 
 
 def parse_ollama_proposal(envelope: dict[str, Any]) -> dict[str, Any]:
-    """Parse structured model output from supported Ollama envelope fields.
-
-    Most models place final output in ``response``. Some reasoning models emit
-    the requested JSON in ``thinking`` while leaving ``response`` empty. We
-    accept the first non-empty valid JSON object from those known fields only.
-    """
     parse_errors: list[str] = []
     for field in ("response", "thinking"):
         candidate = envelope.get(field)
@@ -99,10 +115,8 @@ def parse_ollama_proposal(envelope: dict[str, Any]) -> dict[str, Any]:
         if isinstance(proposal, dict):
             return proposal
         parse_errors.append(f"{field}: JSON value is not an object")
-
     detail = "; ".join(parse_errors)
-    suffix = f" ({detail})" if detail else ""
-    raise ExecutionError(f"model did not return valid proposal JSON{suffix}")
+    raise ExecutionError("model did not return valid proposal JSON" + (f" ({detail})" if detail else ""))
 
 
 def call_ollama(task: Task, prompt: str) -> dict[str, Any]:
@@ -114,10 +128,8 @@ def call_ollama(task: Task, prompt: str) -> dict[str, Any]:
         "options": {"temperature": 0},
     }).encode("utf-8")
     request = urllib.request.Request(
-        f"{task.ollama_url}/api/generate",
-        data=payload,
-        headers={"Content-Type": "application/json"},
-        method="POST",
+        f"{task.ollama_url}/api/generate", data=payload,
+        headers={"Content-Type": "application/json"}, method="POST",
     )
     try:
         with urllib.request.urlopen(request, timeout=180) as response:
@@ -141,44 +153,69 @@ def validate_proposal(task: Task, proposal: dict[str, Any]) -> tuple[str, str]:
     return new_content, summary
 
 
+def validate_validation_command(task: Task) -> None:
+    command = task.validation_command
+    executable = Path(command[0]).name.lower()
+    allowed_executables = {"powershell", "powershell.exe", "pwsh", "pwsh.exe"}
+    if executable not in allowed_executables:
+        raise ExecutionError("validation executable is not allowlisted")
+    if len(command) != 5:
+        raise ExecutionError("validation command must use the approved five-argument PowerShell form")
+    if command[1:4] != ["-ExecutionPolicy", "Bypass", "-File"]:
+        raise ExecutionError("validation command arguments are not allowlisted")
+    script = (task.workspace / command[4]).resolve()
+    try:
+        script.relative_to(task.workspace)
+    except ValueError as exc:
+        raise ExecutionError("validation script escapes approved workspace") from exc
+    if script.name.lower() != "validate.ps1" or not script.is_file():
+        raise ExecutionError("only an existing workspace-local validate.ps1 is allowlisted")
+
+
 def run_validation(task: Task) -> subprocess.CompletedProcess[str]:
+    validate_validation_command(task)
     return subprocess.run(
-        task.validation_command,
-        cwd=task.workspace,
-        text=True,
-        capture_output=True,
-        timeout=120,
-        shell=False,
-        check=False,
+        task.validation_command, cwd=task.workspace, text=True, capture_output=True,
+        timeout=120, shell=False, check=False,
     )
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description="Run one bounded AI Hands Ollama task")
-    parser.add_argument("task", type=Path, help="Path to task JSON")
-    parser.add_argument("--dry-run", action="store_true", help="Do not write or validate")
-    args = parser.parse_args()
+def set_next_action(report: dict[str, Any]) -> None:
+    status = report["status"]
+    actions = {
+        "COMPLETE": "Controller should review the diff and validation evidence, then decide whether to accept or expand scope.",
+        "DRY_RUN_OK": "Controller should review the proposed diff and authorize a non-dry run if acceptable.",
+        "VALIDATION_FAILED_ROLLED_BACK": "Controller should inspect validation output and revise the task or implementation before retrying.",
+        "INTERRUPTED_ROLLED_BACK": "Operator should confirm workspace state, then retry only after controller approval.",
+        "FAILED": "Controller should inspect the error, correct the task or adapter, and issue a new bounded run instruction.",
+    }
+    report["next_recommended_action"] = actions.get(status, actions["FAILED"])
 
+
+def execute(task: Task, dry_run: bool) -> tuple[dict[str, Any], int]:
     report: dict[str, Any] = {"status": "FAILED"}
     original: str | None = None
     target: Path | None = None
+    wrote = False
+    exit_code = 1
     try:
-        task = load_task(args.task.resolve())
+        verify_isolated_branch(task)
         target = resolve_target(task)
         original = target.read_text(encoding="utf-8")
         proposal = call_ollama(task, build_prompt(task, original))
         new_content, model_summary = validate_proposal(task, proposal)
         diff = "".join(difflib.unified_diff(
-            original.splitlines(keepends=True),
-            new_content.splitlines(keepends=True),
-            fromfile=f"a/{task.target_file}",
-            tofile=f"b/{task.target_file}",
+            original.splitlines(keepends=True), new_content.splitlines(keepends=True),
+            fromfile=f"a/{task.target_file}", tofile=f"b/{task.target_file}",
         ))
         report.update({"model": task.model, "model_summary": model_summary, "diff": diff})
-        if args.dry_run:
+        if dry_run:
             report["status"] = "DRY_RUN_OK"
+            exit_code = 0
         else:
+            validate_validation_command(task)
             target.write_text(new_content, encoding="utf-8")
+            wrote = True
             validation = run_validation(task)
             report["validation"] = {
                 "command": task.validation_command,
@@ -188,19 +225,40 @@ def main() -> int:
             }
             if validation.returncode != 0:
                 target.write_text(original, encoding="utf-8")
+                wrote = False
                 report["status"] = "VALIDATION_FAILED_ROLLED_BACK"
             else:
                 report["status"] = "COMPLETE"
-    except Exception as exc:  # final safety boundary for CLI report
-        if original is not None and target is not None and target.exists():
+                exit_code = 0
+    except KeyboardInterrupt:
+        report["status"] = "INTERRUPTED_ROLLED_BACK"
+        report["error"] = "execution interrupted by operator"
+    except Exception as exc:
+        report["error"] = str(exc)
+    finally:
+        if wrote and report["status"] != "COMPLETE" and original is not None and target is not None:
             try:
                 target.write_text(original, encoding="utf-8")
-            except OSError:
-                pass
-        report["error"] = str(exc)
+            except OSError as exc:
+                report["rollback_error"] = str(exc)
+        set_next_action(report)
+    return report, exit_code
 
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run one bounded AI Hands Ollama task")
+    parser.add_argument("task", type=Path, help="Path to task JSON")
+    parser.add_argument("--dry-run", action="store_true", help="Do not write or validate")
+    args = parser.parse_args()
+    try:
+        task = load_task(args.task.resolve())
+        report, exit_code = execute(task, args.dry_run)
+    except BaseException as exc:
+        report = {"status": "FAILED", "error": str(exc)}
+        set_next_action(report)
+        exit_code = 1
     print(json.dumps(report, ensure_ascii=False, indent=2))
-    return 0 if report["status"] in {"COMPLETE", "DRY_RUN_OK"} else 1
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/projects/ai-hands/mvp/ai_hands.py
+++ b/projects/ai-hands/mvp/ai_hands.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""AI Hands MVP: bounded local-model file edit through Ollama.
+
+The controller supplies an exact task packet. The local model may propose one
+full-file replacement in JSON. This adapter validates the proposal, applies it
+inside the approved workspace only, runs one allowlisted validation command,
+and prints a machine-readable execution report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class ExecutionError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Task:
+    workspace: Path
+    model: str
+    instruction: str
+    target_file: str
+    validation_command: list[str]
+    ollama_url: str = "http://127.0.0.1:11434"
+
+
+def load_task(path: Path) -> Task:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    command = raw.get("validation_command")
+    if not isinstance(command, list) or not command or not all(isinstance(x, str) for x in command):
+        raise ExecutionError("validation_command must be a non-empty string array")
+    return Task(
+        workspace=Path(raw["workspace"]).expanduser().resolve(),
+        model=str(raw["model"]),
+        instruction=str(raw["instruction"]),
+        target_file=str(raw["target_file"]),
+        validation_command=command,
+        ollama_url=str(raw.get("ollama_url", "http://127.0.0.1:11434")).rstrip("/"),
+    )
+
+
+def resolve_target(task: Task) -> Path:
+    if not task.workspace.is_dir():
+        raise ExecutionError(f"workspace does not exist: {task.workspace}")
+    target = (task.workspace / task.target_file).resolve()
+    try:
+        target.relative_to(task.workspace)
+    except ValueError as exc:
+        raise ExecutionError("target_file escapes approved workspace") from exc
+    if not target.is_file():
+        raise ExecutionError(f"target file does not exist: {target}")
+    return target
+
+
+def build_prompt(task: Task, current_content: str) -> str:
+    return f"""You are a bounded file-edit executor. You do not choose architecture.
+Follow the controller instruction exactly. Do not propose commands or other files.
+Return JSON only with this exact schema:
+{{"target_file": {json.dumps(task.target_file)}, "new_content": "complete replacement content", "summary": "one sentence"}}
+
+CONTROLLER INSTRUCTION:
+{task.instruction}
+
+CURRENT FILE CONTENT:
+---
+{current_content}
+---
+"""
+
+
+def call_ollama(task: Task, prompt: str) -> dict[str, Any]:
+    payload = json.dumps({
+        "model": task.model,
+        "prompt": prompt,
+        "stream": False,
+        "format": "json",
+        "options": {"temperature": 0},
+    }).encode("utf-8")
+    request = urllib.request.Request(
+        f"{task.ollama_url}/api/generate",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=180) as response:
+            envelope = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise ExecutionError(f"Ollama request failed: {exc}") from exc
+    try:
+        proposal = json.loads(envelope["response"])
+    except (KeyError, TypeError, json.JSONDecodeError) as exc:
+        raise ExecutionError("model did not return valid proposal JSON") from exc
+    if not isinstance(proposal, dict):
+        raise ExecutionError("model proposal must be a JSON object")
+    return proposal
+
+
+def validate_proposal(task: Task, proposal: dict[str, Any]) -> tuple[str, str]:
+    if proposal.get("target_file") != task.target_file:
+        raise ExecutionError("model attempted to change an unapproved file")
+    new_content = proposal.get("new_content")
+    summary = proposal.get("summary", "")
+    if not isinstance(new_content, str):
+        raise ExecutionError("new_content must be a string")
+    if not isinstance(summary, str):
+        raise ExecutionError("summary must be a string")
+    return new_content, summary
+
+
+def run_validation(task: Task) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        task.validation_command,
+        cwd=task.workspace,
+        text=True,
+        capture_output=True,
+        timeout=120,
+        shell=False,
+        check=False,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run one bounded AI Hands Ollama task")
+    parser.add_argument("task", type=Path, help="Path to task JSON")
+    parser.add_argument("--dry-run", action="store_true", help="Do not write or validate")
+    args = parser.parse_args()
+
+    report: dict[str, Any] = {"status": "FAILED"}
+    original: str | None = None
+    target: Path | None = None
+    try:
+        task = load_task(args.task.resolve())
+        target = resolve_target(task)
+        original = target.read_text(encoding="utf-8")
+        proposal = call_ollama(task, build_prompt(task, original))
+        new_content, model_summary = validate_proposal(task, proposal)
+        diff = "".join(difflib.unified_diff(
+            original.splitlines(keepends=True),
+            new_content.splitlines(keepends=True),
+            fromfile=f"a/{task.target_file}",
+            tofile=f"b/{task.target_file}",
+        ))
+        report.update({"model": task.model, "model_summary": model_summary, "diff": diff})
+        if args.dry_run:
+            report["status"] = "DRY_RUN_OK"
+        else:
+            target.write_text(new_content, encoding="utf-8")
+            validation = run_validation(task)
+            report["validation"] = {
+                "command": task.validation_command,
+                "returncode": validation.returncode,
+                "stdout": validation.stdout,
+                "stderr": validation.stderr,
+            }
+            if validation.returncode != 0:
+                target.write_text(original, encoding="utf-8")
+                report["status"] = "VALIDATION_FAILED_ROLLED_BACK"
+            else:
+                report["status"] = "COMPLETE"
+    except Exception as exc:  # final safety boundary for CLI report
+        if original is not None and target is not None and target.exists():
+            try:
+                target.write_text(original, encoding="utf-8")
+            except OSError:
+                pass
+        report["error"] = str(exc)
+
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0 if report["status"] in {"COMPLETE", "DRY_RUN_OK"} else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/projects/ai-hands/mvp/ai_hands.py
+++ b/projects/ai-hands/mvp/ai_hands.py
@@ -79,6 +79,32 @@ CURRENT FILE CONTENT:
 """
 
 
+def parse_ollama_proposal(envelope: dict[str, Any]) -> dict[str, Any]:
+    """Parse structured model output from supported Ollama envelope fields.
+
+    Most models place final output in ``response``. Some reasoning models emit
+    the requested JSON in ``thinking`` while leaving ``response`` empty. We
+    accept the first non-empty valid JSON object from those known fields only.
+    """
+    parse_errors: list[str] = []
+    for field in ("response", "thinking"):
+        candidate = envelope.get(field)
+        if not isinstance(candidate, str) or not candidate.strip():
+            continue
+        try:
+            proposal = json.loads(candidate)
+        except json.JSONDecodeError as exc:
+            parse_errors.append(f"{field}: {exc.msg}")
+            continue
+        if isinstance(proposal, dict):
+            return proposal
+        parse_errors.append(f"{field}: JSON value is not an object")
+
+    detail = "; ".join(parse_errors)
+    suffix = f" ({detail})" if detail else ""
+    raise ExecutionError(f"model did not return valid proposal JSON{suffix}")
+
+
 def call_ollama(task: Task, prompt: str) -> dict[str, Any]:
     payload = json.dumps({
         "model": task.model,
@@ -98,13 +124,9 @@ def call_ollama(task: Task, prompt: str) -> dict[str, Any]:
             envelope = json.loads(response.read().decode("utf-8"))
     except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
         raise ExecutionError(f"Ollama request failed: {exc}") from exc
-    try:
-        proposal = json.loads(envelope["response"])
-    except (KeyError, TypeError, json.JSONDecodeError) as exc:
-        raise ExecutionError("model did not return valid proposal JSON") from exc
-    if not isinstance(proposal, dict):
-        raise ExecutionError("model proposal must be a JSON object")
-    return proposal
+    if not isinstance(envelope, dict):
+        raise ExecutionError("Ollama response envelope must be a JSON object")
+    return parse_ollama_proposal(envelope)
 
 
 def validate_proposal(task: Task, proposal: dict[str, Any]) -> tuple[str, str]:

--- a/projects/ai-hands/mvp/task.example.json
+++ b/projects/ai-hands/mvp/task.example.json
@@ -3,6 +3,7 @@
   "model": "qwen3:4b",
   "instruction": "Replace the line beta with delta. Preserve all other text and line order exactly.",
   "target_file": "notes.txt",
+  "expected_branch": "smoke/nondefault",
   "validation_command": [
     "powershell",
     "-ExecutionPolicy",

--- a/projects/ai-hands/mvp/task.example.json
+++ b/projects/ai-hands/mvp/task.example.json
@@ -1,0 +1,14 @@
+{
+  "workspace": "C:\\Users\\oleg3\\Documents\\AI Hands\\wp003-ollama-smoke",
+  "model": "qwen3:4b",
+  "instruction": "Replace the line beta with delta. Preserve all other text and line order exactly.",
+  "target_file": "notes.txt",
+  "validation_command": [
+    "powershell",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-File",
+    ".\\validate.ps1"
+  ],
+  "ollama_url": "http://127.0.0.1:11434"
+}

--- a/projects/ai-hands/mvp/test_ai_hands.py
+++ b/projects/ai-hands/mvp/test_ai_hands.py
@@ -1,0 +1,53 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import ai_hands
+
+
+class AdapterSafetyTests(unittest.TestCase):
+    def test_rejects_target_outside_workspace(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            task = ai_hands.Task(
+                workspace=workspace,
+                model="test",
+                instruction="test",
+                target_file="../outside.txt",
+                validation_command=["python", "-c", "pass"],
+            )
+            with self.assertRaises(ai_hands.ExecutionError):
+                ai_hands.resolve_target(task)
+
+    def test_rejects_unapproved_model_target(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            task = ai_hands.Task(
+                workspace=Path(tmp),
+                model="test",
+                instruction="test",
+                target_file="notes.txt",
+                validation_command=["python", "-c", "pass"],
+            )
+            with self.assertRaises(ai_hands.ExecutionError):
+                ai_hands.validate_proposal(
+                    task,
+                    {"target_file": "other.txt", "new_content": "x", "summary": "x"},
+                )
+
+    def test_load_task_requires_argv_validation_command(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "task.json"
+            path.write_text(json.dumps({
+                "workspace": tmp,
+                "model": "test",
+                "instruction": "test",
+                "target_file": "notes.txt",
+                "validation_command": "dangerous shell string",
+            }), encoding="utf-8")
+            with self.assertRaises(ai_hands.ExecutionError):
+                ai_hands.load_task(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/ai-hands/mvp/test_ai_hands.py
+++ b/projects/ai-hands/mvp/test_ai_hands.py
@@ -2,33 +2,36 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import ai_hands
+
+
+def make_task(workspace: Path, **overrides):
+    values = {
+        "workspace": workspace,
+        "model": "test",
+        "instruction": "test",
+        "target_file": "notes.txt",
+        "expected_branch": "smoke/nondefault",
+        "validation_command": [
+            "powershell", "-ExecutionPolicy", "Bypass", "-File", ".\\validate.ps1"
+        ],
+    }
+    values.update(overrides)
+    return ai_hands.Task(**values)
 
 
 class AdapterSafetyTests(unittest.TestCase):
     def test_rejects_target_outside_workspace(self):
         with tempfile.TemporaryDirectory() as tmp:
-            workspace = Path(tmp)
-            task = ai_hands.Task(
-                workspace=workspace,
-                model="test",
-                instruction="test",
-                target_file="../outside.txt",
-                validation_command=["python", "-c", "pass"],
-            )
+            task = make_task(Path(tmp), target_file="../outside.txt")
             with self.assertRaises(ai_hands.ExecutionError):
                 ai_hands.resolve_target(task)
 
     def test_rejects_unapproved_model_target(self):
         with tempfile.TemporaryDirectory() as tmp:
-            task = ai_hands.Task(
-                workspace=Path(tmp),
-                model="test",
-                instruction="test",
-                target_file="notes.txt",
-                validation_command=["python", "-c", "pass"],
-            )
+            task = make_task(Path(tmp))
             with self.assertRaises(ai_hands.ExecutionError):
                 ai_hands.validate_proposal(
                     task,
@@ -43,6 +46,7 @@ class AdapterSafetyTests(unittest.TestCase):
                 "model": "test",
                 "instruction": "test",
                 "target_file": "notes.txt",
+                "expected_branch": "smoke/nondefault",
                 "validation_command": "dangerous shell string",
             }), encoding="utf-8")
             with self.assertRaises(ai_hands.ExecutionError):
@@ -50,24 +54,38 @@ class AdapterSafetyTests(unittest.TestCase):
 
     def test_parses_standard_response_field(self):
         proposal = {"target_file": "notes.txt", "new_content": "x", "summary": "done"}
-        self.assertEqual(
-            ai_hands.parse_ollama_proposal({"response": json.dumps(proposal)}),
-            proposal,
-        )
+        self.assertEqual(ai_hands.parse_ollama_proposal({"response": json.dumps(proposal)}), proposal)
 
     def test_parses_reasoning_field_when_response_is_empty(self):
         proposal = {"target_file": "notes.txt", "new_content": "x", "summary": "done"}
         self.assertEqual(
-            ai_hands.parse_ollama_proposal({
-                "response": "",
-                "thinking": json.dumps(proposal),
-            }),
+            ai_hands.parse_ollama_proposal({"response": "", "thinking": json.dumps(proposal)}),
             proposal,
         )
 
     def test_rejects_non_json_reasoning_output(self):
         with self.assertRaises(ai_hands.ExecutionError):
             ai_hands.parse_ollama_proposal({"response": "", "thinking": "not-json"})
+
+    def test_rejects_non_allowlisted_validation_executable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            (workspace / "validate.ps1").write_text("exit 0", encoding="utf-8")
+            task = make_task(workspace, validation_command=["python", "-c", "pass"])
+            with self.assertRaises(ai_hands.ExecutionError):
+                ai_hands.validate_validation_command(task)
+
+    def test_rejects_default_branch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            task = make_task(Path(tmp), expected_branch="main")
+            with mock.patch("ai_hands.git_output", side_effect=["true", "main"]):
+                with self.assertRaises(ai_hands.ExecutionError):
+                    ai_hands.verify_isolated_branch(task)
+
+    def test_report_always_gets_next_action(self):
+        report = {"status": "FAILED"}
+        ai_hands.set_next_action(report)
+        self.assertTrue(report["next_recommended_action"])
 
 
 if __name__ == "__main__":

--- a/projects/ai-hands/mvp/test_ai_hands.py
+++ b/projects/ai-hands/mvp/test_ai_hands.py
@@ -48,6 +48,27 @@ class AdapterSafetyTests(unittest.TestCase):
             with self.assertRaises(ai_hands.ExecutionError):
                 ai_hands.load_task(path)
 
+    def test_parses_standard_response_field(self):
+        proposal = {"target_file": "notes.txt", "new_content": "x", "summary": "done"}
+        self.assertEqual(
+            ai_hands.parse_ollama_proposal({"response": json.dumps(proposal)}),
+            proposal,
+        )
+
+    def test_parses_reasoning_field_when_response_is_empty(self):
+        proposal = {"target_file": "notes.txt", "new_content": "x", "summary": "done"}
+        self.assertEqual(
+            ai_hands.parse_ollama_proposal({
+                "response": "",
+                "thinking": json.dumps(proposal),
+            }),
+            proposal,
+        )
+
+    def test_rejects_non_json_reasoning_output(self):
+        with self.assertRaises(ai_hands.ExecutionError):
+            ai_hands.parse_ollama_proposal({"response": "", "thinking": "not-json"})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Implements the first controller-authored AI Hands execution adapter without touching Cline or the owner's existing DeepSeek configuration.

## Architecture

- Python standard library only.
- Controller-supplied JSON task packet.
- Ollama `/api/generate` with JSON output.
- One approved existing target file per run.
- Workspace path containment enforcement.
- No model-proposed command execution.
- One controller-supplied validation command executed with `shell=False`.
- Automatic rollback on validation failure or execution error.
- Machine-readable diff and execution report.

## Added

- `projects/ai-hands/mvp/ai_hands.py`
- `projects/ai-hands/mvp/README.md`
- `projects/ai-hands/mvp/task.example.json`
- `projects/ai-hands/mvp/test_ai_hands.py`

## Governance

Updates `projects/ai-hands/AGENTS.md` to formalize the owner/controller/executor authority model: ChatGPT specifies and reviews; the executor implements and gathers evidence; material architectural decisions are escalated rather than silently invented.

## Local validation required

The executor should run the unit tests and one disposable `qwen3:4b` smoke test on the owner machine, then report exact logs and any blocker. No Cline configuration changes are required or permitted.