### PR TITLE
Create global visitor analytics control plane

### DIFF
--- a/capability-library/REGISTRY.md
+++ b/capability-library/REGISTRY.md
@@ -26,6 +26,8 @@ A row records architectural intent and implementation status. It must not imply 
 | `media.clip` | idea | — | not created | ffmpeg | media artifact plus time ranges | one or more clip artifacts | Reels factory, QuizLight phrase clips | exact-cut versus stream-copy behavior needs fixtures |
 | `media.generate_captions` | idea | — | not created | transcript formatter, ffmpeg/libass optional | transcript artifact | SRT/VTT/ASS caption artifacts | short-video workflow | styling contract not yet defined |
 | `media.render_vertical` | idea | — | not created | ffmpeg | media, captions, layout parameters | vertical video artifact | Reels/Shorts/TikTok factory | layout presets not yet defined |
+| `analytics.track` | idea | — | not created | Umami v3 default; PostHog optional escalation | pageview/event plus normalized project context | provider event/session record | Olga Polo web surfaces, then a second independent site | contract exists only in `projects/visitor-analytics-control-plane/ARCHITECTURE.md`; no executable adapter yet |
+| `analytics.query` | idea | — | not created | Umami REST API default | project/date/session/event filters | normalized analytics result | private cross-project operator console | provider-normalization contract not yet implemented |
 
 ## Implementation Sequence
 
@@ -35,6 +37,24 @@ A row records architectural intent and implementation status. It must not imply 
 3. media.extract_audio
 4. media.transcribe
 5. media.download
+```
+
+Analytics sequence is tracked separately under:
+
+```text
+projects/visitor-analytics-control-plane/
+```
+
+Current analytics order:
+
+```text
+central Umami deployment
+-> analytics.track candidate
+-> Olga pilot
+-> analytics.track validated
+-> analytics.query candidate
+-> global private admin MVP
+-> second-project validation
 ```
 
 Reasoning:

--- a/projects/visitor-analytics-control-plane/ARCHITECTURE.md
+++ b/projects/visitor-analytics-control-plane/ARCHITECTURE.md
@@ -1,0 +1,256 @@
+# Universal Visitor Analytics — Architecture
+
+## Goal
+
+Provide one reusable system that answers, across all projects:
+
+- who visited, where anonymity is preserved unless the user legitimately identifies themselves;
+- which project/site they visited;
+- how they arrived;
+- what pages they viewed;
+- what meaningful actions they performed;
+- whether they converted;
+- what the ordered session timeline looked like;
+- when available and privacy-safe, what happened in session replay.
+
+## Selected Donor
+
+### Default: Umami v3
+
+Use Umami as the analytics engine and datastore/API surface instead of creating our own collector.
+
+Official capabilities verified on 2026-08-25 include:
+
+- anonymous sessions;
+- visitor activity history;
+- pageviews/referrers/devices/countries;
+- custom events with structured event data;
+- funnels, journeys, retention, UTM tracking and goals;
+- session replay and heatmaps;
+- teams/access control;
+- REST API;
+- self-hosted or cloud operation;
+- official Vercel hosting guide with PostgreSQL.
+
+### Optional escalation: PostHog
+
+Use only when a project needs capabilities Umami does not adequately cover, such as advanced product analytics, experimentation, feature flags or deeper customer-data infrastructure.
+
+## System Shape
+
+```text
+Website / App
+   |
+Standard analytics adapter
+   |
+Umami tracking endpoint
+   |
+Central Umami + PostgreSQL
+   |
+Umami API
+   |
+Private cross-project operator console
+```
+
+The custom part should remain thin:
+
+- integration adapter;
+- project registry;
+- normalized event naming;
+- cross-project admin UI.
+
+Do not custom-build ingestion/storage/sessionization first.
+
+## Central Project Registry
+
+Minimum metadata for every consumer project:
+
+```text
+project_id
+project_name
+website_id
+domains
+environment
+owner
+tracking_status
+replay_enabled
+event_schema_version
+integration_type
+last_verified_at
+```
+
+## Standard Event Contract
+
+### Common event names
+
+```text
+nav_click
+outbound_click
+cta_click
+contact_click
+form_start
+form_submit
+entity_open
+search
+media_play
+conversion
+```
+
+Projects may add domain-specific events, but they should map back to generic semantics where practical.
+
+### Minimum event fields
+
+```text
+project_id
+event_schema_version
+page_path
+page_title
+entity_type   optional
+entity_id     optional
+entity_name   optional
+destination   optional
+cta_name      optional
+source        optional
+```
+
+Never put secrets, payment details, passwords, medical data or raw sensitive form contents into analytics events.
+
+## Identity Model
+
+### Anonymous default
+
+Use Umami's anonymous visitor/session model by default.
+
+### Known identity
+
+Only link a visitor to a known internal lead/customer when a legitimate first-party identification event exists.
+
+Preferred analytics identifier:
+
+```text
+lead_id / customer_id / internal distinct id
+```
+
+Avoid sending raw email, phone number or other unnecessary PII to analytics when an internal opaque identifier can be used.
+
+## Global Admin UI
+
+Phase 2 is a thin private UI on top of the Umami API.
+
+### Required screens
+
+#### All Projects
+
+- visitors;
+- sessions;
+- pageviews;
+- conversions;
+- top sources;
+- trend by project.
+
+#### Recent Visitors
+
+- anonymous visitor/session ID;
+- project;
+- timestamp;
+- landing page;
+- referrer/UTM;
+- country/device/browser;
+- session duration;
+- conversion status.
+
+#### Session Timeline
+
+Ordered timeline:
+
+```text
+landing page
+-> page view
+-> nav click
+-> entity open
+-> CTA/contact click
+-> form start
+-> form submit
+```
+
+#### Entity Interest
+
+Cross-project reporting for reusable domain entities such as venue, wedding, product, article, service, vendor or listing.
+
+#### Sources -> Behavior -> Conversion
+
+Show which traffic source produced which behavior and which conversion outcome.
+
+#### Replay
+
+Only where enabled and privacy-reviewed. Link to or embed replay rather than cloning replay infrastructure.
+
+## Olga Pilot Event Map
+
+Sites:
+
+- `olgapoloweddings.com`
+- `venues.olgapoloweddings.com`
+
+Events:
+
+```text
+nav_click { destination }
+entity_open { entity_type: "venue", entity_id, entity_name }
+entity_open { entity_type: "wedding", entity_id, entity_name }
+contact_click { location }
+form_start { form_id }
+form_submit { form_id }
+outbound_click { destination_domain }
+```
+
+Acceptance journey:
+
+```text
+main site
+-> VENUES
+-> Peterloon
+-> CONTACT
+```
+
+The admin must show one coherent anonymous activity trail where the browser/session model technically permits it.
+
+## Privacy And Security
+
+- private admin only;
+- mask sensitive replay fields;
+- no secrets in client bundles;
+- no raw sensitive form payloads in analytics;
+- document retention and deletion/export procedure;
+- enable replay per project only after privacy/consent review;
+- keep production admin credentials separate from site tracking identifiers.
+
+## Deployment Direction
+
+Umami supports deployment on Vercel with a PostgreSQL database. Use an existing managed PostgreSQL provider supported by Umami/Vercel rather than inventing database operations.
+
+Exact infrastructure choice must be based on the currently available connected account/resources and cost, but the interface above remains provider-independent.
+
+## Capability Boundaries
+
+Potential reusable capability entries:
+
+- `analytics.track` — normalized event/page tracking adapter;
+- `analytics.query` — normalized read adapter over the selected analytics provider.
+
+These remain `idea` until executable code and tests exist.
+
+## Promotion Plan
+
+```text
+architecture selected
+-> central analytics deployed
+-> analytics.track candidate
+-> Olga Vercel pilot
+-> Showit pilot
+-> cross-surface QA
+-> analytics.track validated
+-> private global admin MVP
+-> second independent project integration
+-> production promotion
+```

--- a/projects/visitor-analytics-control-plane/PROJECT.md
+++ b/projects/visitor-analytics-control-plane/PROJECT.md
@@ -1,0 +1,91 @@
+# Visitor Analytics Control Plane
+
+## Status
+
+`active — architecture selected, implementation not yet deployed`
+
+## Purpose
+
+Create one reusable visitor-intelligence and operator-admin system for all current and future web projects.
+
+This is a global Project Execution OS capability. Individual projects such as Olga Polo are consumers/pilots, not the owner of the analytics architecture.
+
+## Project Type
+
+Internal cross-project platform capability and private operator application.
+
+## Operating System
+
+This project operates under `Project Execution OS`.
+
+Top-level entrypoint:
+
+`START_HERE.md`
+
+Relevant standards:
+
+- `docs/EXISTING_SOLUTION_FIRST_STANDARD.md`
+- `docs/COMPOSABLE_CAPABILITY_BLOCKS_STANDARD.md`
+- `docs/PROJECT_MEMORY_STANDARD.md`
+
+## Existing Solution First Decision
+
+Default analytics core: **Umami v3**.
+
+Why:
+
+- open source and self-hostable;
+- privacy-first anonymous tracking without cookies by default;
+- pageviews, referrers, devices, geography and sessions;
+- individual anonymous visitor/session activity;
+- custom events and event properties;
+- funnels, journeys, goals and UTM attribution;
+- session replay and heatmaps;
+- REST API suitable for a custom private admin wrapper;
+- official Vercel deployment path;
+- one installation can serve multiple websites/projects.
+
+PostHog is an optional escalation provider for projects that later require deeper product analytics, experiments, feature flags, warehouse/CDP or other capabilities beyond the current global requirement.
+
+Do not build a custom event collector/database unless Umami is proven insufficient for a concrete requirement.
+
+## Architecture
+
+See:
+
+`ARCHITECTURE.md`
+
+## First Pilot
+
+Olga Polo Weddings:
+
+- `https://olgapoloweddings.com/`
+- `https://venues.olgapoloweddings.com/`
+
+The pilot must prove that one visitor journey can be inspected across pageviews and meaningful events without inventing identity.
+
+## Identity Rule
+
+Visitors are anonymous by default.
+
+A real person identity may only be linked after an explicit identification event such as a submitted inquiry, authenticated account, or another legitimate first-party identifier. Analytics must not receive raw sensitive form contents.
+
+## Source Of Truth
+
+- architecture/current project state: `projects/visitor-analytics-control-plane/`
+- reusable executable capability readiness: `capability-library/REGISTRY.md`
+- execution task: GitHub Issue #127
+
+## Current Work
+
+1. establish the central Umami deployment and PostgreSQL storage;
+2. create standard multi-project registry fields;
+3. create reusable tracking contract for pageviews + events;
+4. integrate Olga Vercel surface first;
+5. integrate Showit surface;
+6. validate session timeline and conversion events;
+7. only then build the private cross-project admin wrapper on the Umami API.
+
+## Next Exact Step
+
+Deploy the central Umami instance using its supported Vercel path plus PostgreSQL, then register Olga as the first tracked website and issue the first website ID.


### PR DESCRIPTION
Creates the global cross-project visitor analytics project and architecture, selects Umami v3 as the Existing-Solution-First default core, keeps PostHog as optional escalation, and registers `analytics.track` / `analytics.query` as reusable capability ideas. Linked execution task: #127.